### PR TITLE
fix(pipeline): fix broken post-processing pipeline — 6 critical bugs

### DIFF
--- a/nikita/context/utils/token_counter.py
+++ b/nikita/context/utils/token_counter.py
@@ -207,7 +207,10 @@ class TokenCounter:
             budget: Maximum token budget (default 4000).
         """
         self.budget = budget
-        self._encoder = _get_encoder()
+        try:
+            self._encoder = _get_encoder()
+        except Exception:
+            self._encoder = None
 
     def count(self, text: str) -> int:
         """Count tokens in text.

--- a/nikita/pipeline/stages/summary.py
+++ b/nikita/pipeline/stages/summary.py
@@ -1,5 +1,6 @@
 """Summary generation stage (T2.10).
 
+Generates a per-conversation summary and stores it on the conversation record.
 Non-critical: logs error on failure, continues.
 """
 
@@ -19,9 +20,10 @@ logger = structlog.get_logger(__name__)
 
 
 class SummaryStage(BaseStage):
-    """Generate daily/weekly conversation summaries.
+    """Generate per-conversation summary and store on conversation record.
 
-    Ports logic from nikita/post_processing/summary_generator.py.
+    Uses extraction_summary from ExtractionStage as the base, optionally
+    enriched with Claude Haiku for a more narrative summary.
 
     Non-critical: failure does not stop the pipeline.
     """
@@ -34,21 +36,86 @@ class SummaryStage(BaseStage):
         super().__init__(session=session, **kwargs)
 
     async def _run(self, ctx: PipelineContext) -> dict | None:
-        """Generate conversation summary.
+        """Generate and store conversation summary.
 
-        Note: Summary generation is now handled directly in the pipeline stage
-        without the deprecated post_processing.summary_generator module.
+        Uses the extraction_summary from ExtractionStage. If available,
+        enriches it with Haiku for a concise, first-person Nikita summary.
+        Stores the summary directly on the conversation record.
         """
         if ctx.conversation is None:
-            return {"daily_updated": False, "weekly_updated": False}
+            return {"summary_stored": False, "reason": "no_conversation"}
 
-        # Summary generation logic inlined
-        # For now, just mark as updated (actual summary generation happens elsewhere)
-        # TODO: Implement full summary generation logic if needed
-        self._logger.info(
-            "summary_generation_skipped",
-            reason="Summary generation moved to dedicated task",
-            conversation_id=str(ctx.conversation_id),
-        )
+        # Use extraction summary as base
+        base_summary = ctx.extraction_summary or ""
+        if not base_summary:
+            self._logger.info(
+                "summary_skipped",
+                reason="no_extraction_summary",
+                conversation_id=str(ctx.conversation_id),
+            )
+            return {"summary_stored": False, "reason": "no_extraction_summary"}
 
-        return {"daily_updated": False, "weekly_updated": False}
+        # Try to generate a concise Nikita-perspective summary via Haiku
+        final_summary = await self._enrich_summary(base_summary, ctx)
+
+        # Store summary on conversation record
+        try:
+            ctx.conversation.conversation_summary = final_summary
+            ctx.conversation.emotional_tone = ctx.emotional_tone
+            if self._session:
+                await self._session.flush()
+
+            ctx.daily_summary_updated = True
+            self._logger.info(
+                "summary_stored",
+                conversation_id=str(ctx.conversation_id),
+                summary_length=len(final_summary),
+            )
+        except Exception as e:
+            self._logger.warning(
+                "summary_store_failed",
+                conversation_id=str(ctx.conversation_id),
+                error=str(e),
+            )
+            return {"summary_stored": False, "reason": str(e)}
+
+        return {
+            "summary_stored": True,
+            "summary_length": len(final_summary),
+            "enriched": final_summary != base_summary,
+        }
+
+    async def _enrich_summary(self, base_summary: str, ctx: PipelineContext) -> str:
+        """Optionally enrich summary with Haiku for Nikita's perspective.
+
+        Falls back to base_summary on any failure.
+        """
+        try:
+            from pydantic_ai import Agent
+            from pydantic_ai.models.anthropic import AnthropicModel
+            from nikita.config.settings import get_settings
+
+            settings = get_settings()
+            if not settings.anthropic_api_key:
+                return base_summary
+
+            prompt = (
+                f"You are Nikita, a woman in her 20s summarizing a conversation with your boyfriend. "
+                f"Write a brief 1-2 sentence first-person summary. Be natural, not robotic.\n\n"
+                f"Chapter: {ctx.chapter}/5\n"
+                f"Emotional tone: {ctx.emotional_tone}\n"
+                f"Conversation summary: {base_summary}\n\n"
+                f"Write ONLY the summary, nothing else."
+            )
+
+            import asyncio
+            model = AnthropicModel("claude-haiku-4-5-20251001", api_key=settings.anthropic_api_key)
+            agent = Agent(model=model)
+            result = await asyncio.wait_for(agent.run(prompt), timeout=10.0)
+
+            if result.data and len(result.data) > 10:
+                return result.data.strip()
+        except Exception as e:
+            self._logger.warning("summary_enrichment_failed error=%s", str(e))
+
+        return base_summary

--- a/tests/pipeline/conftest.py
+++ b/tests/pipeline/conftest.py
@@ -22,6 +22,22 @@ from nikita.pipeline.models import PipelineContext
 
 
 @pytest.fixture
+def mock_load_context(monkeypatch):
+    """Mock PipelineOrchestrator._load_context as a no-op.
+
+    Use this for tests that call orchestrator.process() with FakeStages
+    and don't need real DB loading.
+    """
+    async def _noop(self, ctx):
+        pass
+
+    monkeypatch.setattr(
+        "nikita.pipeline.orchestrator.PipelineOrchestrator._load_context",
+        _noop,
+    )
+
+
+@pytest.fixture
 def make_context():
     """Factory function for creating PipelineContext instances.
 

--- a/tests/pipeline/test_e2e_unified.py
+++ b/tests/pipeline/test_e2e_unified.py
@@ -25,6 +25,8 @@ from nikita.pipeline.models import PipelineContext, PipelineResult
 from nikita.pipeline.orchestrator import PipelineOrchestrator
 from nikita.pipeline.stages.base import BaseStage, StageResult
 
+pytestmark = pytest.mark.usefixtures("mock_load_context")
+
 
 # ── FakeStage implementations ────────────────────────────────────────────
 

--- a/tests/pipeline/test_integration.py
+++ b/tests/pipeline/test_integration.py
@@ -8,6 +8,8 @@ from nikita.pipeline.models import PipelineContext, PipelineResult
 from nikita.pipeline.orchestrator import PipelineOrchestrator
 from nikita.pipeline.stages.base import BaseStage, StageResult
 
+pytestmark = pytest.mark.usefixtures("mock_load_context")
+
 
 class MockStage(BaseStage):
     """Mock stage for integration testing."""

--- a/tests/pipeline/test_integration_full.py
+++ b/tests/pipeline/test_integration_full.py
@@ -16,6 +16,8 @@ from nikita.pipeline.orchestrator import PipelineOrchestrator
 from nikita.pipeline.models import PipelineContext, PipelineResult
 from nikita.pipeline.stages.base import BaseStage, StageResult
 
+pytestmark = pytest.mark.usefixtures("mock_load_context")
+
 
 # ============================================================================
 # Fake Stage Implementations (Deterministic, No External Calls)

--- a/tests/pipeline/test_orchestrator.py
+++ b/tests/pipeline/test_orchestrator.py
@@ -21,6 +21,8 @@ from nikita.pipeline.stages.base import StageResult
 from nikita.pipeline.models import PipelineContext, PipelineResult
 from nikita.pipeline.orchestrator import PipelineOrchestrator
 
+pytestmark = pytest.mark.usefixtures("mock_load_context")
+
 
 class FakeStage:
     """Fake stage for testing the orchestrator."""

--- a/tests/pipeline/test_performance.py
+++ b/tests/pipeline/test_performance.py
@@ -19,6 +19,8 @@ from nikita.pipeline.models import PipelineContext
 from nikita.pipeline.stages.base import StageResult
 from nikita.pipeline.orchestrator import PipelineOrchestrator
 
+pytestmark = pytest.mark.usefixtures("mock_load_context")
+
 
 # ====================================================================================
 # FAKE STAGE FOR TESTING

--- a/tests/pipeline/test_pipeline_integration.py
+++ b/tests/pipeline/test_pipeline_integration.py
@@ -1,0 +1,819 @@
+"""Integration tests for the post-processing pipeline.
+
+Tests each stage with realistic data structures to prove the pipeline
+works end-to-end. Unlike test_e2e_unified.py which uses FakeStages,
+these tests use the REAL stage implementations with mocked external deps.
+
+Tests prove:
+1. Orchestrator loads conversation + user state into context
+2. Extraction handles JSONB dict messages correctly
+3. Memory update receives dict-format facts from extraction
+4. Summary stage generates and stores per-conversation summary
+5. Full pipeline flow from conversation -> processed with all artifacts
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone, timedelta
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from uuid import uuid4
+
+import pytest
+
+from nikita.pipeline.models import PipelineContext, PipelineResult
+from nikita.pipeline.orchestrator import PipelineOrchestrator
+from nikita.pipeline.stages.base import BaseStage, StageResult, StageError
+from nikita.pipeline.stages.extraction import ExtractionStage, ExtractionResult
+from nikita.pipeline.stages.summary import SummaryStage
+from nikita.pipeline.stages.game_state import GameStateStage
+from nikita.pipeline.stages.conflict import ConflictStage
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def make_conversation(
+    user_id=None,
+    messages=None,
+    platform="telegram",
+    status="processing",
+):
+    """Create a mock conversation with JSONB dict messages."""
+    conv = MagicMock()
+    conv.id = uuid4()
+    conv.user_id = user_id or uuid4()
+    conv.platform = platform
+    conv.status = status
+    conv.messages = messages if messages is not None else [
+        {"role": "user", "content": "Hey babe, how was your day?", "timestamp": "2026-02-10T10:00:00"},
+        {"role": "assistant", "content": "ugh it was awful. my boss yelled at me again", "timestamp": "2026-02-10T10:01:00"},
+        {"role": "user", "content": "That sucks, want to talk about it?", "timestamp": "2026-02-10T10:02:00"},
+        {"role": "assistant", "content": "not really... can we just watch something tonight?", "timestamp": "2026-02-10T10:03:00"},
+    ]
+    conv.conversation_summary = None
+    conv.emotional_tone = None
+    conv.extracted_entities = None
+    return conv
+
+
+def make_user(user_id=None, chapter=2, score=Decimal("65.00")):
+    """Create a mock user with metrics, engagement, and vices."""
+    user = MagicMock()
+    user.id = user_id or uuid4()
+    user.chapter = chapter
+    user.game_status = "active"
+    user.relationship_score = score
+
+    # Metrics
+    user.metrics = MagicMock()
+    user.metrics.intimacy = Decimal("55.00")
+    user.metrics.passion = Decimal("48.00")
+    user.metrics.trust = Decimal("62.00")
+    user.metrics.secureness = Decimal("50.00")
+
+    # Engagement state
+    user.engagement_state = MagicMock()
+    user.engagement_state.current_state = "engaged"
+
+    # Vice preferences
+    vice1 = MagicMock()
+    vice1.category = "jealousy"
+    vice2 = MagicMock()
+    vice2.category = "materialism"
+    user.vice_preferences = [vice1, vice2]
+
+    return user
+
+
+def make_session():
+    """Create a mock async session."""
+    session = MagicMock()
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+    session.flush = AsyncMock()
+    session.rollback = AsyncMock()
+    session.refresh = AsyncMock()
+
+    # begin_nested returns an async context manager
+    nested = AsyncMock()
+    nested.__aenter__ = AsyncMock(return_value=None)
+    nested.__aexit__ = AsyncMock(return_value=None)
+    session.begin_nested = MagicMock(return_value=nested)
+
+    return session
+
+
+def _patch_repos(conversation, user):
+    """Patch both repositories used by _load_context()."""
+    mock_conv_repo_cls = MagicMock()
+    mock_conv_repo_cls.return_value.get = AsyncMock(return_value=conversation)
+    mock_user_repo_cls = MagicMock()
+    mock_user_repo_cls.return_value.get = AsyncMock(return_value=user)
+    return (
+        patch("nikita.db.repositories.conversation_repository.ConversationRepository", mock_conv_repo_cls),
+        patch("nikita.db.repositories.user_repository.UserRepository", mock_user_repo_cls),
+    )
+
+
+# ── Test: Orchestrator loads context ─────────────────────────────────────
+
+class TestOrchestratorContextLoading:
+    """Prove the orchestrator loads conversation + user state before stages."""
+
+    @pytest.mark.asyncio
+    async def test_load_context_populates_conversation(self):
+        """Orchestrator sets ctx.conversation from DB."""
+        session = make_session()
+        conv_id = uuid4()
+        user_id = uuid4()
+        conversation = make_conversation(user_id=user_id)
+        conversation.id = conv_id
+        user = make_user(user_id=user_id)
+
+        # Directly mock _load_context to control behavior
+        orchestrator = PipelineOrchestrator(session, stages=[])
+
+        async def mock_load(ctx):
+            ctx.conversation = conversation
+            ctx.user = user
+            ctx.chapter = user.chapter
+            ctx.game_status = user.game_status
+            ctx.relationship_score = user.relationship_score
+            ctx.metrics = {
+                "intimacy": user.metrics.intimacy,
+                "passion": user.metrics.passion,
+                "trust": user.metrics.trust,
+                "secureness": user.metrics.secureness,
+            }
+            ctx.engagement_state = user.engagement_state.current_state
+            ctx.vices = [vp.category for vp in user.vice_preferences]
+
+        with patch.object(orchestrator, "_load_context", side_effect=mock_load):
+            result = await orchestrator.process(conv_id, user_id, "text")
+
+        assert result.success is True
+        assert result.context.conversation is conversation
+        assert result.context.user is user
+        assert result.context.chapter == 2
+        assert result.context.relationship_score == Decimal("65.00")
+        assert result.context.game_status == "active"
+        assert result.context.engagement_state == "engaged"
+        assert result.context.vices == ["jealousy", "materialism"]
+        assert result.context.metrics["intimacy"] == Decimal("55.00")
+
+    @pytest.mark.asyncio
+    async def test_load_context_fails_on_missing_conversation(self):
+        """Pipeline fails gracefully if conversation not found."""
+        session = make_session()
+        conv_id = uuid4()
+        user_id = uuid4()
+
+        orchestrator = PipelineOrchestrator(session, stages=[])
+
+        async def mock_load_fail(ctx):
+            raise ValueError(f"Conversation {ctx.conversation_id} not found")
+
+        with patch.object(orchestrator, "_load_context", side_effect=mock_load_fail):
+            result = await orchestrator.process(conv_id, user_id, "text")
+
+        assert result.success is False
+        assert result.error_stage == "context_load"
+        assert "not found" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_load_context_fails_on_missing_user(self):
+        """Pipeline fails gracefully if user not found."""
+        session = make_session()
+        conv_id = uuid4()
+        user_id = uuid4()
+
+        orchestrator = PipelineOrchestrator(session, stages=[])
+
+        async def mock_load_fail(ctx):
+            raise ValueError(f"User {ctx.user_id} not found")
+
+        with patch.object(orchestrator, "_load_context", side_effect=mock_load_fail):
+            result = await orchestrator.process(conv_id, user_id, "text")
+
+        assert result.success is False
+        assert result.error_stage == "context_load"
+        assert "User" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_load_context_handles_user_without_metrics(self):
+        """Pipeline works even if user has no metrics/engagement/vices."""
+        session = make_session()
+        conv_id = uuid4()
+        user_id = uuid4()
+        conversation = make_conversation(user_id=user_id)
+
+        orchestrator = PipelineOrchestrator(session, stages=[])
+
+        async def mock_load(ctx):
+            ctx.conversation = conversation
+            ctx.user = MagicMock()
+            ctx.chapter = 1
+            ctx.game_status = "active"
+            ctx.relationship_score = Decimal("50.00")
+            # No metrics, no engagement, no vices
+
+        with patch.object(orchestrator, "_load_context", side_effect=mock_load):
+            result = await orchestrator.process(conv_id, user_id, "text")
+
+        assert result.success is True
+        assert result.context.chapter == 1
+        assert result.context.vices == []
+
+    @pytest.mark.asyncio
+    async def test_load_context_real_implementation(self):
+        """Test _load_context() method directly with mocked repos."""
+        session = make_session()
+        conv_id = uuid4()
+        user_id = uuid4()
+        conversation = make_conversation(user_id=user_id)
+        conversation.id = conv_id
+        user = make_user(user_id=user_id)
+
+        # Build mock repos
+        mock_conv_repo = MagicMock()
+        mock_conv_repo.get = AsyncMock(return_value=conversation)
+        mock_user_repo = MagicMock()
+        mock_user_repo.get = AsyncMock(return_value=user)
+
+        ctx = PipelineContext(
+            conversation_id=conv_id,
+            user_id=user_id,
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+
+        orchestrator = PipelineOrchestrator(session, stages=[])
+
+        with patch("nikita.db.repositories.conversation_repository.ConversationRepository", return_value=mock_conv_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo):
+            await orchestrator._load_context(ctx)
+
+        assert ctx.conversation is conversation
+        assert ctx.user is user
+        assert ctx.chapter == 2
+        assert ctx.relationship_score == Decimal("65.00")
+        assert ctx.vices == ["jealousy", "materialism"]
+        assert ctx.metrics["intimacy"] == Decimal("55.00")
+        assert ctx.engagement_state == "engaged"
+
+
+# ── Test: Extraction handles JSONB dict messages ─────────────────────────
+
+class TestExtractionStageIntegration:
+    """Prove extraction stage handles JSONB dict messages correctly."""
+
+    @pytest.mark.asyncio
+    async def test_extraction_formats_jsonb_messages(self):
+        """Messages stored as JSONB dicts are correctly formatted for LLM."""
+        session = make_session()
+        stage = ExtractionStage(session=session)
+
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        ctx.conversation = make_conversation()
+
+        # Mock the Pydantic AI agent to return extraction result
+        mock_result = MagicMock()
+        mock_result.data = ExtractionResult(
+            facts=["User asked about Nikita's day", "User is empathetic"],
+            threads=["Boss conflict at work"],
+            thoughts=["He actually cares about my feelings"],
+            summary="Player checked in on Nikita after a bad day at work, offered emotional support",
+            emotional_tone="positive",
+        )
+
+        with patch.object(stage, "_get_agent") as mock_get_agent:
+            mock_agent = MagicMock()
+            mock_agent.run = AsyncMock(return_value=mock_result)
+            mock_get_agent.return_value = mock_agent
+
+            result = await stage._run(ctx)
+
+        # Verify agent was called with properly formatted text
+        call_args = mock_agent.run.call_args[0][0]
+        assert "user: Hey babe, how was your day?" in call_args
+        assert "assistant: ugh it was awful" in call_args
+
+        # Verify extraction output is dict format (not raw strings)
+        assert len(ctx.extracted_facts) == 2
+        assert isinstance(ctx.extracted_facts[0], dict)
+        assert ctx.extracted_facts[0]["content"] == "User asked about Nikita's day"
+        assert ctx.extracted_facts[0]["type"] == "user_fact"
+
+        # Verify threads are dict format
+        assert len(ctx.extracted_threads) == 1
+        assert ctx.extracted_threads[0]["content"] == "Boss conflict at work"
+
+        # Verify summary and tone
+        assert ctx.extraction_summary == "Player checked in on Nikita after a bad day at work, offered emotional support"
+        assert ctx.emotional_tone == "positive"
+
+        # Verify return dict has counts
+        assert result["facts_count"] == 2
+        assert result["threads_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_extraction_fails_without_conversation(self):
+        """Extraction raises StageError when conversation not loaded."""
+        session = make_session()
+        stage = ExtractionStage(session=session)
+
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        # ctx.conversation is None
+
+        with pytest.raises(StageError, match="No conversation loaded"):
+            await stage._run(ctx)
+
+    @pytest.mark.asyncio
+    async def test_extraction_skips_empty_messages(self):
+        """Extraction returns empty result for conversation with no messages."""
+        session = make_session()
+        stage = ExtractionStage(session=session)
+
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        conv = make_conversation(messages=[])
+        ctx.conversation = conv
+
+        result = await stage._run(ctx)
+        assert result is not None
+        # Empty message returns early with neutral defaults
+        assert "tone" in result or "summary" in result or "facts" in result
+
+
+# ── Test: Memory update handles dict-format facts ────────────────────────
+
+class TestMemoryUpdateStageIntegration:
+    """Prove memory update correctly processes dict-format facts from extraction."""
+
+    @pytest.mark.asyncio
+    async def test_memory_update_skips_when_no_facts(self):
+        """MemoryUpdateStage returns early with zero counts when no facts."""
+        from nikita.pipeline.stages.memory_update import MemoryUpdateStage
+
+        session = make_session()
+        stage = MemoryUpdateStage(session=session)
+
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        ctx.extracted_facts = []  # No facts
+
+        result = await stage._run(ctx)
+        assert result["stored"] == 0
+        assert result["deduplicated"] == 0
+
+
+# ── Test: Summary stage generates and stores summary ─────────────────────
+
+class TestSummaryStageIntegration:
+    """Prove summary stage generates and stores per-conversation summary."""
+
+    @pytest.mark.asyncio
+    async def test_summary_stores_on_conversation(self):
+        """SummaryStage writes summary to conversation record."""
+        session = make_session()
+        stage = SummaryStage(session=session)
+
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        ctx.conversation = make_conversation()
+        ctx.extraction_summary = "Player showed empathy about Nikita's bad day"
+        ctx.emotional_tone = "positive"
+        ctx.chapter = 2
+
+        # Mock _enrich_summary to return base summary (no Haiku call)
+        with patch.object(stage, "_enrich_summary", new_callable=AsyncMock, return_value="Player showed empathy about Nikita's bad day"):
+            result = await stage._run(ctx)
+
+        assert result["summary_stored"] is True
+        assert result["summary_length"] > 0
+        assert ctx.conversation.conversation_summary == "Player showed empathy about Nikita's bad day"
+        assert ctx.conversation.emotional_tone == "positive"
+        assert ctx.daily_summary_updated is True
+
+    @pytest.mark.asyncio
+    async def test_summary_skips_without_extraction_summary(self):
+        """SummaryStage returns early if no extraction_summary available."""
+        session = make_session()
+        stage = SummaryStage(session=session)
+
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        ctx.conversation = make_conversation()
+        ctx.extraction_summary = ""  # Empty
+
+        result = await stage._run(ctx)
+        assert result["summary_stored"] is False
+        assert result["reason"] == "no_extraction_summary"
+
+    @pytest.mark.asyncio
+    async def test_summary_skips_without_conversation(self):
+        """SummaryStage returns early if no conversation loaded."""
+        session = make_session()
+        stage = SummaryStage(session=session)
+
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        # ctx.conversation is None
+
+        result = await stage._run(ctx)
+        assert result["summary_stored"] is False
+        assert result["reason"] == "no_conversation"
+
+    @pytest.mark.asyncio
+    async def test_summary_enrichment_with_haiku(self):
+        """SummaryStage enriches summary via Haiku when API key available."""
+        session = make_session()
+        stage = SummaryStage(session=session)
+
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        ctx.conversation = make_conversation()
+        ctx.extraction_summary = "Player showed empathy"
+        ctx.emotional_tone = "positive"
+        ctx.chapter = 2
+
+        enriched = "He was actually really sweet about my day. Made me feel heard."
+        with patch.object(stage, "_enrich_summary", new_callable=AsyncMock, return_value=enriched):
+            result = await stage._run(ctx)
+
+        assert result["summary_stored"] is True
+        assert result["enriched"] is True
+        assert ctx.conversation.conversation_summary == enriched
+
+
+# ── Test: Conflict stage uses real user state ─────────────────────────────
+
+class TestConflictStageIntegration:
+    """Prove conflict stage uses real user state from context."""
+
+    @pytest.mark.asyncio
+    async def test_conflict_triggers_on_low_score(self):
+        """ConflictStage detects low score and triggers conflict."""
+        session = make_session()
+        stage = ConflictStage(session=session)
+
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        ctx.relationship_score = Decimal("25")  # Below 30 threshold
+        ctx.chapter = 3
+
+        result = await stage._run(ctx)
+        assert result["active"] is True
+        assert result["type"] == "low_score"
+        assert ctx.active_conflict is True
+
+    @pytest.mark.asyncio
+    async def test_conflict_triggers_on_emotional_distance(self):
+        """ConflictStage detects cold emotional tone + chapter >= 3."""
+        session = make_session()
+        stage = ConflictStage(session=session)
+
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        ctx.relationship_score = Decimal("55")
+        ctx.emotional_tone = "cold"
+        ctx.chapter = 3
+
+        result = await stage._run(ctx)
+        assert result["active"] is True
+        assert result["type"] == "emotional_distance"
+
+    @pytest.mark.asyncio
+    async def test_no_conflict_for_healthy_relationship(self):
+        """No conflict when score is healthy and tone is positive."""
+        session = make_session()
+        stage = ConflictStage(session=session)
+
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        ctx.relationship_score = Decimal("65")
+        ctx.emotional_tone = "positive"
+        ctx.chapter = 2
+
+        result = await stage._run(ctx)
+        assert result["active"] is False
+        assert result["type"] is None
+
+
+# ── Test: Game state stage uses real context ──────────────────────────────
+
+class TestGameStateStageIntegration:
+    """Prove game state stage reads extraction data from context."""
+
+    @pytest.mark.asyncio
+    async def test_game_state_reads_extraction_data(self):
+        """GameStateStage uses extraction_summary to evaluate."""
+        session = make_session()
+        stage = GameStateStage(session=session)
+
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        ctx.extraction_summary = "Player was supportive and caring"
+        ctx.chapter = 2
+
+        result = await stage._run(ctx)
+        assert result is not None
+        assert "score_delta" in result
+        assert "chapter_changed" in result
+
+
+# ── Test: Full pipeline with mocked LLM ──────────────────────────────────
+
+class TestFullPipelineWithMockedLLM:
+    """Integration test: full pipeline with mocked external deps.
+
+    Proves all stages connect properly, context propagates, and
+    conversation gets processed with all artifacts stored.
+    """
+
+    @pytest.mark.asyncio
+    async def test_full_pipeline_produces_all_artifacts(self):
+        """Full pipeline produces summary, facts, emotional state, prompt."""
+        session = make_session()
+        conv_id = uuid4()
+        user_id = uuid4()
+
+        conversation = make_conversation(user_id=user_id)
+        conversation.id = conv_id
+        user = make_user(user_id=user_id)
+
+        # Build extraction stage that returns test data
+        class TestExtractionStage(BaseStage):
+            name = "extraction"
+            is_critical = True
+            timeout_seconds = 5.0
+
+            async def _run(self, ctx):
+                ctx.extracted_facts = [
+                    {"content": "User likes cats", "type": "user_fact"},
+                    {"content": "User works in tech", "type": "personal"},
+                ]
+                ctx.extracted_threads = [
+                    {"content": "Boss conflict", "type": "thread"},
+                ]
+                ctx.extracted_thoughts = [
+                    {"content": "He seems really caring", "type": "thought"},
+                ]
+                ctx.extraction_summary = "Player showed empathy about Nikita's work stress"
+                ctx.emotional_tone = "positive"
+                return {"facts_count": 2, "threads_count": 1}
+
+        # Build memory update stage that counts stored facts
+        class TestMemoryStage(BaseStage):
+            name = "memory_update"
+            is_critical = True
+            timeout_seconds = 5.0
+
+            async def _run(self, ctx):
+                ctx.facts_stored = len(ctx.extracted_facts)
+                ctx.facts_deduplicated = 0
+                return {"stored": ctx.facts_stored, "deduplicated": 0}
+
+        # Build summary stage that stores summary
+        class TestSummaryStage(BaseStage):
+            name = "summary"
+            is_critical = False
+            timeout_seconds = 5.0
+
+            async def _run(self, ctx):
+                summary = ctx.extraction_summary
+                ctx.conversation.conversation_summary = summary
+                ctx.conversation.emotional_tone = ctx.emotional_tone
+                ctx.daily_summary_updated = True
+                return {"summary_stored": True, "summary_length": len(summary)}
+
+        # Build prompt builder that generates a test prompt
+        class TestPromptStage(BaseStage):
+            name = "prompt_builder"
+            is_critical = False
+            timeout_seconds = 5.0
+
+            async def _run(self, ctx):
+                prompt = (
+                    f"You are Nikita. Chapter {ctx.chapter}. "
+                    f"Score: {ctx.relationship_score}. "
+                    f"Vices: {', '.join(ctx.vices)}. "
+                    f"Facts: {len(ctx.extracted_facts)}. "
+                    f"Emotional state: {ctx.emotional_tone}. "
+                    f"Summary: {ctx.extraction_summary}"
+                )
+                ctx.generated_prompt = prompt
+                ctx.prompt_token_count = len(prompt.split())
+                return {"generated": True, "text_tokens": ctx.prompt_token_count}
+
+        stages = [
+            ("extraction", TestExtractionStage(session=session), True),
+            ("memory_update", TestMemoryStage(session=session), True),
+            ("summary", TestSummaryStage(session=session), False),
+            ("prompt_builder", TestPromptStage(session=session), False),
+        ]
+
+        orchestrator = PipelineOrchestrator(session, stages=stages)
+
+        async def mock_load(ctx):
+            ctx.conversation = conversation
+            ctx.user = user
+            ctx.chapter = user.chapter
+            ctx.game_status = user.game_status
+            ctx.relationship_score = user.relationship_score
+            ctx.metrics = {
+                "intimacy": user.metrics.intimacy,
+                "passion": user.metrics.passion,
+                "trust": user.metrics.trust,
+                "secureness": user.metrics.secureness,
+            }
+            ctx.engagement_state = user.engagement_state.current_state
+            ctx.vices = [vp.category for vp in user.vice_preferences]
+
+        with patch.object(orchestrator, "_load_context", side_effect=mock_load):
+            result = await orchestrator.process(conv_id, user_id, "text")
+
+        # Pipeline succeeded
+        assert result.success is True
+        assert result.error_stage is None
+
+        # Context was loaded
+        ctx = result.context
+        assert ctx.conversation is conversation
+        assert ctx.user is user
+        assert ctx.chapter == 2
+        assert ctx.relationship_score == Decimal("65.00")
+        assert ctx.vices == ["jealousy", "materialism"]
+
+        # Extraction produced facts
+        assert len(ctx.extracted_facts) == 2
+        assert ctx.extracted_facts[0]["content"] == "User likes cats"
+        assert ctx.extraction_summary == "Player showed empathy about Nikita's work stress"
+        assert ctx.emotional_tone == "positive"
+
+        # Memory stored facts
+        assert ctx.facts_stored == 2
+        assert ctx.facts_deduplicated == 0
+
+        # Summary was stored on conversation
+        assert ctx.daily_summary_updated is True
+        assert conversation.conversation_summary == "Player showed empathy about Nikita's work stress"
+        assert conversation.emotional_tone == "positive"
+
+        # Prompt was generated with all context
+        assert ctx.generated_prompt is not None
+        assert "Chapter 2" in ctx.generated_prompt
+        assert "65" in ctx.generated_prompt
+        assert "jealousy" in ctx.generated_prompt
+        assert "Facts: 2" in ctx.generated_prompt
+
+        # All 4 stages completed
+        assert len(ctx.stage_timings) == 4
+        assert "extraction" in ctx.stage_timings
+        assert "memory_update" in ctx.stage_timings
+        assert "summary" in ctx.stage_timings
+        assert "prompt_builder" in ctx.stage_timings
+
+    @pytest.mark.asyncio
+    async def test_pipeline_with_critical_failure_preserves_partial_context(self):
+        """When extraction fails, no downstream stages run but context load is preserved."""
+        session = make_session()
+        conv_id = uuid4()
+        user_id = uuid4()
+
+        conversation = make_conversation(user_id=user_id)
+        conversation.id = conv_id
+        user = make_user(user_id=user_id)
+
+        class FailingExtractionStage(BaseStage):
+            name = "extraction"
+            is_critical = True
+            timeout_seconds = 5.0
+
+            async def _run(self, ctx):
+                raise StageError("extraction", "LLM API down")
+
+        class NeverReachedStage(BaseStage):
+            name = "summary"
+            is_critical = False
+            timeout_seconds = 5.0
+
+            async def _run(self, ctx):
+                raise AssertionError("This stage should never run")
+
+        stages = [
+            ("extraction", FailingExtractionStage(session=session), True),
+            ("summary", NeverReachedStage(session=session), False),
+        ]
+
+        orchestrator = PipelineOrchestrator(session, stages=stages)
+
+        async def mock_load(ctx):
+            ctx.conversation = conversation
+            ctx.user = user
+            ctx.chapter = user.chapter
+            ctx.game_status = user.game_status
+            ctx.relationship_score = user.relationship_score
+
+        with patch.object(orchestrator, "_load_context", side_effect=mock_load):
+            result = await orchestrator.process(conv_id, user_id, "text")
+
+        # Pipeline failed at extraction
+        assert result.success is False
+        assert result.error_stage == "extraction"
+
+        # But context was loaded successfully before stages ran
+        assert result.context.conversation is conversation
+        assert result.context.user is user
+        assert result.context.chapter == 2
+
+
+# ── Test: Pipeline result used in tasks.py ───────────────────────────────
+
+class TestPipelineResultAccess:
+    """Prove PipelineResult attributes used in tasks.py work correctly."""
+
+    def test_failed_result_has_context_conversation_id(self):
+        """tasks.py accesses r.context.conversation_id for logging."""
+        conv_id = uuid4()
+        ctx = PipelineContext(
+            conversation_id=conv_id,
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        result = PipelineResult.failed(ctx, "extraction", "test error")
+
+        assert result.success is False
+        assert result.context.conversation_id == conv_id
+
+    def test_succeeded_result_has_summary_flag(self):
+        """tasks.py checks ctx.daily_summary_updated to avoid overwriting enriched summary."""
+        ctx = PipelineContext(
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            started_at=datetime.now(timezone.utc),
+            platform="text",
+        )
+        ctx.daily_summary_updated = True
+        ctx.extraction_summary = "raw summary"
+        result = PipelineResult.succeeded(ctx)
+
+        # When daily_summary_updated is True, tasks.py passes summary=None
+        # to mark_processed() so it doesn't overwrite the enriched summary
+        summary_for_mark_processed = (
+            None if result.context.daily_summary_updated
+            else (result.context.extraction_summary or None)
+        )
+        assert summary_for_mark_processed is None


### PR DESCRIPTION
The pipeline was completely non-functional: every conversation failed at
stage 1 because PipelineContext.conversation was never populated.

Root causes and fixes:
1. Orchestrator never loaded conversation/user from DB into context.
   Added _load_context() that fetches conversation, user, metrics,
   vices, and engagement state before running stages.

2. ExtractionStage accessed JSONB messages as objects (msg.role) when
   they're dicts (msg['role']). Added isinstance check for both formats.

3. ExtractionStage returned facts as list[str] but MemoryUpdateStage
   expected list[dict] with .get("content"). Now converts strings to
   dicts in extraction output.

4. SummaryStage was a stub that did nothing. Implemented real summary
   generation: uses extraction_summary as base, enriches with Haiku,
   stores directly on conversation record in Supabase.

5. tasks.py accessed r.conversation_id instead of r.context.conversation_id
   causing AttributeError after pipeline completed.

6. TokenCounter.__init__ raised ProxyError when tiktoken couldn't
   download encoding data. Added exception handling with fallback.

Tests: 211 pipeline tests pass (21 new integration tests + 190 existing)

https://claude.ai/code/session_016yrYj6PxgRq2uE2Yh6CdSi