### PR TITLE
chore(portal): CI Node 22, security headers, npm audit, engines field

### DIFF
--- a/.github/workflows/portal-ci.yml
+++ b/.github/workflows/portal-ci.yml
@@ -27,12 +27,15 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: 'portal/package-lock.json'
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Audit dependencies
+        run: npm audit --audit-level=high || true
 
       - name: Run unit tests
         run: npm run test:ci
@@ -66,7 +69,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: 'portal/package-lock.json'
 

--- a/portal/package.json
+++ b/portal/package.json
@@ -2,6 +2,9 @@
   "name": "portal",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/portal/vercel.json
+++ b/portal/vercel.json
@@ -14,7 +14,9 @@
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.supabase.co https://nikita-api-1040094048579.us-central1.run.app https://*.vercel-insights.com https://*.vercel-analytics.com" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- **H1** (#165): Update portal-ci.yml Node version from 20 → 22 (matches local dev requirement)
- **H2** (#166): Add Content-Security-Policy and Strict-Transport-Security headers to vercel.json
- **M3** (#170): Add `npm audit --audit-level=high` step to portal CI
- **L4** (#176): Add `"engines": { "node": ">=22" }` to portal/package.json

## Test plan
- [ ] Portal CI runs on Node 22 and passes lint/type-check/build
- [ ] `npm audit` step executes without blocking CI (uses `|| true`)
- [ ] Verify security headers on Vercel preview deploy via `curl -I`
- [ ] `npm install` with Node <22 warns about engine mismatch

Closes #165, #166, #170, #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)