### PR TITLE
docs: enforce PR workflow + QA review gates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,6 +24,22 @@
 
 **E2E after implementation**: `/e2e full` — 13 epics, 363 scenarios via Telegram MCP, Gmail MCP, Supabase MCP, Chrome DevTools MCP
 
+## Sprint Workflow (Multi-Issue Batches)
+
+When working on multiple issues in parallel:
+1. **Plan**: Create plan with issue-to-branch mapping (one branch per issue or logical group)
+2. **Implement**: Launch worktree agents — each creates branch + commits
+3. **PR per branch**: After agent completes, create PR via `gh pr create` from the branch
+4. **QA gate per PR**: Run `/qa-review --pr N` on each PR — fix until 0 blocking/important
+5. **Merge sequentially**: Squash merge PRs one at a time, running tests between each
+6. **Close issues**: Reference PR in issue close comment
+
+**Agent worktree rules**:
+- Agents commit to their worktree branch (never to master)
+- Main orchestrator creates PRs from agent branches
+- PRs must pass `/qa-review` before merge
+- If agent output is unsatisfactory, request fixes via SendMessage before creating PR
+
 ## Code Intelligence (`/project-intel`)
 
 Queries PROJECT_INDEX.json (988 files indexed, 17ms jq). Refresh with `/index` when stale.
@@ -54,6 +70,7 @@ Queries PROJECT_INDEX.json (988 files indexed, 17ms jq). Refresh with `/index` w
 6. **Agent invocation**: Use Task tool to spawn sdd-coordinator, sdd-*-validator agents. Main context is for orchestration only — delegate validation and research to subagents.
 7. **GATE 2 Analyze-Fix Loop**: After 6 validators complete: (a) user reviews validation-reports/, (b) CRITICAL/HIGH → create GH issues + fix spec + re-validate (max 3 iterations), (c) MEDIUM → create GH issue or document as accepted, (d) LOW → log in validation-findings.md, (e) user approves proceeding to Phase 5, (f) gate fails 3x → escalate, NEVER auto-waive.
 8. **Validation Findings Manifest**: Each spec gets `specs/NNN-*/validation-findings.md` with GH issue numbers for CRITICAL/HIGH, accept/defer decisions for MEDIUM, and user approval checkbox.
+9. **PR mandatory**: Every implementation MUST go through a PR. After `/implement` completes, create PR via `gh pr create`, then run `/qa-review --pr N`. Merge only after 0 blocking + 0 important issues.
 
 **Spec Lifecycle Rules**:
 - Specs are living documents — update when implementation diverges from original plan

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -1,0 +1,29 @@
+---
+description: Enforce PR-based workflow — never commit to master directly
+globs: ["**"]
+---
+
+# PR Workflow Enforcement
+
+## Hard Rules
+- NEVER push directly to master. Always create a feature branch first.
+- NEVER merge a branch without creating a PR via `gh pr create`.
+- NEVER merge a PR without running `/qa-review --pr N` and reaching 0 blocking + 0 important issues.
+- NEVER close a GH issue without referencing the PR that resolved it.
+
+## Per-Change Workflow
+1. `git checkout -b {type}/{issue}-{description}`
+2. Implement with TDD (tests first)
+3. `gh pr create --title "..." --body "..."`
+4. `/qa-review --pr N` — fix issues, re-review, repeat until PASS
+5. Squash merge after QA PASS + CI green
+6. `gh issue close N --comment "Fixed in PR #M"`
+
+## Sprint/Batch Exceptions
+- Multiple issues MAY share a branch if tightly coupled (e.g., `test/146-147-boss-engagement`)
+- Worktree agents commit to branches, orchestrator creates PRs
+- Each PR still requires its own `/qa-review` pass
+
+## Deployment
+- Deploy to Cloud Run / Vercel only AFTER PR merged to master
+- Never deploy from a feature branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,20 @@ See `docs/deployment.md` for full deployment reference (URLs, project IDs, comma
 - **Branches**: `{type}/{spec-number}-{description}` (e.g., `feature/042-unified-pipeline`)
 - **Merge**: Squash merge to master. Max 400 lines per PR.
 
+## PR Workflow (Mandatory)
+
+**NEVER commit directly to master.** All changes require a PR with QA review.
+
+1. **Branch**: Create `{type}/{issue}-{description}` from master
+2. **Implement**: TDD — tests first, then code, on the feature branch
+3. **PR**: `gh pr create` with summary + test plan
+4. **QA Review**: Run `/qa-review --pr N` — iterative fix loop until 0 blocking + 0 important issues
+5. **CI**: All checks must pass (backend-ci, portal-ci, e2e)
+6. **Merge**: Squash merge only. Max 400 lines per PR.
+7. **Close**: Reference GH issues in PR body (`Closes #N`)
+
+**Sprint/batch work**: Each issue gets its own branch + PR. Worktree agents MUST push branches and create PRs — never merge directly.
+
 ## Critical Rules
 
 1. **Verify before implementing**: Use MCP Ref tool to check official docs for ANY external library/API before writing code. Training data is outdated.


### PR DESCRIPTION
## Summary
- Add mandatory PR workflow rules to CLAUDE.md hierarchy
- Add `.claude/rules/pr-workflow.md` always-loaded rule: NEVER commit to master directly
- Add Sprint Workflow section with agent worktree rules
- Add SDD Enforcement #9: PR + `/qa-review` mandatory after `/implement`

## Why
The 2026-03-23 bugfix sprint committed 12 issues directly to master without PRs or QA review loops. This PR closes that gap by encoding the rules at every layer: root CLAUDE.md, toolkit CLAUDE.md, and a `.claude/rules/` always-loaded file.

## Test plan
- [ ] Verify root CLAUDE.md ≤150 lines
- [ ] Verify `.claude/rules/pr-workflow.md` is loaded by glob `**`
- [ ] New session picks up the "NEVER commit directly to master" rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)