### PR TITLE
fix(onboarding): correct field name mismatches for FR-008 first message

### DIFF
--- a/tests/platforms/telegram/test_onboarding_handler.py
+++ b/tests/platforms/telegram/test_onboarding_handler.py
@@ -374,10 +374,10 @@ class TestFirstNikitaMessage:
             chat_id=123456789,
             selected_backstory={
                 "venue": "Berghain",
-                "hook": "I still think about that look you gave me",
+                "unresolved_hook": "I still think about that look you gave me",
                 "the_moment": "when our eyes met across the dancefloor",
             },
-            answers={"interest": "techno", "scene": "nightlife"},
+            answers={"primary_interest": "techno", "social_scene": "nightlife"},
         )
 
         # Verify message sent with hook
@@ -404,7 +404,7 @@ class TestFirstNikitaMessage:
         await handler._send_first_nikita_message(
             chat_id=123456789,
             selected_backstory={"venue": "Bar 25"},
-            answers={"interest": "photography", "scene": "art"},
+            answers={"primary_interest": "photography", "social_scene": "art"},
         )
 
         # Verify message mentions their interest
@@ -437,6 +437,36 @@ class TestFirstNikitaMessage:
         call_args = bot.send_message.call_args
         message = call_args.kwargs.get("text", "")
         assert "the club" in message
+        assert "😏" in message
+
+    async def test_send_first_nikita_message_custom_backstory_with_moment(self):
+        """FR-008: Uses the_moment for custom backstories when no hook."""
+        from nikita.platforms.telegram.onboarding.handler import OnboardingHandler
+
+        bot = MagicMock()
+        bot.send_message = AsyncMock()
+
+        handler = OnboardingHandler(
+            bot=bot,
+            onboarding_repository=MagicMock(),
+            profile_repository=MagicMock(),
+        )
+
+        # Call with custom backstory (has the_moment but no unresolved_hook)
+        await handler._send_first_nikita_message(
+            chat_id=123456789,
+            selected_backstory={
+                "venue": "Hive Club",
+                "the_moment": "3am techno set",
+            },
+            answers={"primary_interest": "techno", "social_scene": "nightlife"},
+        )
+
+        # Verify message uses the_moment
+        call_args = bot.send_message.call_args
+        message = call_args.kwargs.get("text", "")
+        assert "3am techno set" in message
+        assert "Hive Club" in message
         assert "😏" in message
 
     async def test_send_first_nikita_message_handles_error_gracefully(self):


### PR DESCRIPTION
## Summary

Fixes #2, #3

### Root Cause

The onboarding handler stored answers with keys `"social_scene"` and `"primary_interest"` but retrieved them using wrong keys `"scene"` and `"interest"`. This caused:

1. **Issue #2**: Profile/backstory NOT persisted (backstory generation failed)
2. **Issue #3**: FR-008 first Nikita message NOT sent (personalization data unavailable)

### Changes

1. **Fixed `_ProfileFromAnswers`** (lines 53, 55): Use correct keys for backstory generation
2. **Fixed `_send_first_nikita_message`** (lines 1001, 1003-1004): Use correct keys for personalization
3. **Fixed venue research/custom backstory** (lines 637, 844): Use correct scene key
4. **Added custom backstory fallback**: Generate hook from `the_moment` when `unresolved_hook` missing
5. **Added warning logging**: Alert when personalization data unavailable
6. **Fixed persistence layer** (lines 1073-1074): Use correct field names
7. **Updated tests**: Fixed field names in 2 tests + added 1 new test for custom backstory

### Impact

- ✅ Profile data now persists correctly
- ✅ Backstory generation receives correct input
- ✅ First Nikita message sent with personalization
- ✅ Custom backstories (user-provided) now work

### Files Changed

- `nikita/platforms/telegram/onboarding/handler.py` (+42/-24)
- `tests/platforms/telegram/test_onboarding_handler.py` (+24/-0)

**Total**: 2 files changed, 66 insertions(+), 24 deletions(-)

---

Generated with [Claude Code](https://claude.ai/code)