### PR TITLE
chore(docs,e2e): fix deployment docs + migrate E2E skill to agent-browser

### DIFF
--- a/.claude/skills/e2e-nikita/SKILL.md
+++ b/.claude/skills/e2e-nikita/SKILL.md
@@ -14,7 +14,7 @@ version: 2.0.0
 allowed-tools: >
   Bash, Read, Write, Edit, Glob, Grep, Agent, ToolSearch,
   mcp__telegram-mcp__*, mcp__gmail__*, mcp__supabase__*,
-  mcp__chrome-devtools__*, mcp__ElevenLabs__*
+  mcp__ElevenLabs__*
 ---
 
 # E2E Nikita — Master Test Suite
@@ -148,8 +148,8 @@ ToolSearch: select:mcp__telegram-mcp__list_inline_buttons,mcp__telegram-mcp__pre
 ToolSearch: select:mcp__telegram-mcp__resolve_username,mcp__telegram-mcp__get_chats
 ToolSearch: select:mcp__supabase__execute_sql
 ToolSearch: select:mcp__gmail__search_emails,mcp__gmail__read_email
-ToolSearch: select:mcp__chrome-devtools__navigate_page,mcp__chrome-devtools__take_screenshot
-ToolSearch: select:mcp__chrome-devtools__evaluate_script,mcp__chrome-devtools__click
+# Portal browser testing: use agent-browser CLI (vercel:agent-browser skill)
+# Commands: agent-browser navigate <url>, agent-browser snapshot, agent-browser click @ref, agent-browser fill @ref "value", agent-browser screenshot <path>
 ```
 
 ---
@@ -193,7 +193,7 @@ Step 6: Record result: <step_result status="pass|fail">evidence here</step_resul
 **Minimum evidence per phase:**
 - At least 1 Telegram message exchange captured
 - At least 1 Supabase SQL result confirming DB state
-- For portal phases: at least 1 Chrome DevTools screenshot
+- For portal phases: at least 1 agent-browser screenshot
 - For job phases: at least 1 job_executions row confirmed
 
 ---
@@ -309,7 +309,7 @@ Store USER_ID in working memory once established in Phase 01. Use it in all subs
 | File | Phase | Epics |
 |------|-------|-------|
 | @workflows/00-prerequisites.md | Setup, wipe, health checks | — |
-| @workflows/01-onboarding.md | Registration + text onboarding | E01 |
+| @workflows/01-onboarding.md | Registration + portal onboarding | E01 |
 | @workflows/02-gameplay.md | Text conversations, scoring | E02 |
 | @workflows/03-boss-encounters.md | Boss trigger, pass, fail, retry | E03 |
 | @workflows/04-decay.md | Decay application, grace periods | E04 |
@@ -323,7 +323,7 @@ Store USER_ID in working memory once established in Phase 01. Use it in all subs
 | @workflows/12-cross-platform.md | Text + voice combined scoring | E12 |
 | @workflows/13-gap-scenarios.md | Race conditions, security, edge cases | E13 |
 | @workflows/time-simulation.md | SQL time manipulation reference | — |
-| @workflows/portal-monitoring.md | Chrome DevTools patterns | — |
+| @workflows/portal-monitoring.md | agent-browser patterns | — |
 
 ## Reference Files
 

--- a/.claude/skills/e2e-nikita/workflows/01-onboarding.md
+++ b/.claude/skills/e2e-nikita/workflows/01-onboarding.md
@@ -11,13 +11,13 @@ Phase 00 complete. Account wiped. MCP tools loaded.
   Active → "Welcome back"
 
 Email → RegistrationHandler.handle_email_input() → send_otp_code()
-6-8 digit OTP → OTPHandler.handle() → verify → inline keyboard (Voice/Text)
-"onboarding_text" callback → OnboardingHandler.start() → LOCATION prompt
-Steps: LOCATION → LIFE_STAGE → SCENE → INTEREST → DRUG_TOLERANCE
-  → VENUE_RESEARCH (auto, 10-15s LLM) → SCENARIO_SELECTION → COMPLETE
+6-8 digit OTP → OTPHandler.handle() → verify → "You're in!" + inline button "Enter Nikita's World →"
+Button URL → Portal /onboarding (cinematic scroll, Spec 081)
+Portal onboarding: 5 sections → The Score, The Chapters, The Rules, Who Are You (form), Your Mission (CTA)
+Form submit → redirect to t.me/Nikita_my_bot → game_status=active
 ```
 
-## Step 1: Send /start
+## Step 1: Send /start [method: F]
 ```
 mcp__telegram-mcp__send_message(chat_id="8211370823", text="/start")
 ```
@@ -27,13 +27,13 @@ mcp__telegram-mcp__get_messages(chat_id="8211370823", page_size=5)
 ```
 Assert: response contains "email"
 
-## Step 2: Submit Email
+## Step 2: Submit Email [method: F]
 ```
 mcp__telegram-mcp__send_message(chat_id="8211370823", text="simon.yang.ch@gmail.com")
 ```
 Wait 5s. Assert response contains "sent a code" or similar OTP confirmation.
 
-## Step 3: Retrieve OTP from Gmail
+## Step 3: Retrieve OTP from Gmail [method: F]
 ```
 mcp__gmail__search_emails(query="from:onboarding@silent-agents.com newer_than:5m", maxResults=3)
 mcp__gmail__read_email(id="<message_id>")
@@ -41,38 +41,58 @@ mcp__gmail__read_email(id="<message_id>")
 Extract 6-8 digit code from email body. Retry every 10s up to 90s if no email.
 If still missing: check `pending_registrations` via Supabase (otp_state should be "pending").
 
-## Step 4: Submit OTP and Choose Text Onboarding
+## Step 4: Submit OTP [method: F]
 ```
 mcp__telegram-mcp__send_message(chat_id="8211370823", text="<OTP_CODE>")
 ```
+Wait 5s. Assert: bot responds with "You're in!" (or similar confirmation) and an inline button
+with text "Enter Nikita's World" linking to the portal onboarding URL.
+```
+mcp__telegram-mcp__get_messages(chat_id="8211370823", page_size=5)
+```
+Extract the portal onboarding URL from the inline button (points to portal `/onboarding`).
+
+## Step 5: Navigate to Portal Onboarding [method: F]
+Open the portal onboarding page via agent-browser:
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/onboarding"
+```
+Wait 3s for hydration.
+```bash
+agent-browser screenshot /tmp/e2e-onboarding-landing.png
+```
+Assert: Cinematic onboarding page loads with 5 scroll sections visible:
+1. **The Score** — explains the 4 relationship metrics
+2. **The Chapters** — explains chapter progression 1-5
+3. **The Rules** — explains decay, boss encounters, engagement
+4. **Who Are You** — profile form with city input + scene selector
+5. **Your Mission** — CTA button "Start Talking to Nikita"
+
+## Step 6: Fill Profile Form and Submit [method: F]
+Scroll to the "Who Are You" section and fill the profile form:
+```bash
+agent-browser fill @city-input "Zurich"
+```
+Select a scene option (e.g., techno):
+```bash
+agent-browser click @scene-techno
+```
+Scroll to the final CTA and click:
+```bash
+agent-browser click @start-talking-cta
+```
 Wait 5s.
+```bash
+agent-browser screenshot /tmp/e2e-onboarding-complete.png
 ```
-mcp__telegram-mcp__list_inline_buttons(chat_id="8211370823")
-mcp__telegram-mcp__press_inline_button(message_id="<msg_id>", button_text="Text")
-```
-Assert: Nikita sends first onboarding question (city/location).
+Assert: Redirect to `t.me/Nikita_my_bot` or a confirmation page indicating onboarding is complete.
 
-## Step 5: Answer 5 Profile Questions (2-3s between each)
-Send in order — wait for each question to appear before answering:
-1. Location: `"Zurich"`
-2. Life stage: `"tech"`
-3. Scene: `"techno"`
-4. Interest: `"building AI"`
-5. Drug tolerance: `"4"`
+**Note on @ref selectors:** The exact `@ref` identifiers depend on the portal's accessibility tree.
+Use `agent-browser snapshot` to inspect the current page and find the correct refs for form fields
+and buttons before interacting.
 
-Wait 15s after drug tolerance answer — venue research LLM call takes 10-15s.
-
-## Step 6: Select Scenario
-```
-mcp__telegram-mcp__get_messages(chat_id="8211370823", page_size=10)
-```
-Assert: 3 venue scenarios presented.
-```
-mcp__telegram-mcp__send_message(chat_id="8211370823", text="1")
-```
-Wait 10s. Assert: backstory generated + first Nikita in-character message received.
-
-## Evidence Queries
+## Step 7: Verify DB State [method: A]
+Wait 5s after form submission for backend processing.
 
 ```sql
 -- Primary verification
@@ -82,38 +102,55 @@ FROM users u
 LEFT JOIN user_metrics um ON um.user_id = u.id
 WHERE u.id = (SELECT id FROM auth.users WHERE email = 'simon.yang.ch@gmail.com');
 -- Assert: score=50, ch=1, game_status=active, onboarding_status=completed, metrics=50
+```
 
+```sql
 -- Profile check
-SELECT city, life_stage, scene, interest, drug_tolerance
-FROM user_profiles
+SELECT city, scene FROM user_profiles
 WHERE id = (SELECT id FROM auth.users WHERE email = 'simon.yang.ch@gmail.com');
--- Assert: all fields non-null, drug_tolerance present
-
--- Backstory check
-SELECT backstory FROM user_profiles
-WHERE id = (SELECT id FROM auth.users WHERE email = 'simon.yang.ch@gmail.com');
--- Assert: non-null, non-empty
+-- Assert: city='Zurich', scene non-null
 ```
 
 Store USER_ID from this query — used in ALL subsequent phases.
+
+## Evidence Queries
+
+```sql
+-- Primary verification (same as Step 7)
+SELECT u.id, u.telegram_id, u.relationship_score, u.chapter, u.game_status,
+       u.onboarding_status, um.intimacy, um.passion, um.trust, um.secureness
+FROM users u
+LEFT JOIN user_metrics um ON um.user_id = u.id
+WHERE u.id = (SELECT id FROM auth.users WHERE email = 'simon.yang.ch@gmail.com');
+-- Assert: score=50, ch=1, game_status=active, onboarding_status=completed, metrics=50
+
+-- Profile check
+SELECT city, scene FROM user_profiles
+WHERE id = (SELECT id FROM auth.users WHERE email = 'simon.yang.ch@gmail.com');
+-- Assert: city and scene non-null
+```
 
 ## Pass/Fail Criteria
 
 | Scenario | Priority | Pass Condition |
 |----------|----------|----------------|
 | S-1.1.1: /start for new user | P0 | Bot asks for email |
+| S-1.1.2: Email accepted, OTP sent | P0 | Bot confirms code sent |
 | S-1.1.3: Expired OTP rejected | P1 | See @references for simulation |
 | S-1.1.4: Wrong OTP rejected | P1 | Bot says code incorrect |
-| S-1.2.1: Complete 5 onboarding questions | P0 | onboarding_status=completed |
-| S-1.2.6: Backstory generation | P1 | backstory non-null in user_profiles |
-| S-1.2.5: Text vs Voice choice | P1 | Text button pressed, text onboarding starts |
+| S-1.2.1: OTP verified, portal link shown | P0 | "You're in!" + portal URL button |
+| S-1.2.2: Portal onboarding page loads | P0 | 5 cinematic sections visible |
+| S-1.2.3: Profile form submission | P0 | City + scene submitted, redirect to Telegram |
+| S-1.2.4: DB state after onboarding | P0 | game_status=active, score=50, onboarding_status=completed |
+| S-1.2.5: Profile data persisted | P1 | city and scene non-null in user_profiles |
 
 ## Recovery
 If stuck at any step:
 ```sql
 -- Check current state
-SELECT telegram_id, current_step, collected_answers FROM onboarding_states WHERE telegram_id = 746410893;
--- If step is wrong, check: did the message actually arrive? Check messages again.
+SELECT telegram_id, game_status, onboarding_status FROM users
+WHERE id = (SELECT id FROM auth.users WHERE email = 'simon.yang.ch@gmail.com');
+-- If onboarding stuck, check portal logs or agent-browser screenshot for errors.
 -- Nuclear option: wipe and restart from Step 1
 DELETE FROM onboarding_states WHERE telegram_id = 746410893;
 DELETE FROM users WHERE id = '<USER_ID>';

--- a/.claude/skills/e2e-nikita/workflows/08-portal-player.md
+++ b/.claude/skills/e2e-nikita/workflows/08-portal-player.md
@@ -1,23 +1,23 @@
 # Phase 08: Portal — Player Pages (E08, 35 scenarios)
 
 ## Prerequisites
-USER_ID established. User active with score data. Chrome DevTools MCP loaded.
-See @workflows/portal-monitoring.md for Chrome MCP patterns.
+USER_ID established. User active with score data. agent-browser available via Bash.
+See @workflows/portal-monitoring.md for agent-browser patterns.
 
 ## Step 1: Navigate to Portal [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app")
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app"
 ```
 Wait 3s.
-```
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser screenshot /tmp/e2e-portal-login.png
 ```
 Assert: Login page visible (email input or Supabase magic link form).
 
 ## Step 2: Initiate Magic Link Login [method: F]
-```
-mcp__chrome-devtools__fill(selector="input[type='email']", value="simon.yang.ch@gmail.com")
-mcp__chrome-devtools__click(selector="button[type='submit']")
+```bash
+agent-browser fill @email-input "simon.yang.ch@gmail.com"
+agent-browser click @submit-button
 ```
 Wait 5s.
 
@@ -29,50 +29,50 @@ mcp__gmail__read_email(id="<message_id>")
 Extract the magic link URL from email body.
 
 ## Step 4: Navigate Magic Link [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="<magic_link_url>")
+```bash
+agent-browser navigate "<magic_link_url>"
 ```
 Wait 5s.
-```
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser screenshot /tmp/e2e-portal-dashboard.png
 ```
 Assert: Redirected to /dashboard (player home).
 
 ## Step 5: Verify Dashboard (S-8.1.1) [method: F]
-```
-mcp__chrome-devtools__evaluate_script(
-  script="document.querySelector('[data-testid=relationship-score]')?.textContent || document.body.innerText.substring(0,200)"
-)
+```bash
+agent-browser execute "document.querySelector('[data-testid=relationship-score]')?.textContent || document.body.innerText.substring(0,200)"
 ```
 Assert: Dashboard shows relationship score, chapter indicator, and Nikita's status.
-Screenshot for evidence.
+```bash
+agent-browser screenshot /tmp/e2e-dashboard.png
+```
 
 ## Step 6: Verify Engagement Page (S-8.2.1) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/dashboard/engagement")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/dashboard/engagement"
+agent-browser screenshot /tmp/e2e-engagement.png
 ```
 Assert: Engagement state displayed (clingy/in_zone/distant etc.), multiplier visible.
 
 ## Step 7: Verify Insights Page (S-8.2.2) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/dashboard/insights")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/dashboard/insights"
+agent-browser screenshot /tmp/e2e-insights.png
 ```
 Assert: "Deep Insights" heading visible. Score Breakdown table has rows.
 Assert: At least 1 row with non-zero Delta value (regression for GH #153).
 
 ## Step 8: Verify Vices Page (S-8.3.1) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/dashboard/vices")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/dashboard/vices"
+agent-browser screenshot /tmp/e2e-vices.png
 ```
 Assert: Vice categories displayed (if any detected). Page renders without error.
 
 ## Step 9: Verify Conversations List (S-8.4.1) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/dashboard/conversations")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/dashboard/conversations"
+agent-browser screenshot /tmp/e2e-conversations.png
 ```
 Assert: Conversation history listed. All/Text/Voice/Boss filters visible.
 
@@ -81,69 +81,70 @@ Get conversation ID:
 ```sql
 SELECT id FROM conversations WHERE user_id='<USER_ID>' LIMIT 1;
 ```
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/dashboard/conversations/<ID>")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/dashboard/conversations/<ID>"
+agent-browser screenshot /tmp/e2e-conversation-detail.png
 ```
 Assert: Message thread visible with timestamps.
 
 ## Step 11: Verify Nikita's World Hub (S-8.6.1) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/dashboard/nikita")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/dashboard/nikita"
+agent-browser screenshot /tmp/e2e-nikita-world.png
 ```
 Assert: MoodOrb renders. "Today's Events" and "What's on Her Mind" sections visible.
 
 ## Step 12: Verify Nikita's Day (S-8.6.2) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/dashboard/nikita/day")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/dashboard/nikita/day"
+agent-browser screenshot /tmp/e2e-nikita-day.png
 ```
 Assert: Date navigation arrows visible. Psyche Insights section with tips. WarmthMeter present.
 
 ## Step 13: Verify Nikita's Mind (S-8.6.3) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/dashboard/nikita/mind")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/dashboard/nikita/mind"
+agent-browser screenshot /tmp/e2e-nikita-mind.png
 ```
 Assert: "Nikita's Mind" heading with thought count. Empty state OR thought feed.
 
 ## Step 14: Verify Storylines (S-8.6.4) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/dashboard/nikita/stories")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/dashboard/nikita/stories"
+agent-browser screenshot /tmp/e2e-nikita-stories.png
 ```
 Assert: "Storylines" heading. "Show resolved" toggle. Empty state OR arc cards.
 
 ## Step 15: Verify Social Circle (S-8.6.5) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/dashboard/nikita/circle")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/dashboard/nikita/circle"
+agent-browser screenshot /tmp/e2e-nikita-circle.png
 ```
 Assert: "Social Circle" heading with friend count. Empty state OR gallery.
 
 ## Step 16: Verify Diary (S-8.7.1) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/dashboard/diary")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/dashboard/diary"
+agent-browser screenshot /tmp/e2e-diary.png
 ```
 Assert: Diary page renders. Empty state "No diary entries yet" OR diary cards.
 
 ## Step 17: Verify Settings (S-8.8.1) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/dashboard/settings")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/dashboard/settings"
+agent-browser screenshot /tmp/e2e-settings.png
 ```
 Assert: Email, timezone, push notifications, Telegram status, Delete Account visible.
 
 ## Step 18: JS Console Error Sweep (S-8.5.1) [method: F]
 For EACH player route visited, check console:
+```bash
+agent-browser execute "(() => { const errorBoundaries = document.querySelectorAll('[class*=error], [data-error]'); const bodyText = document.body.innerText; const hasErrorText = /something went wrong|error occurred|500|TypeError/i.test(bodyText); return { errorBoundaries: errorBoundaries.length, hasErrorText }; })()"
 ```
-mcp__chrome-devtools__evaluate_script(
-  script="(() => { const errorBoundaries = document.querySelectorAll('[class*=error], [data-error]'); const bodyText = document.body.innerText; const hasErrorText = /something went wrong|error occurred|500|TypeError/i.test(bodyText); return { errorBoundaries: errorBoundaries.length, hasErrorText }; })()"
-)
+Also check for errors:
+```bash
+agent-browser execute "JSON.stringify(window.__console_errors || [])"
 ```
-Also use `list_console_messages` and filter for error-level entries.
 Assert: Zero error-level console messages across all player routes.
 
 ## Pass/Fail Criteria
@@ -151,7 +152,7 @@ Assert: Zero error-level console messages across all player routes.
 | Scenario | Priority | Pass Condition |
 |----------|----------|----------------|
 | S-8.1.1: Dashboard loads | P0 | Relationship score visible on /dashboard [F] |
-| S-8.1.2: Score data accurate | P1 | Score matches DB value ±0.5 [F] |
+| S-8.1.2: Score data accurate | P1 | Score matches DB value +-0.5 [F] |
 | S-8.1.3: Score ring shows correct score | P1 | Score ring matches DB within +-1 [F] |
 | S-8.2.1: Engagement page renders | P1 | No 500 error, state visible [F] |
 | S-8.2.2: Insights renders with non-zero deltas | P1 | Non-zero Delta in at least 1 row (GH #153) [F] |

--- a/.claude/skills/e2e-nikita/workflows/09-portal-admin.md
+++ b/.claude/skills/e2e-nikita/workflows/09-portal-admin.md
@@ -3,12 +3,12 @@
 ## Prerequisites
 User `simon.yang.ch@gmail.com` must have `raw_user_meta_data.role = "admin"` in Supabase
 AND email must be in Cloud Run ADMIN_EMAILS env var. Already configured per CLAUDE.md.
-Chrome DevTools MCP loaded, portal session from Phase 08 may still be active.
+agent-browser available via Bash, portal session from Phase 08 may still be active.
 
 ## Step 1: Navigate to Admin Dashboard (S-9.1.1) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/admin")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/admin"
+agent-browser screenshot /tmp/e2e-admin-dashboard.png
 ```
 Assert: Admin dashboard loads (cyan accent, NOT rose player accent). If redirected to /dashboard,
 the admin role is not set — verify Supabase metadata.
@@ -21,52 +21,52 @@ FROM auth.users WHERE email = 'simon.yang.ch@gmail.com';
 ```
 
 ## Step 3: Verify User List Page (S-9.1.2) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/admin/users")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/admin/users"
+agent-browser screenshot /tmp/e2e-admin-users.png
 ```
 Assert: User list shows at least 1 user (the test account). Table with game_status, chapter, score.
 
 ## Step 4: Verify Pipeline View (S-9.2.1) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/admin/pipeline")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/admin/pipeline"
+agent-browser screenshot /tmp/e2e-admin-pipeline.png
 ```
 Assert: Pipeline overview renders — no 500 error, shows stage counts or recent pipeline runs.
 
 ## Step 5: Verify Jobs Page (S-9.3.1) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/admin/jobs")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/admin/jobs"
+agent-browser screenshot /tmp/e2e-admin-jobs.png
 ```
 Assert: Job execution history shows. job_executions table visible.
 
 ## Step 6: Verify Admin-only Isolation (S-9.4.1) [method: F]
 Verify a non-admin route redirects properly:
-```
-mcp__chrome-devtools__evaluate_script(script="window.location.href")
+```bash
+agent-browser execute "window.location.href"
 ```
 Assert: If on admin route, confirms admin access is active.
 
 ## Step 7: Verify Text Monitor (S-9.5.1) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/admin/text")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/admin/text"
+agent-browser screenshot /tmp/e2e-admin-text.png
 ```
 Assert: Page renders WITHOUT crash (regression for GH #152).
 Assert: Table with conversation rows OR empty state. No TypeError in console.
 
 ## Step 8: Verify Voice Monitor (S-9.5.2) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/admin/voice")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/admin/voice"
+agent-browser screenshot /tmp/e2e-admin-voice.png
 ```
 Assert: "No voice conversations yet" empty state OR voice table.
 
 ## Step 9: Verify Prompts (S-9.6.1) [method: F]
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/admin/prompts")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/admin/prompts"
+agent-browser screenshot /tmp/e2e-admin-prompts.png
 ```
 Assert: "No prompts generated yet" empty state OR paginated table.
 
@@ -75,18 +75,20 @@ Get conversation ID from DB:
 ```sql
 SELECT id FROM conversations WHERE user_id='<USER_ID>' LIMIT 1;
 ```
-```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app/admin/conversations/<ID>")
-mcp__chrome-devtools__take_screenshot()
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app/admin/conversations/<ID>"
+agent-browser screenshot /tmp/e2e-admin-conversation-inspector.png
 ```
 Assert: "Conversation Inspector" heading with breadcrumbs. Pipeline events section visible.
 
 ## Step 11: JS Console Error Sweep (S-9.8.1) [method: F]
 Same pattern as Phase 08 Step 18 — check all admin routes for console errors.
+```bash
+agent-browser execute "(() => { const errorBoundaries = document.querySelectorAll('[class*=error], [data-error]'); const bodyText = document.body.innerText; const hasErrorText = /something went wrong|error occurred|500|TypeError/i.test(bodyText); return { errorBoundaries: errorBoundaries.length, hasErrorText }; })()"
 ```
-mcp__chrome-devtools__evaluate_script(
-  script="(() => { const errorBoundaries = document.querySelectorAll('[class*=error], [data-error]'); const bodyText = document.body.innerText; const hasErrorText = /something went wrong|error occurred|500|TypeError/i.test(bodyText); return { errorBoundaries: errorBoundaries.length, hasErrorText }; })()"
-)
+Also check for errors:
+```bash
+agent-browser execute "JSON.stringify(window.__console_errors || [])"
 ```
 Assert: Zero error-level console messages across all admin routes.
 

--- a/.claude/skills/e2e-nikita/workflows/portal-monitoring.md
+++ b/.claude/skills/e2e-nikita/workflows/portal-monitoring.md
@@ -1,52 +1,74 @@
-# Portal Monitoring — Chrome DevTools MCP Reference
+# Portal Monitoring — agent-browser Reference
 
-## Load Chrome MCP
+## About agent-browser
+
+agent-browser is a CLI tool for browser automation in E2E testing. It replaces the
+Chrome DevTools MCP and runs via Bash commands. All portal testing phases (08, 09)
+use these patterns.
+
+## Core Commands
+
+### Navigate to a URL
+```bash
+agent-browser navigate "https://portal-phi-orcin.vercel.app"
 ```
-ToolSearch: select:mcp__chrome-devtools__navigate_page,mcp__chrome-devtools__take_screenshot
-ToolSearch: select:mcp__chrome-devtools__evaluate_script,mcp__chrome-devtools__click
-ToolSearch: select:mcp__chrome-devtools__fill
+Wait 3s for hydration before interacting.
+
+### Take a Screenshot
+```bash
+agent-browser screenshot /tmp/e2e-screenshot-name.png
 ```
 
-## Core Operations
-
-### Navigate and Screenshot
+### Inspect Page (Accessibility Snapshot)
+```bash
+agent-browser snapshot
 ```
-mcp__chrome-devtools__navigate_page(url="https://portal-phi-orcin.vercel.app")
--- Wait 3s for hydration
-mcp__chrome-devtools__take_screenshot()
+Returns the accessibility tree with `@ref` identifiers for interactive elements.
+Always run this before `click` or `fill` to discover the correct refs.
+
+### Click an Element
+```bash
+agent-browser click @ref-identifier
+```
+
+### Fill a Form Field
+```bash
+agent-browser fill @ref-identifier "value"
+```
+
+### Execute JavaScript
+```bash
+agent-browser execute "window.location.href"
+```
+
+```bash
+agent-browser execute "document.body.innerText.substring(0, 500)"
 ```
 
 ### Check Current URL (verify redirect worked)
-```
-mcp__chrome-devtools__evaluate_script(script="window.location.href")
+```bash
+agent-browser execute "window.location.href"
 ```
 
 ### Get Page Text (verify content loaded)
-```
-mcp__chrome-devtools__evaluate_script(script="document.body.innerText.substring(0, 500)")
-```
-
-### Fill Form Field
-```
-mcp__chrome-devtools__fill(selector="input[type='email']", value="simon.yang.ch@gmail.com")
-mcp__chrome-devtools__click(selector="button[type='submit']")
+```bash
+agent-browser execute "document.body.innerText.substring(0, 500)"
 ```
 
 ### Check for Errors in DOM
-```
-mcp__chrome-devtools__evaluate_script(
-  script="Array.from(document.querySelectorAll('[class*=error]')).map(e=>e.textContent).join(', ')"
-)
+```bash
+agent-browser execute "Array.from(document.querySelectorAll('[class*=error]')).map(e=>e.textContent).join(', ')"
 ```
 
 ### JS Console Error Check Pattern
 After navigating each route:
+```bash
+agent-browser execute "(() => { const errorBoundaries = document.querySelectorAll('[class*=error], [data-error]'); const bodyText = document.body.innerText; const hasErrorText = /something went wrong|error occurred|500|TypeError/i.test(bodyText); return { errorBoundaries: errorBoundaries.length, hasErrorText }; })()"
 ```
-mcp__chrome-devtools__evaluate_script(
-  script="(() => { const errorBoundaries = document.querySelectorAll('[class*=error], [data-error]'); const bodyText = document.body.innerText; const hasErrorText = /something went wrong|error occurred|500|TypeError/i.test(bodyText); return { errorBoundaries: errorBoundaries.length, hasErrorText }; })()"
-)
+Also check for collected console errors:
+```bash
+agent-browser execute "JSON.stringify(window.__console_errors || [])"
 ```
-Also use `list_console_messages` and filter for `TypeError|ReferenceError|Unhandled` if available.
 
 ## Complete Portal Route Inventory (24 routes)
 
@@ -82,13 +104,33 @@ Also use `list_console_messages` and filter for `TypeError|ReferenceError|Unhand
 | `/admin/voice` | Voice conversation table OR empty state | F |
 | `/admin/conversations/[id]` | Conversation Inspector with pipeline events | F |
 
+## Workflow: Navigate + Verify Pattern
+
+For each route, follow this pattern:
+```bash
+# 1. Navigate
+agent-browser navigate "<url>"
+
+# 2. Wait for hydration (3-5s)
+
+# 3. Screenshot for evidence
+agent-browser screenshot /tmp/e2e-<route-name>.png
+
+# 4. Verify content (optional, when screenshot alone is insufficient)
+agent-browser execute "<js expression>"
+
+# 5. Check for errors
+agent-browser execute "(() => { ... error check ... })()"
+```
+
 ## Common Failures
 
 | Symptom | Likely Cause | Action |
 |---------|-------------|--------|
-| Blank page after navigate | Vercel cold start | Wait 5s, refresh screenshot |
+| Blank page after navigate | Vercel cold start | Wait 5s, re-navigate |
 | Redirected to / on /admin | Admin role not set | Fix Supabase metadata |
 | 500 error on any route | API proxy failing | Check Cloud Run health |
 | Loading spinner forever | Supabase client init | Check env vars in Vercel |
 | TypeError on /admin/text | score_delta.toFixed on null | GH #152 — apply Number() guard |
 | Delta always 0 on /insights | Only reads details.delta | GH #153 — use _compute_score_delta |
+| @ref not found | Page not fully loaded | Run `agent-browser snapshot` to inspect current state |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -95,14 +95,17 @@ Dashboard: Configure server tools, knowledge base, and voice settings at `https:
 | Env Var | Secret Name | Purpose |
 |---------|-------------|---------|
 | `DATABASE_URL` | `nikita-database-url` | PostgreSQL connection string |
-| `SUPABASE_URL` | `nikita-supabase-url` | Supabase project URL |
 | `SUPABASE_SERVICE_KEY` | `nikita-supabase-service-key` | Supabase service role key |
+| `SUPABASE_JWT_SECRET` | `nikita-supabase-jwt-secret` | JWT verification key |
 | `ANTHROPIC_API_KEY` | `nikita-anthropic-api-key` | Claude API key |
 | `ELEVENLABS_API_KEY` | `nikita-elevenlabs-api-key` | ElevenLabs voice API key |
 | `TELEGRAM_BOT_TOKEN` | `nikita-telegram-bot-token` | Telegram bot authentication |
 | `TELEGRAM_WEBHOOK_SECRET` | `nikita-telegram-webhook-secret` | Webhook signature validation |
 | `TASK_AUTH_SECRET` | `nikita-task-auth-secret` | pg_cron task endpoint auth (PR #127) |
-| `ELEVENLABS_PHONE_NUMBER_ID` | (env var, not secret) | Phone number resource ID for outbound calls (`phnum_9201keym29f7fgcbymyq80wk6t4e`) |
+
+**Plain env vars (not secrets):**
+- `SUPABASE_URL` — Public project URL (`https://vlvlwmolfdpzdfmtipji.supabase.co`). Not a credential — same value as `NEXT_PUBLIC_SUPABASE_URL` in the portal. Set as a plain Cloud Run env var, not a Secret Manager reference.
+- `ELEVENLABS_PHONE_NUMBER_ID` — Phone number resource ID for outbound calls (`phnum_9201keym29f7fgcbymyq80wk6t4e`).
 
 **TASK_AUTH_SECRET**: Required in non-debug mode. Startup raises `RuntimeError` if missing (`nikita/api/main.py:78-85`). Created 2026-03-15 during audit remediation deployment.
 


### PR DESCRIPTION
## Summary
- Fixes `docs/deployment.md`: removed `SUPABASE_URL` from secrets table (it's a public URL, not a credential), added plain env vars section
- Migrated E2E skill from Chrome DevTools MCP to agent-browser CLI across all portal workflows
- Rewrote onboarding workflow for Spec 081 portal-based cinematic flow (replaces stale text-based flow)
- Updated portal-player, portal-admin, and portal-monitoring workflows

Closes #184

## Test plan
- [x] No code changes — docs + skill config only
- [ ] Verify `docs/deployment.md` secrets table is accurate
- [ ] Run `/e2e onboarding` with updated skill (after #183 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)