### PR TITLE
fix(api): BKD-003 — startup assertion for task_auth_secret in non-debug mode

### DIFF
--- a/nikita/api/main.py
+++ b/nikita/api/main.py
@@ -74,6 +74,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     print("Starting Nikita API server...")
 
+    # BKD-003: task_auth_secret is required in non-debug environments.
+    # The fallback was removed in PR #118; a hard startup assertion ensures the
+    # misconfiguration is caught at deploy time rather than silently at runtime.
+    if not settings.debug and not settings.task_auth_secret:
+        raise RuntimeError(
+            "task_auth_secret must be set in non-debug environments. "
+            "Set the TASK_AUTH_SECRET environment variable."
+        )
+
     # 1. Validate database connection
     engine = get_async_engine()
     app.state.db_engine = engine


### PR DESCRIPTION
## Summary

- **BKD-003**: Add `RuntimeError` at lifespan startup if `task_auth_secret` is unset in non-debug environments. PR #118 removed the empty-string fallback but added no hard assertion — a missing secret would only surface when the first cron job fired.
- **BKD-006**: `detect_stuck`/`recover_stuck` 410 stubs are handled by open PR #123 (chore/dead-code).

## Behavior

```python
# Non-debug with no TASK_AUTH_SECRET:
RuntimeError: task_auth_secret must be set in non-debug environments.
             Set the TASK_AUTH_SECRET environment variable.

# debug=True or secret set: startup proceeds normally
```

## Test plan

- [ ] `pytest tests/ -x -q` passes (lifespan not exercised in unit tests)
- [ ] Cloud Run deploy with `TASK_AUTH_SECRET` unset: container crashes at startup (expected)
- [ ] Cloud Run deploy with `TASK_AUTH_SECRET` set: starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)