### PR TITLE
chore(engine): update stale TODOs + remove empty platform stubs

### DIFF
--- a/nikita/conflicts/breakup.py
+++ b/nikita/conflicts/breakup.py
@@ -346,7 +346,7 @@ class BreakupManager:
             "should_breakup": threshold_result.should_breakup,
             "consecutive_crises": threshold_result.consecutive_crises,
             # DEPRECATED (Spec 109): ConflictStore removed. Stub zeros for API compat.
-            # TODO: Remove these fields in next breaking API version.
+            # Kept for backward compatibility (Spec 109). Remove when API bumps to v2.
             "total_conflicts": 0,
             "resolved_conflicts": 0,
             "resolution_rate": 0.0,

--- a/nikita/platforms/__init__.py
+++ b/nikita/platforms/__init__.py
@@ -1,1 +1,1 @@
-"""Platform integrations (Telegram, Voice, Portal)."""
+"""Platform integrations (Telegram)."""

--- a/nikita/platforms/portal/__init__.py
+++ b/nikita/platforms/portal/__init__.py
@@ -1,1 +1,0 @@
-"""Player portal API for stats dashboard."""

--- a/nikita/platforms/voice/__init__.py
+++ b/nikita/platforms/voice/__init__.py
@@ -1,1 +1,0 @@
-"""Voice platform integration using ElevenLabs Conversational AI."""

--- a/nikita/touchpoints/engine.py
+++ b/nikita/touchpoints/engine.py
@@ -399,14 +399,15 @@ class TouchpointEngine:
 
         Spec 103 FR-004: Provides open threads for message generation context.
 
-        TODO: Requires conversation_threads table (not yet created).
-        Returns empty list until table and repository are implemented.
+        Note: conversation_threads table exists (baseline_schema.sql) but no
+        upstream writer populates it yet. Returns empty list until touchpoint
+        creation writes threads.
 
         Args:
             user_id: User's UUID.
 
         Returns:
-            List of open thread descriptions (always empty until table exists).
+            List of open thread descriptions (empty until writer is implemented).
         """
         return []
 


### PR DESCRIPTION
## Summary
- Update stale TODO in touchpoints/engine.py — conversation_threads table exists but no writer populates it yet
- Clarify deprecated fields TODO in breakup.py — kept for API v1 backward compat (Spec 109)
- Delete empty nikita/platforms/voice/ and nikita/platforms/portal/ directories (zero imports, unused stubs)

## Test plan
- [x] Python imports still work (`import nikita.platforms.telegram`)
- [ ] No test failures from deleted stubs

Closes #174, #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)