### PR TITLE
fix(portal): resolve all 13 pre-existing ESLint warnings

### DIFF
--- a/portal/src/__tests__/components/engagement-timeline.test.tsx
+++ b/portal/src/__tests__/components/engagement-timeline.test.tsx
@@ -3,7 +3,7 @@
  * Verifies chart rendering with mocked data, loading state, empty state
  */
 import { describe, it, expect, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { EngagementTimeline } from "@/components/charts/engagement-timeline"
 

--- a/portal/src/__tests__/hooks/use-admin-users.test.ts
+++ b/portal/src/__tests__/hooks/use-admin-users.test.ts
@@ -75,7 +75,7 @@ describe("useAdminUsers", () => {
   it("handles API error", async () => {
     vi.mocked(adminApi.getUsers).mockRejectedValue({ detail: "Unauthorized", status: 401 })
 
-    const { result } = renderHook(() => useAdminUsers(), { wrapper })
+    renderHook(() => useAdminUsers(), { wrapper })
 
     await waitFor(() => expect(adminApi.getUsers).toHaveBeenCalled())
   })

--- a/portal/src/app/admin/conversations/[id]/page-client.tsx
+++ b/portal/src/app/admin/conversations/[id]/page-client.tsx
@@ -6,14 +6,13 @@ import { useQuery } from "@tanstack/react-query"
 import { adminApi } from "@/lib/api/admin"
 import type { PipelineEvent } from "@/lib/api/types"
 import { Badge } from "@/components/ui/badge"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
 import {
   Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb"
 import { LoadingSkeleton } from "@/components/shared/loading-skeleton"
 import { ErrorDisplay } from "@/components/shared/error-boundary"
-import { EmptyState } from "@/components/shared/empty-state"
-import { formatDateTime, formatDuration, cn } from "@/lib/utils"
+import { formatDuration, cn } from "@/lib/utils"
 import { STALE_TIMES } from "@/lib/constants"
 
 // ---------------------------------------------------------------------------

--- a/portal/src/app/dashboard/engagement/page-client.tsx
+++ b/portal/src/app/dashboard/engagement/page-client.tsx
@@ -33,7 +33,7 @@ export default function EngagementPage() {
             </p>
           ) : (
             <div className="space-y-3">
-              {engagement.recent_transitions.map((t, i) => (
+              {engagement.recent_transitions.map((t) => (
                 <div key={`${t.created_at}-${t.to_state}`} className="flex items-start gap-3 text-sm">
                   <div className="flex-shrink-0 mt-1">
                     <div className="h-2 w-2 rounded-full bg-white/20" />

--- a/portal/src/app/dashboard/nikita/day/page-client.tsx
+++ b/portal/src/app/dashboard/nikita/day/page-client.tsx
@@ -33,7 +33,8 @@ export default function NikitaDayPage() {
   // Initialize empty to avoid SSR/client hydration mismatch (React #418),
   // then set to today on mount.
   const [dateStr, setDateStr] = useState("")
-  useEffect(() => { setDateStr(formatDate(new Date())) }, [])
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { setDateStr(formatDate(new Date())) }, []) // hydration-safe: SSR renders empty, client sets today
   const lifeEvents = useLifeEvents(dateStr)
   const emotionalState = useEmotionalState()
   const socialCircle = useSocialCircle()

--- a/portal/src/app/onboarding/onboarding-cinematic.tsx
+++ b/portal/src/app/onboarding/onboarding-cinematic.tsx
@@ -18,7 +18,7 @@ interface OnboardingCinematicProps {
   userId: string
 }
 
-export function OnboardingCinematic({ userId }: OnboardingCinematicProps) {
+export function OnboardingCinematic({ userId: _userId }: OnboardingCinematicProps) {
   const [submitting, setSubmitting] = useState(false)
   const [submitted, setSubmitted] = useState(false)
   const [error, setError] = useState<string | null>(null)

--- a/portal/src/app/onboarding/sections/score-section.tsx
+++ b/portal/src/app/onboarding/sections/score-section.tsx
@@ -24,7 +24,8 @@ function CountUp({ target, duration = 1.2 }: { target: number; duration?: number
   useEffect(() => {
     if (!inView) return
     if (prefersReducedMotion) {
-      setValue(target)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setValue(target) // intentional: immediately set final value when motion is reduced
       return
     }
     let frameId: number

--- a/portal/src/components/dashboard/conflict-banner.tsx
+++ b/portal/src/components/dashboard/conflict-banner.tsx
@@ -26,38 +26,39 @@ const conflictBadgeStyles: Record<string, { variant: "default" | "secondary" | "
   explosive: { variant: "destructive", className: "bg-red-500/20" },
 }
 
+// Calculate time since conflict started
+function getTimeSince(timestamp: string | null): string {
+  if (!timestamp) return "Unknown"
+
+  const now = new Date()
+  const started = new Date(timestamp)
+  const diffMs = now.getTime() - started.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMins / 60)
+  const diffDays = Math.floor(diffHours / 24)
+
+  if (diffDays > 0) return `${diffDays} day${diffDays > 1 ? "s" : ""} ago`
+  if (diffHours > 0) return `${diffHours} hour${diffHours > 1 ? "s" : ""} ago`
+  if (diffMins > 0) return `${diffMins} minute${diffMins > 1 ? "s" : ""} ago`
+  return "Just now"
+}
+
 export function ConflictBanner({
   conflictState,
   conflictTrigger,
   conflictStartedAt,
 }: ConflictBannerProps) {
-  // Only render if in conflict
-  if (conflictState === "none") {
-    return null
-  }
-
-  // Calculate time since conflict started
-  const getTimeSince = (timestamp: string | null): string => {
-    if (!timestamp) return "Unknown"
-
-    const now = new Date()
-    const started = new Date(timestamp)
-    const diffMs = now.getTime() - started.getTime()
-    const diffMins = Math.floor(diffMs / 60000)
-    const diffHours = Math.floor(diffMins / 60)
-    const diffDays = Math.floor(diffHours / 24)
-
-    if (diffDays > 0) return `${diffDays} day${diffDays > 1 ? "s" : ""} ago`
-    if (diffHours > 0) return `${diffHours} hour${diffHours > 1 ? "s" : ""} ago`
-    if (diffMins > 0) return `${diffMins} minute${diffMins > 1 ? "s" : ""} ago`
-    return "Just now"
-  }
-
   // Compute time since on client only to avoid SSR hydration mismatch (React #418)
   const [timeSince, setTimeSince] = useState("")
   useEffect(() => {
-    setTimeSince(getTimeSince(conflictStartedAt || null))
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setTimeSince(getTimeSince(conflictStartedAt || null)) // hydration-safe: compute on client only
   }, [conflictStartedAt])
+
+  // Only render if in conflict — hooks must be above this early return
+  if (conflictState === "none") {
+    return null
+  }
 
   const badgeStyle = conflictBadgeStyles[conflictState] || conflictBadgeStyles.explosive
 

--- a/portal/src/components/shared/relative-time.tsx
+++ b/portal/src/components/shared/relative-time.tsx
@@ -18,6 +18,9 @@ export function RelativeTime({ date, className }: RelativeTimeProps) {
   const [display, setDisplay] = useState(() => formatDate(date))
 
   useEffect(() => {
+    // Intentional: switch from SSR absolute date to relative time on client mount.
+    // The synchronous setState here is safe — it batches with the effect commit.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDisplay(formatRelativeTime(date))
 
     const interval = setInterval(() => {


### PR DESCRIPTION
## Summary

Clears all 13 pre-existing ESLint warnings surfaced during the PR #211 QA review. 0 warnings, 0 errors after this change.

**Unused vars (5 files):**
- `engagement-timeline.test.tsx` — remove unused `screen` import
- `use-admin-users.test.ts` — drop unused `result` destructure in error test
- `conversations/[id]/page-client.tsx` — remove `CardHeader`, `CardTitle`, `EmptyState`, `formatDateTime`
- `engagement/page-client.tsx` — drop unused `i` loop param
- `onboarding-cinematic.tsx` — prefix unused `userId` with `_`

**Rules of Hooks violation (1 file):**
- `conflict-banner.tsx` — move `useState`/`useEffect` above early `return null` (hooks must never be called conditionally)

**`react-hooks/set-state-in-effect` (4 files — intentional hydration-safe patterns):**
- `relative-time.tsx`, `day/page-client.tsx`, `conflict-banner.tsx`, `score-section.tsx` — all use `setState` synchronously in an effect to switch from SSR-safe initial state to client-side computed value. Suppressed with targeted `eslint-disable-next-line` + explanation comment at each site.

## Test plan

- [x] `npm run lint` → 0 errors, 0 warnings
- [x] `npx vitest run` → 459/459 passing
- [x] `npx tsc --noEmit` → clean