### PR TITLE
feat(portal): UX-001/002/003/004 + FE-009/010 + IT-005 — UX improvements and security

### DIFF
--- a/nikita/api/main.py
+++ b/nikita/api/main.py
@@ -286,11 +286,22 @@ def create_app() -> FastAPI:
             "status": "online",
         }
 
+    @app.get("/healthz")
+    async def healthz():
+        """Cloud Run liveness probe target (IT-005).
+
+        Alias for /health — fast, no DB query, returns 200 while process is alive.
+        Cloud Run startup probe and liveness probe should point here.
+        Use /health/deep for post-deploy readiness verification.
+        """
+        return {"status": "ok"}
+
     @app.get("/health")
     async def health():
         """Basic health check endpoint (fast, no DB query).
 
         Returns cached startup state. Use /health/deep for live DB check.
+        Cloud Run liveness probe: /healthz (faster 200 response).
         """
         db_healthy = getattr(app.state, "db_healthy", False)
         supabase_ok = getattr(app.state, "supabase", None) is not None

--- a/portal/src/app/auth/callback/route.ts
+++ b/portal/src/app/auth/callback/route.ts
@@ -4,7 +4,10 @@ import { createClient } from "@/lib/supabase/server"
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get("code")
-  const next = searchParams.get("next") ?? "/dashboard"
+  // FE-010: Reject open-redirect attempts (e.g. next=//evil.com or next=https://evil.com).
+  // Only allow same-origin relative paths starting with a single slash.
+  const rawNext = searchParams.get("next") ?? "/dashboard"
+  const next = rawNext.startsWith("/") && !rawNext.startsWith("//") ? rawNext : "/dashboard"
 
   if (code) {
     const supabase = await createClient()

--- a/portal/src/app/dashboard/nikita/day/page.tsx
+++ b/portal/src/app/dashboard/nikita/day/page.tsx
@@ -59,13 +59,13 @@ export default function NikitaDayPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold text-foreground">Nikita&apos;s Day</h1>
         <div className="flex items-center gap-2">
-          <Button variant="ghost" size="icon" onClick={goBack} className="h-8 w-8">
+          <Button variant="ghost" size="icon" onClick={goBack} className="h-8 w-8" aria-label="Previous day">
             <ChevronLeft className="h-4 w-4" />
           </Button>
           <span className="text-sm text-muted-foreground min-w-[180px] text-center">
             {formatDisplayDate(dateStr)}
           </span>
-          <Button variant="ghost" size="icon" onClick={goForward} disabled={isToday} className="h-8 w-8">
+          <Button variant="ghost" size="icon" onClick={goForward} disabled={isToday} className="h-8 w-8" aria-label="Next day">
             <ChevronRight className="h-4 w-4" />
           </Button>
         </div>

--- a/portal/src/app/dashboard/page.tsx
+++ b/portal/src/app/dashboard/page.tsx
@@ -21,9 +21,9 @@ import { GlassCard } from "@/components/glass/glass-card"
 export default function DashboardPage() {
   const { data: stats, isLoading: statsLoading, error: statsError, refetch: refetchStats } = useUserStats()
   const { data: history, isLoading: historyLoading } = useScoreHistory()
-  const { data: emotionalState } = useEmotionalState()
+  const { data: emotionalState, isLoading: emotionalLoading } = useEmotionalState()
   const { data: thoughts } = useThoughts({ limit: 1 })
-  const { data: decay } = useDecay()
+  const { data: decay, isLoading: decayLoading } = useDecay()
   const { data: psyche } = usePsycheTips()
 
   if (statsLoading) {
@@ -42,17 +42,21 @@ export default function DashboardPage() {
 
   return (
     <div className="space-y-6">
-      {emotionalState && emotionalState.conflict_state !== "none" && (
+      {emotionalLoading ? (
+        <LoadingSkeleton variant="card" />
+      ) : emotionalState && emotionalState.conflict_state !== "none" ? (
         <ConflictBanner
           conflictState={emotionalState.conflict_state}
           conflictTrigger={emotionalState.conflict_trigger}
           conflictStartedAt={emotionalState.conflict_started_at}
         />
-      )}
+      ) : null}
 
       <RelationshipHero stats={stats} />
 
-      {emotionalState && (
+      {emotionalLoading ? (
+        <LoadingSkeleton variant="card" />
+      ) : emotionalState ? (
         <GlassCard className="p-4">
           <div className="flex items-center justify-between">
             <MoodOrbMini state={emotionalState} />
@@ -62,13 +66,17 @@ export default function DashboardPage() {
               </div>
             )}
           </div>
-          {decay && (
+          {decayLoading ? (
+            <div className="mt-3 border-t border-white/5 pt-3">
+              <LoadingSkeleton variant="card" />
+            </div>
+          ) : decay ? (
             <div className="mt-3 border-t border-white/5 pt-3">
               <DecayCountdown decay={decay} />
             </div>
-          )}
+          ) : null}
         </GlassCard>
-      )}
+      ) : null}
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         {historyLoading ? (

--- a/portal/src/app/providers.tsx
+++ b/portal/src/app/providers.tsx
@@ -13,7 +13,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       defaultOptions: {
         queries: {
           staleTime: 30_000,
-          retry: 3,
+          retry: 1, // UX-004: reduce from 3 — avoid 3× delay before showing error state
           retryDelay: (attemptIndex) =>
             Math.min(1000 * 2 ** attemptIndex, 30000),
           refetchOnWindowFocus: false,

--- a/portal/src/components/layout/mobile-nav.tsx
+++ b/portal/src/components/layout/mobile-nav.tsx
@@ -21,7 +21,7 @@ export function MobileNav() {
   if (!isMobile) return null
 
   return (
-    <nav data-testid="nav-mobile" className="fixed bottom-0 left-0 right-0 z-50 backdrop-blur-md bg-white/5 border-t border-white/10 pb-[env(safe-area-inset-bottom)]">
+    <nav data-testid="nav-mobile" aria-label="Mobile navigation" className="fixed bottom-0 left-0 right-0 z-50 backdrop-blur-md bg-white/5 border-t border-white/10 pb-[env(safe-area-inset-bottom)]">
       <div className="flex items-center justify-around">
         {tabs.map((tab) => {
           const isActive =

--- a/portal/src/components/layout/sidebar.tsx
+++ b/portal/src/components/layout/sidebar.tsx
@@ -58,7 +58,7 @@ function AppSidebar({ variant }: AppSidebarProps) {
   }
 
   return (
-    <Sidebar collapsible="icon" className="border-r border-white/5" data-testid="nav-sidebar">
+    <Sidebar collapsible="icon" className="border-r border-white/5" data-testid="nav-sidebar" aria-label="Primary navigation">
       <SidebarHeader className="p-4">
         <div className="flex items-center justify-between">
           <Link href={variant === "player" ? "/dashboard" : "/admin"} className="flex items-center gap-2">
@@ -117,7 +117,7 @@ export function AppLayout({ variant, children }: { variant: "player" | "admin"; 
       <AppSidebar variant={variant} />
       <main className="flex-1 overflow-auto">
         <div className="flex items-center gap-2 p-4 md:hidden">
-          <SidebarTrigger />
+          <SidebarTrigger aria-label="Toggle navigation" />
         </div>
         <div className={cn("p-4 md:p-6 lg:p-8", variant === "player" && "pb-16 md:pb-0")}>{children}</div>
       </main>

--- a/portal/src/hooks/use-admin-mutations.ts
+++ b/portal/src/hooks/use-admin-mutations.ts
@@ -3,6 +3,9 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { adminApi } from "@/lib/api/admin"
 import { toast } from "sonner"
 
+// UX-004/FE-009: Admin mutations must not retry — avoid duplicate writes on transient errors.
+const ADMIN_MUTATION_DEFAULTS = { retry: 0 } as const
+
 export function useAdminMutations(userId: string) {
   const queryClient = useQueryClient()
 
@@ -12,6 +15,7 @@ export function useAdminMutations(userId: string) {
   }
 
   const setScore = useMutation({
+    ...ADMIN_MUTATION_DEFAULTS,
     mutationFn: ({ score, reason }: { score: number; reason: string }) =>
       adminApi.setScore(userId, score, reason),
     onSuccess: () => { invalidateUser(); toast.success("Score updated") },
@@ -19,6 +23,7 @@ export function useAdminMutations(userId: string) {
   })
 
   const setChapter = useMutation({
+    ...ADMIN_MUTATION_DEFAULTS,
     mutationFn: ({ chapter, reason }: { chapter: number; reason: string }) =>
       adminApi.setChapter(userId, chapter, reason),
     onSuccess: () => { invalidateUser(); toast.success("Chapter updated") },
@@ -26,6 +31,7 @@ export function useAdminMutations(userId: string) {
   })
 
   const setStatus = useMutation({
+    ...ADMIN_MUTATION_DEFAULTS,
     mutationFn: ({ status, reason }: { status: string; reason: string }) =>
       adminApi.setStatus(userId, status, reason),
     onSuccess: () => { invalidateUser(); toast.success("Status updated") },
@@ -33,6 +39,7 @@ export function useAdminMutations(userId: string) {
   })
 
   const setEngagement = useMutation({
+    ...ADMIN_MUTATION_DEFAULTS,
     mutationFn: ({ state, reason }: { state: string; reason: string }) =>
       adminApi.setEngagement(userId, state, reason),
     onSuccess: () => { invalidateUser(); toast.success("Engagement updated") },
@@ -40,18 +47,21 @@ export function useAdminMutations(userId: string) {
   })
 
   const resetBoss = useMutation({
+    ...ADMIN_MUTATION_DEFAULTS,
     mutationFn: (_reason?: string) => adminApi.resetBoss(userId),
     onSuccess: () => { invalidateUser(); toast.success("Boss reset") },
     onError: () => toast.error("Failed to reset boss"),
   })
 
   const clearEngagement = useMutation({
+    ...ADMIN_MUTATION_DEFAULTS,
     mutationFn: (_reason?: string) => adminApi.clearEngagement(userId),
     onSuccess: () => { invalidateUser(); toast.success("Engagement cleared") },
     onError: () => toast.error("Failed to clear engagement"),
   })
 
   const setMetrics = useMutation({
+    ...ADMIN_MUTATION_DEFAULTS,
     mutationFn: (data: { intimacy?: number; passion?: number; trust?: number; secureness?: number; reason: string }) =>
       adminApi.setMetrics(userId, data),
     onSuccess: () => { invalidateUser(); toast.success("Metrics updated") },
@@ -59,6 +69,7 @@ export function useAdminMutations(userId: string) {
   })
 
   const triggerPipeline = useMutation({
+    ...ADMIN_MUTATION_DEFAULTS,
     mutationFn: (_reason?: string) => adminApi.triggerPipeline(userId),
     onSuccess: () => { toast.info("Pipeline triggered") },
     onError: () => toast.error("Failed to trigger pipeline"),


### PR DESCRIPTION
## Summary

- **UX-001**: `aria-label` on day-nav Previous/Next day chevron buttons in `day/page.tsx`
- **UX-002**: `aria-label` on `SidebarTrigger` ("Toggle navigation"), `Sidebar` ("Primary navigation"), mobile `<nav>` ("Mobile navigation")
- **UX-003**: `LoadingSkeleton variant="card"` for emotional state and decay rows while data loads (was silently absent)
- **UX-004/FE-009**: Global query `retry: 3 → 1` (faster error display); admin mutations `retry: 0` (prevent duplicate writes via `ADMIN_MUTATION_DEFAULTS`)
- **FE-010**: Sanitize `next` param in auth callback — reject `//evil.com` open-redirect patterns; only allow `/path` (single-slash prefix)
- **IT-005**: Add `/healthz` alias endpoint — fast `{"status":"ok"}` for Cloud Run liveness probe; no DB query overhead

## Test plan

- [ ] `cd portal && npm run type-check` passes
- [ ] `cd portal && npm run build` passes
- [ ] Day navigation chevrons have aria-labels (screen reader accessible)
- [ ] `/healthz` returns 200 on Cloud Run
- [ ] Auth callback with `next=//evil.com` redirects to `/dashboard` instead
- [ ] Admin mutations fire once, no retries on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)