### PR TITLE
fix(api): activate game after portal onboarding completes

### DIFF
--- a/nikita/api/routes/onboarding.py
+++ b/nikita/api/routes/onboarding.py
@@ -15,7 +15,7 @@ import time
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Request
 from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
@@ -27,6 +27,8 @@ from nikita.config.settings import get_settings
 from nikita.db.database import get_async_session
 from nikita.db.repositories.profile_repository import ProfileRepository
 from nikita.db.repositories.user_repository import UserRepository
+from nikita.db.repositories.vice_repository import VicePreferenceRepository
+from nikita.onboarding.handoff import HandoffManager
 from nikita.onboarding import (
     OnboardingServerToolHandler,
     OnboardingToolRequest,
@@ -86,6 +88,11 @@ async def get_user_repo(session: AsyncSession = Depends(get_async_session)) -> U
 async def get_profile_repo(session: AsyncSession = Depends(get_async_session)) -> ProfileRepository:
     """Get profile repository."""
     return ProfileRepository(session)
+
+
+async def get_vice_repo(session: AsyncSession = Depends(get_async_session)) -> VicePreferenceRepository:
+    """Get vice preference repository."""
+    return VicePreferenceRepository(session)
 
 
 # Singleton handler instance
@@ -627,18 +634,21 @@ class PortalProfileResponse(BaseModel):
 @router.post(
     "/profile",
     response_model=PortalProfileResponse,
-    summary="Save profile from portal onboarding (Spec 081)",
+    summary="Save profile from portal onboarding (Spec 081, GH #183)",
     description="""
     Accepts profile data from the portal cinematic onboarding experience.
-    Creates user_profiles row and updates onboarding_status to 'completed'.
-    Triggers venue research in background.
+    Creates user_profiles row, updates onboarding_status to 'completed',
+    activates game state, seeds vice preferences, and triggers handoff
+    (first Nikita message via Telegram) in background.
     """,
 )
 async def save_portal_profile(
     body: PortalProfileRequest,
+    background_tasks: BackgroundTasks,
     user_id: UUID = Depends(get_current_user_id),
     profile_repo: ProfileRepository = Depends(get_profile_repo),
     user_repo: UserRepository = Depends(get_user_repo),
+    vice_repo: VicePreferenceRepository = Depends(get_vice_repo),
 ) -> PortalProfileResponse:
     """Save player profile submitted from portal onboarding."""
     try:
@@ -662,12 +672,37 @@ async def save_portal_profile(
         )
 
         # Update onboarding status to completed
-        # (get_async_session auto-commits on success)
         await user_repo.update_onboarding_status(user_id, "completed")
+
+        # GH #183: Activate game state (game_status='active', score=50, days=0)
+        await user_repo.activate_game(user_id)
+
+        # GH #183: Seed vice preferences from drug_tolerance (maps to darkness_level)
+        try:
+            from nikita.engine.vice.seeder import seed_vices_from_profile
+            await seed_vices_from_profile(
+                user_id=user_id,
+                profile={"darkness_level": body.drug_tolerance},
+                vice_repo=vice_repo,
+            )
+        except Exception as vice_err:
+            logger.warning(
+                "Vice seeding failed for user_id=%s: %s", user_id, vice_err
+            )
+
+        # (get_async_session auto-commits on success)
 
         logger.info(
             "Portal profile saved for user_id=%s city=%s scene=%s",
             user_id, body.location_city.replace("\n", " "), body.social_scene
+        )
+
+        # GH #183: Trigger handoff in background (first Nikita message via Telegram)
+        background_tasks.add_task(
+            _trigger_portal_handoff,
+            user_id=user_id,
+            user_repo=user_repo,
+            drug_tolerance=body.drug_tolerance,
         )
 
         return PortalProfileResponse()
@@ -675,3 +710,58 @@ async def save_portal_profile(
     except Exception as e:
         logger.error("Error saving portal profile for user_id=%s: %s", user_id, e)
         raise HTTPException(status_code=500, detail="Failed to save profile")
+
+
+async def _trigger_portal_handoff(
+    user_id: UUID,
+    user_repo: UserRepository,
+    drug_tolerance: int,
+) -> None:
+    """Trigger handoff from portal onboarding to Nikita (GH #183).
+
+    Runs as a background task after the profile save response is sent.
+    Sends the first Nikita message via Telegram and bootstraps the pipeline.
+
+    Args:
+        user_id: User's UUID.
+        user_repo: UserRepository for fetching user data.
+        drug_tolerance: Maps to darkness_level for message personalization.
+    """
+    try:
+        user = await user_repo.get(user_id)
+        if not user:
+            logger.error("User %s not found for portal handoff", user_id)
+            return
+
+        telegram_id = user.telegram_id
+        if not telegram_id:
+            logger.warning(
+                "User %s has no telegram_id, skipping handoff", user_id
+            )
+            return
+
+        # Build minimal onboarding profile for message generation
+        from nikita.onboarding.models import UserOnboardingProfile
+        profile = UserOnboardingProfile(darkness_level=drug_tolerance)
+
+        handoff = HandoffManager()
+        result = await handoff.execute_handoff(
+            user_id=user_id,
+            telegram_id=telegram_id,
+            profile=profile,
+            user_name="friend",
+        )
+
+        if result.success:
+            logger.info("Portal handoff completed for user_id=%s", user_id)
+        else:
+            logger.error(
+                "Portal handoff failed for user_id=%s: %s",
+                user_id, result.error
+            )
+
+    except Exception as e:
+        logger.error(
+            "Portal handoff error for user_id=%s: %s", user_id, e,
+            exc_info=True,
+        )

--- a/nikita/db/repositories/user_repository.py
+++ b/nikita/db/repositories/user_repository.py
@@ -502,6 +502,34 @@ class UserRepository(BaseRepository[User]):
 
         return user
 
+    async def activate_game(self, user_id: UUID) -> User:
+        """Activate game state for a newly onboarded user (GH #183).
+
+        Sets game_status='active', relationship_score=50.00, days_played=0.
+        Called after portal or voice onboarding completes to start the game.
+
+        Args:
+            user_id: The user's UUID.
+
+        Returns:
+            Updated User entity.
+
+        Raises:
+            ValueError: If user not found.
+        """
+        user = await self.get(user_id)
+        if user is None:
+            raise ValueError(f"User {user_id} not found")
+
+        user.game_status = "active"
+        user.relationship_score = Decimal("50.00")
+        user.days_played = 0
+
+        await self.session.flush()
+        await self.session.refresh(user)
+
+        return user
+
     # --- Onboarding Methods (Spec 028) ---
 
     async def update_onboarding_status(

--- a/tests/api/routes/test_onboarding_profile.py
+++ b/tests/api/routes/test_onboarding_profile.py
@@ -1,12 +1,14 @@
-"""Tests for POST /api/v1/onboarding/profile endpoint (Spec 081).
+"""Tests for POST /api/v1/onboarding/profile endpoint (Spec 081, GH #183).
 
 Tests verify the portal profile save endpoint that replaces
 Telegram-based profile collection.
 
 AC Coverage: AC-4.1, AC-4.2, AC-4.3, AC-4.4, AC-4.5 (Spec 081)
+GH #183: Game activation (game_status, relationship_score, vices, handoff)
 """
 
 import pytest
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
@@ -110,15 +112,24 @@ class TestOnboardingProfileIntegration:
     def mock_user_repo(self):
         repo = AsyncMock()
         repo.update_onboarding_status.return_value = None
+        repo.activate_game.return_value = None
+        repo.get.return_value = MagicMock(telegram_id=None, phone=None, onboarding_profile=None)
         return repo
 
     @pytest.fixture
-    def client(self, mock_profile_repo, mock_user_repo):
+    def mock_vice_repo(self):
+        repo = AsyncMock()
+        repo.discover.return_value = MagicMock()
+        return repo
+
+    @pytest.fixture
+    def client(self, mock_profile_repo, mock_user_repo, mock_vice_repo):
         """Create TestClient with dependency overrides for the profile endpoint."""
         from nikita.api.dependencies.auth import get_current_user_id
         from nikita.api.routes.onboarding import (
             get_profile_repo,
             get_user_repo,
+            get_vice_repo,
             router,
         )
 
@@ -128,6 +139,7 @@ class TestOnboardingProfileIntegration:
         app.dependency_overrides[get_current_user_id] = lambda: USER_ID
         app.dependency_overrides[get_profile_repo] = lambda: mock_profile_repo
         app.dependency_overrides[get_user_repo] = lambda: mock_user_repo
+        app.dependency_overrides[get_vice_repo] = lambda: mock_vice_repo
 
         return TestClient(app)
 
@@ -148,6 +160,7 @@ class TestOnboardingProfileIntegration:
         # Verify mocks were called
         mock_profile_repo.create_profile.assert_awaited_once()
         mock_user_repo.update_onboarding_status.assert_awaited_once()
+        mock_user_repo.activate_game.assert_awaited_once()
 
     def test_profile_endpoint_returns_422_on_missing_fields(self, client):
         """Missing required fields return 422 validation error."""
@@ -174,3 +187,163 @@ class TestOnboardingProfileIntegration:
             "drug_tolerance": 3,
         })
         assert response.status_code == 422
+
+
+class TestOnboardingGameActivation:
+    """GH #183: Game activation after portal profile save.
+
+    Verifies that save_portal_profile activates game state,
+    seeds vices, and triggers handoff.
+    """
+
+    @pytest.fixture
+    def mock_profile_repo(self):
+        repo = AsyncMock()
+        repo.get_by_user_id.return_value = None  # No existing profile
+        repo.create_profile.return_value = MagicMock(id=USER_ID)
+        return repo
+
+    @pytest.fixture
+    def mock_user_repo(self):
+        repo = AsyncMock()
+        repo.update_onboarding_status.return_value = None
+        repo.activate_game.return_value = None
+        return repo
+
+    @pytest.fixture
+    def mock_vice_repo(self):
+        repo = AsyncMock()
+        repo.discover.return_value = MagicMock()
+        return repo
+
+    @pytest.fixture
+    def client(self, mock_profile_repo, mock_user_repo, mock_vice_repo):
+        """Create TestClient with dependency overrides."""
+        from nikita.api.dependencies.auth import get_current_user_id
+        from nikita.api.routes.onboarding import (
+            get_profile_repo,
+            get_user_repo,
+            get_vice_repo,
+            router,
+        )
+
+        app = FastAPI()
+        app.include_router(router, prefix="/onboarding")
+
+        app.dependency_overrides[get_current_user_id] = lambda: USER_ID
+        app.dependency_overrides[get_profile_repo] = lambda: mock_profile_repo
+        app.dependency_overrides[get_user_repo] = lambda: mock_user_repo
+        app.dependency_overrides[get_vice_repo] = lambda: mock_vice_repo
+
+        return TestClient(app)
+
+    def test_game_activated_after_profile_save(
+        self, client, mock_user_repo
+    ):
+        """GH #183: game_status set to 'active' after portal profile save."""
+        response = client.post("/onboarding/profile", json={
+            "location_city": "Zurich",
+            "social_scene": "techno",
+            "drug_tolerance": 3,
+        })
+        assert response.status_code == 200
+
+        mock_user_repo.activate_game.assert_awaited_once_with(USER_ID)
+
+    def test_vices_seeded_after_profile_save(
+        self, client, mock_vice_repo
+    ):
+        """GH #183: Vice preferences seeded from drug_tolerance."""
+        response = client.post("/onboarding/profile", json={
+            "location_city": "Berlin",
+            "social_scene": "art",
+            "drug_tolerance": 4,
+        })
+        assert response.status_code == 200
+
+        # drug_tolerance=4 maps to TIER_HIGH which has 5 categories
+        assert mock_vice_repo.discover.await_count > 0
+
+    @patch("nikita.api.routes.onboarding.HandoffManager")
+    def test_handoff_triggered_in_background(
+        self, mock_handoff_cls, client, mock_user_repo
+    ):
+        """GH #183: HandoffManager.execute_handoff called as background task."""
+        mock_handoff = AsyncMock()
+        mock_handoff.execute_handoff.return_value = MagicMock(success=True)
+        mock_handoff_cls.return_value = mock_handoff
+
+        # Mock user_repo.get to return a user with telegram_id
+        mock_user = MagicMock()
+        mock_user.telegram_id = 12345
+        mock_user.phone = None
+        mock_user.onboarding_profile = None
+        mock_user_repo.get.return_value = mock_user
+
+        response = client.post("/onboarding/profile", json={
+            "location_city": "Zurich",
+            "social_scene": "techno",
+            "drug_tolerance": 3,
+        })
+        assert response.status_code == 200
+
+        # Background task runs synchronously in TestClient
+        mock_handoff.execute_handoff.assert_awaited_once()
+        call_kwargs = mock_handoff.execute_handoff.call_args
+        assert call_kwargs[1]["user_id"] == USER_ID
+        assert call_kwargs[1]["telegram_id"] == 12345
+
+    def test_idempotent_profile_skips_activation(
+        self, client, mock_profile_repo, mock_user_repo
+    ):
+        """GH #183: Existing profile returns early without re-activating game."""
+        mock_profile_repo.get_by_user_id.return_value = MagicMock()  # Profile exists
+
+        response = client.post("/onboarding/profile", json={
+            "location_city": "Zurich",
+            "social_scene": "techno",
+            "drug_tolerance": 3,
+        })
+        assert response.status_code == 200
+        assert response.json()["message"] == "Profile already exists"
+
+        # Game activation should NOT happen
+        mock_user_repo.activate_game.assert_not_awaited()
+
+    def test_vice_seeding_failure_does_not_break_endpoint(
+        self, client, mock_vice_repo, mock_user_repo
+    ):
+        """GH #183: Vice seeding failure is logged but does not fail the request."""
+        mock_vice_repo.discover.side_effect = Exception("DB error")
+
+        response = client.post("/onboarding/profile", json={
+            "location_city": "Zurich",
+            "social_scene": "techno",
+            "drug_tolerance": 3,
+        })
+        # Should still succeed despite vice seeding failure
+        assert response.status_code == 200
+        mock_user_repo.activate_game.assert_awaited_once()
+
+    @patch("nikita.api.routes.onboarding.HandoffManager")
+    def test_handoff_failure_does_not_break_endpoint(
+        self, mock_handoff_cls, client, mock_user_repo
+    ):
+        """GH #183: Handoff failure in background does not affect response."""
+        mock_handoff = AsyncMock()
+        mock_handoff.execute_handoff.side_effect = Exception("Telegram down")
+        mock_handoff_cls.return_value = mock_handoff
+
+        mock_user = MagicMock()
+        mock_user.telegram_id = 12345
+        mock_user.phone = None
+        mock_user.onboarding_profile = None
+        mock_user_repo.get.return_value = mock_user
+
+        response = client.post("/onboarding/profile", json={
+            "location_city": "Zurich",
+            "social_scene": "techno",
+            "drug_tolerance": 3,
+        })
+        # Response should succeed even if handoff fails
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Portal onboarding (`POST /onboarding/profile`) now properly activates the game after profile save
- Adds `activate_game()` to UserRepository: sets `game_status='active'`, `relationship_score=50.00`, `days_played=0`
- Triggers handoff (first Nikita message via Telegram) as a background task
- Seeds vice preferences from profile data (non-blocking)
- 7 new tests covering activation, vice seeding, handoff trigger, idempotency, and error resilience

Closes #183

## Test plan
- [x] 16/16 onboarding profile tests pass
- [x] 1007/1007 API/onboarding/DB tests pass
- [x] 823/823 engine tests pass
- [ ] E2E: wipe account → onboarding → verify game_status=active, score=50

🤖 Generated with [Claude Code](https://claude.com/claude-code)