### PR TITLE
fix(onboarding): harden city validation + deferred handoff retry (#198)

### DIFF
--- a/nikita/api/routes/onboarding.py
+++ b/nikita/api/routes/onboarding.py
@@ -668,9 +668,15 @@ class PortalProfileRequest(BaseModel):
     @field_validator("location_city")
     @classmethod
     def location_not_blank(cls, v: str) -> str:
-        if not v.strip():
-            raise ValueError("City cannot be blank")
-        return v.strip()
+        """Validate city via the shared onboarding validator (GH #198).
+
+        Pydantic v2 converts any ``ValueError`` raised here into a
+        ``ValidationError`` (HTTP 422). ``validate_city`` also strips and
+        normalizes internal whitespace.
+        """
+        from nikita.onboarding.validation import validate_city
+
+        return validate_city(v)
 
 
 class PortalProfileResponse(BaseModel):
@@ -796,8 +802,19 @@ async def _trigger_portal_handoff(
         telegram_id = user.telegram_id
         if not telegram_id:
             logger.warning(
-                "User %s has no telegram_id, skipping handoff", user_id
+                "User %s has no telegram_id, deferring handoff (pending_handoff=True)",
+                user_id,
             )
+            # PR-2 (GH #198-linked): persist deferred-handoff intent so the
+            # MessageHandler fires HandoffManager on the user's first message.
+            try:
+                await user_repo.set_pending_handoff(user_id, True)
+            except Exception as flag_err:
+                logger.error(
+                    "Failed to set pending_handoff for user %s: %s",
+                    user_id,
+                    flag_err,
+                )
             return
 
         # Build minimal onboarding profile for message generation

--- a/nikita/db/models/user.py
+++ b/nikita/db/models/user.py
@@ -121,6 +121,16 @@ class User(Base, TimestampMixin):
     )
     onboarding_call_id: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # PR-2 (GH #198-linked): set True when portal onboarding completes but
+    # user.telegram_id is not yet linked. MessageHandler fires the deferred
+    # handoff on the user's first Telegram message and clears this flag.
+    pending_handoff: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default="false",
+        nullable=False,
+    )
+
     # Life simulation enhanced (Spec 055)
     routine_config: Mapped[dict | None] = mapped_column(JSONB, default=dict, nullable=True)
     meta_instructions: Mapped[dict | None] = mapped_column(JSONB, default=dict, nullable=True)

--- a/nikita/db/repositories/user_repository.py
+++ b/nikita/db/repositories/user_repository.py
@@ -571,6 +571,30 @@ class UserRepository(BaseRepository[User]):
 
         return user
 
+    async def set_pending_handoff(self, user_id: UUID, value: bool) -> None:
+        """Set the user's ``pending_handoff`` flag.
+
+        Used by the portal onboarding → Telegram handoff retry mechanism
+        (PR-2, GH #198-linked). When portal onboarding completes without a
+        linked ``telegram_id``, we set this flag to True and fire the
+        HandoffManager work on the user's first subsequent message.
+
+        Args:
+            user_id: The user's UUID.
+            value: True to defer handoff, False to mark it completed.
+
+        Raises:
+            ValueError: If the user is not found.
+        """
+        user = await self.get(user_id)
+        if user is None:
+            raise ValueError(f"User {user_id} not found")
+
+        user.pending_handoff = value
+
+        await self.session.flush()
+        await self.session.refresh(user)
+
     async def update_onboarding_profile(
         self,
         user_id: UUID,

--- a/nikita/onboarding/validation.py
+++ b/nikita/onboarding/validation.py
@@ -1,0 +1,84 @@
+"""Shared validation utilities for onboarding inputs (PR-2 / GH #198).
+
+Both entry points must use this module — the portal profile API
+(`nikita/api/routes/onboarding.py`) and the Telegram text-onboarding
+fallback (`nikita/platforms/telegram/onboarding/handler.py`) — to keep
+rejection rules consistent across platforms.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+# Small blocklist of obvious placeholder inputs. Covers the concrete cases
+# that leaked through prior validation (issue #198 caught "hey"). Keep this
+# narrow: legitimate city names like "Nice" or "York" must still pass.
+_JUNK_WORDS = frozenset(
+    {
+        "hey",
+        "hi",
+        "test",
+        "asdf",
+        "foo",
+        "bar",
+        "none",
+        "na",
+        "n/a",
+        "xxx",
+    }
+)
+
+_MIN_LENGTH = 2
+_MAX_LENGTH = 100
+
+
+def validate_city(raw: str) -> str:
+    """Validate and normalize a user-supplied city name.
+
+    Rules (applied in order):
+    1. Reject if ``raw`` is falsy.
+    2. Strip leading/trailing whitespace.
+    3. Reject if any character is a Unicode control (Cc) or format (Cf)
+       char — catches NUL bytes, bells, zero-width spaces, etc.
+    4. Collapse runs of 3 or more ASCII spaces into a single space (keeps
+       normal "New York" / double-space typos intact).
+    5. Enforce length between ``_MIN_LENGTH`` and ``_MAX_LENGTH`` chars.
+    6. Reject purely numeric input (e.g. ``"12345"``, ``"0"``).
+    7. Reject if the lowercased value matches the junk-word blocklist.
+
+    Args:
+        raw: The raw user input.
+
+    Returns:
+        The normalized city name.
+
+    Raises:
+        ValueError: If the input fails any of the rules above. The message
+            is safe to surface to end users.
+    """
+    if not raw:
+        raise ValueError("City cannot be blank")
+
+    # Strip only ASCII whitespace at edges. Python's default ``str.strip()``
+    # additionally eats control chars like ``\x1f``, which would hide them
+    # from the control-char check below — strip them explicitly instead.
+    v = raw.strip(" \t\n\r\v\f")
+
+    if any(unicodedata.category(c) in ("Cc", "Cf") for c in v):
+        raise ValueError("City contains invalid characters")
+
+    v = re.sub(r" {3,}", " ", v)
+
+    if len(v) < _MIN_LENGTH or len(v) > _MAX_LENGTH:
+        raise ValueError(
+            f"City must be {_MIN_LENGTH}-{_MAX_LENGTH} characters"
+        )
+
+    if re.fullmatch(r"\d+", v):
+        raise ValueError("City cannot be purely numeric")
+
+    if v.lower() in _JUNK_WORDS:
+        raise ValueError("Please enter a real city name")
+
+    return v

--- a/nikita/onboarding/validation.py
+++ b/nikita/onboarding/validation.py
@@ -14,6 +14,10 @@ import unicodedata
 # Small blocklist of obvious placeholder inputs. Covers the concrete cases
 # that leaked through prior validation (issue #198 caught "hey"). Keep this
 # narrow: legitimate city names like "Nice" or "York" must still pass.
+#
+# Known false-positives we're deliberately accepting:
+#   - "bar" → Bar, Montenegro (pop. ~17k). Affected users can enter
+#     "Bar, Montenegro" or similar disambiguation and the rule will pass.
 _JUNK_WORDS = frozenset(
     {
         "hey",

--- a/nikita/onboarding/validation.py
+++ b/nikita/onboarding/validation.py
@@ -60,10 +60,13 @@ def validate_city(raw: str) -> str:
     if not raw:
         raise ValueError("City cannot be blank")
 
-    # Strip only ASCII whitespace at edges. Python's default ``str.strip()``
-    # additionally eats control chars like ``\x1f``, which would hide them
-    # from the control-char check below — strip them explicitly instead.
-    v = raw.strip(" \t\n\r\v\f")
+    # Strip only ASCII whitespace + common Unicode space separators at the
+    # edges. Python's default ``str.strip()`` additionally eats control
+    # chars like ``\x1f``, which would hide them from the control-char
+    # check below — strip them explicitly instead. The explicit set also
+    # covers NBSP (``\u00a0``) and narrow no-break space (``\u202f``) which
+    # users sometimes paste from websites or rich-text clients.
+    v = raw.strip(" \t\n\r\v\f\u00a0\u2007\u202f")
 
     if any(unicodedata.category(c) in ("Cc", "Cf") for c in v):
         raise ValueError("City contains invalid characters")

--- a/nikita/platforms/telegram/message_handler.py
+++ b/nikita/platforms/telegram/message_handler.py
@@ -796,6 +796,17 @@ class MessageHandler:
         message. The row-lock obtained in :meth:`handle` via
         ``get_by_telegram_id_for_update`` prevents double-fire on rapid
         messages.
+
+        Note on transaction scope: this awaits inside the outer ``handle``
+        transaction which holds ``FOR UPDATE`` on the user row. The only
+        synchronous work here is message generation + the Telegram HTTP
+        send (no DB writes). ``HandoffManager.execute_handoff`` spawns
+        ``generate_and_store_social_circle`` and ``_bootstrap_pipeline``
+        as fire-and-forget asyncio tasks on fresh sessions — those tasks
+        don't update the users row, so the outer FOR UPDATE does not
+        deadlock them. They may briefly serialize behind the outer
+        commit, which is acceptable (~ms) and matches the pre-existing
+        ``_trigger_portal_handoff`` BackgroundTask flow.
         """
         try:
             from nikita.onboarding.handoff import HandoffManager

--- a/nikita/platforms/telegram/message_handler.py
+++ b/nikita/platforms/telegram/message_handler.py
@@ -779,6 +779,56 @@ class MessageHandler:
         except Exception as e:
             logger.error(f"[BOSS] Failed to send boss opening: {e}")
 
+    async def _execute_pending_handoff(self, user) -> None:
+        """Fire a deferred portal→Telegram handoff (PR-2 / GH #198-linked).
+
+        When portal onboarding completes without a linked ``telegram_id``,
+        ``save_portal_profile`` sets ``user.pending_handoff=True``. This
+        method runs on the user's first subsequent Telegram message (from
+        ``_needs_onboarding``) and delegates to :class:`HandoffManager` to:
+
+        - send the scripted first-Nikita message via Telegram,
+        - generate the user's social circle,
+        - bootstrap the pipeline (memory seeding, context warm-up).
+
+        The flag is cleared only on a successful handoff so transient
+        failures (Telegram outage, DB hiccup) naturally retry on the next
+        message. The row-lock obtained in :meth:`handle` via
+        ``get_by_telegram_id_for_update`` prevents double-fire on rapid
+        messages.
+        """
+        try:
+            from nikita.onboarding.handoff import HandoffManager
+            from nikita.onboarding.models import UserOnboardingProfile
+
+            profile_payload = user.onboarding_profile or {}
+            darkness_level = int(profile_payload.get("darkness_level", 3))
+            profile = UserOnboardingProfile(darkness_level=darkness_level)
+
+            manager = HandoffManager()
+            result = await manager.execute_handoff(
+                user_id=user.id,
+                telegram_id=user.telegram_id,
+                profile=profile,
+                user_name="friend",
+            )
+
+            if result.success:
+                await self.user_repository.set_pending_handoff(user.id, False)
+                logger.info(
+                    f"[HANDOFF-RETRY] Fired deferred handoff for user {user.id}"
+                )
+            else:
+                logger.error(
+                    f"[HANDOFF-RETRY] Deferred handoff failed for user {user.id}: "
+                    f"{result.error}"
+                )
+        except Exception as e:
+            logger.exception(
+                f"[HANDOFF-RETRY] Unexpected error for user {getattr(user, 'id', '?')}: {e}"
+            )
+            # Intentionally do NOT clear the flag — next message will retry.
+
     async def _needs_onboarding(
         self,
         user_id: UUID,
@@ -807,6 +857,15 @@ class MessageHandler:
 
             # If completed or skipped, allow through
             if onboarding_status in ("completed", "skipped"):
+                # PR-2 (GH #198-linked): If portal onboarding completed
+                # before telegram_id was linked, fire the deferred handoff
+                # now so Nikita's scripted opening + pipeline bootstrap run
+                # before the user's first message is processed.
+                if (
+                    getattr(user, "pending_handoff", False)
+                    and user.telegram_id is not None
+                ):
+                    await self._execute_pending_handoff(user)
                 logger.debug(
                     f"[ONBOARDING-GATE] User {user_id} onboarding_status={onboarding_status} - allowing"
                 )

--- a/nikita/platforms/telegram/onboarding/handler.py
+++ b/nikita/platforms/telegram/onboarding/handler.py
@@ -1164,9 +1164,12 @@ Which one feels right? Reply with 1, 2, 3, or 4."""
     # === Validation Methods ===
 
     def _validate_location(self, text: str) -> bool:
-        """Validate location input.
+        """Validate location input via the shared onboarding validator.
 
-        AC-T2.1-005: Validates location input
+        AC-T2.1-005 + GH #198: Delegates to ``validate_city`` so portal and
+        Telegram onboarding share one set of rejection rules (control-char
+        stripping, junk-word blocklist, length bounds). Kept bool-returning
+        so existing call sites remain unchanged.
 
         Args:
             text: Location input text.
@@ -1174,11 +1177,11 @@ Which one feels right? Reply with 1, 2, 3, or 4."""
         Returns:
             True if valid city name, False otherwise.
         """
-        text = text.strip()
-        # Basic validation: at least 2 chars, not just numbers
-        if len(text) < 2:
-            return False
-        if text.isdigit():
+        from nikita.onboarding.validation import validate_city
+
+        try:
+            validate_city(text)
+        except ValueError:
             return False
         return True
 

--- a/supabase/migrations/20260413140000_add_pending_handoff_column.sql
+++ b/supabase/migrations/20260413140000_add_pending_handoff_column.sql
@@ -1,0 +1,11 @@
+-- Applied via Supabase MCP (2026-04-12). Schema captured in ../reference/00000000000001_baseline_schema.sql
+-- This stub satisfies Supabase CLI migration tracking. Do not add SQL here.
+--
+-- Effective change:
+--   ALTER TABLE public.users ADD COLUMN pending_handoff boolean NOT NULL DEFAULT false;
+--
+-- Used by PR-2 (GH #198 linked work) to defer portal-onboarding handoff until
+-- the user's first Telegram message when telegram_id is not yet linked at
+-- onboarding completion time. See nikita/api/routes/onboarding.py
+-- (_trigger_portal_handoff) and nikita/platforms/telegram/message_handler.py
+-- (_needs_onboarding → _execute_pending_handoff).

--- a/tests/api/routes/test_onboarding_profile.py
+++ b/tests/api/routes/test_onboarding_profile.py
@@ -515,3 +515,28 @@ class TestPortalProfilePendingHandoff:
         assert response.status_code == 200
         mock_user_repo.set_pending_handoff.assert_not_awaited()
         mock_handoff.execute_handoff.assert_awaited_once()
+
+    def test_profile_save_survives_pending_handoff_flag_failure(
+        self, client, mock_user_repo
+    ) -> None:
+        """If set_pending_handoff raises, the profile save must still return 200.
+
+        The inner try/except in ``_trigger_portal_handoff`` is the safety
+        net for a transient DB blip during the deferred-handoff bookkeeping.
+        Even if the flag never gets persisted, the profile must save and the
+        user must not see an HTTP error — they can always retry linking.
+        """
+        # telegram_id=None so we hit the deferred-handoff branch
+        mock_user_repo.set_pending_handoff.side_effect = RuntimeError("db blip")
+
+        response = client.post(
+            "/onboarding/profile",
+            json={
+                "location_city": "Zurich",
+                "social_scene": "techno",
+                "drug_tolerance": 3,
+            },
+        )
+        # Response is 200 even though the background task's flag-set failed
+        assert response.status_code == 200
+        mock_user_repo.set_pending_handoff.assert_awaited_with(USER_ID, True)

--- a/tests/api/routes/test_onboarding_profile.py
+++ b/tests/api/routes/test_onboarding_profile.py
@@ -365,3 +365,153 @@ class TestOnboardingGameActivation:
         })
         # Response should succeed even if handoff fails
         assert response.status_code == 200
+
+
+class TestPortalProfileCityValidation:
+    """PR-2 / GH #198: stricter city validation in PortalProfileRequest."""
+
+    @pytest.mark.parametrize(
+        "city",
+        ["", "   ", "hey", "HEY", "test", "12345", "x" * 101, "a"],
+    )
+    def test_invalid_city_raises_validation_error(self, city: str) -> None:
+        """Each flagged value must be rejected by Pydantic."""
+        from nikita.api.routes.onboarding import PortalProfileRequest
+
+        with pytest.raises(ValidationError):
+            PortalProfileRequest(
+                location_city=city,
+                social_scene="techno",
+                drug_tolerance=3,
+            )
+
+    def test_invalid_city_returns_422_via_api(self) -> None:
+        """POST with a blocklisted city returns HTTP 422."""
+        from nikita.api.dependencies.auth import get_current_user_id
+        from nikita.api.routes.onboarding import (
+            get_profile_repo,
+            get_user_repo,
+            get_vice_repo,
+            router,
+        )
+
+        app = FastAPI()
+        app.include_router(router, prefix="/onboarding")
+        app.dependency_overrides[get_current_user_id] = lambda: USER_ID
+        app.dependency_overrides[get_profile_repo] = lambda: AsyncMock()
+        app.dependency_overrides[get_user_repo] = lambda: AsyncMock()
+        app.dependency_overrides[get_vice_repo] = lambda: AsyncMock()
+        client = TestClient(app)
+
+        response = client.post(
+            "/onboarding/profile",
+            json={
+                "location_city": "hey",
+                "social_scene": "techno",
+                "drug_tolerance": 3,
+            },
+        )
+        assert response.status_code == 422
+
+    def test_valid_city_accepted(self) -> None:
+        """Legitimate city names still pass validation."""
+        from nikita.api.routes.onboarding import PortalProfileRequest
+
+        req = PortalProfileRequest(
+            location_city="São Paulo",
+            social_scene="techno",
+            drug_tolerance=3,
+        )
+        assert req.location_city == "São Paulo"
+
+
+class TestPortalProfilePendingHandoff:
+    """PR-2 / GH #198-linked: pending_handoff flag persistence."""
+
+    @pytest.fixture
+    def mock_profile_repo(self):
+        repo = AsyncMock()
+        repo.get_by_user_id.return_value = None
+        repo.create_profile.return_value = MagicMock(id=USER_ID)
+        return repo
+
+    @pytest.fixture
+    def mock_user_repo(self):
+        repo = AsyncMock()
+        repo.update_onboarding_status.return_value = None
+        repo.activate_game.return_value = None
+        repo.set_pending_handoff.return_value = None
+        # Default: user is in pre-onboarding state and has NO telegram_id
+        repo.get.return_value = MagicMock(
+            telegram_id=None,
+            phone=None,
+            onboarding_profile=None,
+            onboarding_status="pending",
+        )
+        return repo
+
+    @pytest.fixture
+    def mock_vice_repo(self):
+        repo = AsyncMock()
+        repo.discover.return_value = MagicMock()
+        return repo
+
+    @pytest.fixture
+    def client(self, mock_profile_repo, mock_user_repo, mock_vice_repo):
+        from nikita.api.dependencies.auth import get_current_user_id
+        from nikita.api.routes.onboarding import (
+            get_profile_repo,
+            get_user_repo,
+            get_vice_repo,
+            router,
+        )
+
+        app = FastAPI()
+        app.include_router(router, prefix="/onboarding")
+        app.dependency_overrides[get_current_user_id] = lambda: USER_ID
+        app.dependency_overrides[get_profile_repo] = lambda: mock_profile_repo
+        app.dependency_overrides[get_user_repo] = lambda: mock_user_repo
+        app.dependency_overrides[get_vice_repo] = lambda: mock_vice_repo
+        return TestClient(app)
+
+    def test_sets_pending_handoff_when_telegram_id_missing(
+        self, client, mock_user_repo
+    ) -> None:
+        """When user.telegram_id is None, the deferred-handoff flag is set True."""
+        response = client.post(
+            "/onboarding/profile",
+            json={
+                "location_city": "Zurich",
+                "social_scene": "techno",
+                "drug_tolerance": 3,
+            },
+        )
+        assert response.status_code == 200
+        mock_user_repo.set_pending_handoff.assert_awaited_with(USER_ID, True)
+
+    @patch("nikita.api.routes.onboarding.HandoffManager")
+    def test_does_not_set_pending_handoff_when_telegram_id_present(
+        self, mock_handoff_cls, client, mock_user_repo
+    ) -> None:
+        """When telegram_id exists, handoff fires immediately — no flag."""
+        mock_user_repo.get.return_value = MagicMock(
+            telegram_id=12345,
+            phone=None,
+            onboarding_profile=None,
+            onboarding_status="pending",
+        )
+        mock_handoff = AsyncMock()
+        mock_handoff.execute_handoff.return_value = MagicMock(success=True)
+        mock_handoff_cls.return_value = mock_handoff
+
+        response = client.post(
+            "/onboarding/profile",
+            json={
+                "location_city": "Zurich",
+                "social_scene": "techno",
+                "drug_tolerance": 3,
+            },
+        )
+        assert response.status_code == 200
+        mock_user_repo.set_pending_handoff.assert_not_awaited()
+        mock_handoff.execute_handoff.assert_awaited_once()

--- a/tests/db/repositories/test_user_repository.py
+++ b/tests/db/repositories/test_user_repository.py
@@ -502,3 +502,67 @@ class TestUserRepository:
         assert result[0].engagement_state.state == "drifting"
         assert result[1].engagement_state is not None
         assert result[1].engagement_state.state == "clingy"
+
+    # ========================================
+    # PR-2 / GH #198-linked: set_pending_handoff flag persistence
+    # ========================================
+    @pytest.mark.asyncio
+    async def test_set_pending_handoff_true_writes_and_flushes(
+        self, mock_session: AsyncMock
+    ):
+        """set_pending_handoff(True) flips flag on loaded user and flushes."""
+        from nikita.db.repositories.user_repository import UserRepository
+        from nikita.db.models.user import User, UserMetrics
+
+        user_id = uuid4()
+        user = User(id=user_id, telegram_id=12345)
+        user.metrics = UserMetrics(id=uuid4(), user_id=user_id)
+        user.pending_handoff = False
+
+        mock_result = MagicMock()
+        mock_result.unique.return_value.scalar_one_or_none.return_value = user
+        mock_session.execute.return_value = mock_result
+
+        repo = UserRepository(mock_session)
+        await repo.set_pending_handoff(user_id, True)
+
+        assert user.pending_handoff is True
+        mock_session.flush.assert_awaited()
+        mock_session.refresh.assert_awaited_with(user)
+
+    @pytest.mark.asyncio
+    async def test_set_pending_handoff_false_clears_flag(
+        self, mock_session: AsyncMock
+    ):
+        """set_pending_handoff(False) clears an already-set flag."""
+        from nikita.db.repositories.user_repository import UserRepository
+        from nikita.db.models.user import User, UserMetrics
+
+        user_id = uuid4()
+        user = User(id=user_id, telegram_id=12345)
+        user.metrics = UserMetrics(id=uuid4(), user_id=user_id)
+        user.pending_handoff = True
+
+        mock_result = MagicMock()
+        mock_result.unique.return_value.scalar_one_or_none.return_value = user
+        mock_session.execute.return_value = mock_result
+
+        repo = UserRepository(mock_session)
+        await repo.set_pending_handoff(user_id, False)
+
+        assert user.pending_handoff is False
+
+    @pytest.mark.asyncio
+    async def test_set_pending_handoff_raises_for_missing_user(
+        self, mock_session: AsyncMock
+    ):
+        """Missing user → ValueError (mirrors other repo methods)."""
+        from nikita.db.repositories.user_repository import UserRepository
+
+        mock_result = MagicMock()
+        mock_result.unique.return_value.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        repo = UserRepository(mock_session)
+        with pytest.raises(ValueError, match="not found"):
+            await repo.set_pending_handoff(uuid4(), True)

--- a/tests/onboarding/test_validation.py
+++ b/tests/onboarding/test_validation.py
@@ -24,6 +24,8 @@ class TestValidateCityAccepts:
             ("  Berlin  ", "Berlin"),  # trim whitespace
             ("New    York", "New York"),  # collapse 4 spaces to 1
             ("City  With  Spaces", "City  With  Spaces"),  # 2 spaces preserved
+            ("Zurich\u00a0", "Zurich"),  # NBSP at edge stripped
+            ("\u202fBerlin\u202f", "Berlin"),  # narrow no-break space stripped
         ],
     )
     def test_accepts_valid_cities(self, raw: str, expected: str) -> None:

--- a/tests/onboarding/test_validation.py
+++ b/tests/onboarding/test_validation.py
@@ -26,6 +26,9 @@ class TestValidateCityAccepts:
             ("City  With  Spaces", "City  With  Spaces"),  # 2 spaces preserved
             ("Zurich\u00a0", "Zurich"),  # NBSP at edge stripped
             ("\u202fBerlin\u202f", "Berlin"),  # narrow no-break space stripped
+            # Disambiguated form of the "bar" junk-word false-positive must
+            # pass — documented in nikita/onboarding/validation.py.
+            ("Bar, Montenegro", "Bar, Montenegro"),
         ],
     )
     def test_accepts_valid_cities(self, raw: str, expected: str) -> None:

--- a/tests/onboarding/test_validation.py
+++ b/tests/onboarding/test_validation.py
@@ -1,0 +1,80 @@
+"""Tests for nikita.onboarding.validation (PR-2 / GH #198).
+
+Covers:
+- Accept real city names (incl. unicode + multi-word)
+- Reject blank / whitespace-only / too-short / too-long / pure-numeric / junk words
+- Reject control characters and format/zero-width characters
+- Normalize runs of 3+ spaces to a single space
+"""
+
+import pytest
+
+from nikita.onboarding.validation import validate_city
+
+
+class TestValidateCityAccepts:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Zurich", "Zurich"),
+            ("New York", "New York"),
+            ("LA", "LA"),  # short but legit abbreviation
+            ("São Paulo", "São Paulo"),  # unicode letters
+            ("Saint-Étienne", "Saint-Étienne"),  # hyphen + accent
+            ("  Berlin  ", "Berlin"),  # trim whitespace
+            ("New    York", "New York"),  # collapse 4 spaces to 1
+            ("City  With  Spaces", "City  With  Spaces"),  # 2 spaces preserved
+        ],
+    )
+    def test_accepts_valid_cities(self, raw: str, expected: str) -> None:
+        assert validate_city(raw) == expected
+
+
+class TestValidateCityRejects:
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",  # empty
+            "   ",  # whitespace only
+            "a",  # too short after strip
+            "x" * 101,  # too long
+            "12345",  # pure numeric
+            "0",  # single digit
+        ],
+    )
+    def test_rejects_structural_violations(self, raw: str) -> None:
+        with pytest.raises(ValueError):
+            validate_city(raw)
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "hey",
+            "HEY",  # case-insensitive
+            "hi",
+            "test",
+            "asdf",
+            "foo",
+            "bar",
+            "none",
+            "na",
+            "n/a",
+            "xxx",
+        ],
+    )
+    def test_rejects_junk_words(self, raw: str) -> None:
+        with pytest.raises(ValueError, match="real city"):
+            validate_city(raw)
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "Zurich\x00",  # null byte
+            "Zurich\x1f",  # unit separator
+            "Zurich\u200b",  # zero-width space (format char)
+            "\x07Berlin",  # bell
+        ],
+    )
+    def test_rejects_control_characters(self, raw: str) -> None:
+        with pytest.raises(ValueError, match="invalid characters"):
+            validate_city(raw)

--- a/tests/platforms/telegram/test_message_handler.py
+++ b/tests/platforms/telegram/test_message_handler.py
@@ -1363,6 +1363,32 @@ class TestPendingHandoffRetry:
         assert result is False
         spy.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_needs_onboarding_fires_handoff_for_skipped_status(
+        self, handler, mock_user_repository, deferred_user
+    ):
+        """GATE: skipped users with pending_handoff=True also fire the retry.
+
+        The ``in ("completed", "skipped")`` branch in _needs_onboarding must
+        treat both terminal states identically — a user who skipped voice
+        onboarding (darkness=3 default) but completed portal profile without
+        telegram_id is still owed the scripted first message.
+        """
+        deferred_user.onboarding_status = "skipped"
+        mock_user_repository.get.return_value = deferred_user
+
+        with patch.object(
+            handler, "_execute_pending_handoff", new_callable=AsyncMock
+        ) as spy:
+            result = await handler._needs_onboarding(
+                user_id=deferred_user.id,
+                telegram_id=deferred_user.telegram_id,
+                chat_id=12345,
+            )
+
+        assert result is False
+        spy.assert_awaited_once_with(deferred_user)
+
 
 class TestOfferOnboardingChoiceSpec081:
     """Tests for _offer_onboarding_choice() — Spec 081 single-button pattern.

--- a/tests/platforms/telegram/test_message_handler.py
+++ b/tests/platforms/telegram/test_message_handler.py
@@ -1316,6 +1316,53 @@ class TestPendingHandoffRetry:
         kwargs = mock_manager.execute_handoff.call_args.kwargs
         assert kwargs["profile"].darkness_level == 3
 
+    @pytest.mark.asyncio
+    async def test_needs_onboarding_fires_deferred_handoff_on_completed_user(
+        self, handler, mock_user_repository, deferred_user
+    ):
+        """GATE: completed user + pending_handoff=True + telegram_id → handoff fires.
+
+        Guards the condition in ``_needs_onboarding`` that wires the
+        deferred-handoff retry into the message pipeline. A typo in the
+        ``pending_handoff and telegram_id is not None`` predicate would
+        silently skip the first-message opening — this test catches that.
+        """
+        mock_user_repository.get.return_value = deferred_user
+
+        # Patch the inner method so we can observe the gate without running
+        # HandoffManager end-to-end (covered by the other tests in this class).
+        with patch.object(
+            handler, "_execute_pending_handoff", new_callable=AsyncMock
+        ) as spy:
+            result = await handler._needs_onboarding(
+                user_id=deferred_user.id,
+                telegram_id=deferred_user.telegram_id,
+                chat_id=12345,
+            )
+
+        assert result is False  # Onboarding is completed — allow through
+        spy.assert_awaited_once_with(deferred_user)
+
+    @pytest.mark.asyncio
+    async def test_needs_onboarding_skips_handoff_when_flag_false(
+        self, handler, mock_user_repository, deferred_user
+    ):
+        """GATE: completed user but pending_handoff=False → no handoff called."""
+        deferred_user.pending_handoff = False
+        mock_user_repository.get.return_value = deferred_user
+
+        with patch.object(
+            handler, "_execute_pending_handoff", new_callable=AsyncMock
+        ) as spy:
+            result = await handler._needs_onboarding(
+                user_id=deferred_user.id,
+                telegram_id=deferred_user.telegram_id,
+                chat_id=12345,
+            )
+
+        assert result is False
+        spy.assert_not_awaited()
+
 
 class TestOfferOnboardingChoiceSpec081:
     """Tests for _offer_onboarding_choice() — Spec 081 single-button pattern.

--- a/tests/platforms/telegram/test_message_handler.py
+++ b/tests/platforms/telegram/test_message_handler.py
@@ -1210,6 +1210,113 @@ class TestProfileGate:
         mock_text_agent_handler.handle.assert_called_once()
 
 
+class TestPendingHandoffRetry:
+    """PR-2 / GH #198-linked: MessageHandler fires deferred handoff on first msg."""
+
+    @pytest.fixture
+    def mock_user_repository(self):
+        repo = AsyncMock()
+        repo.set_pending_handoff.return_value = None
+        return repo
+
+    @pytest.fixture
+    def handler(self, mock_user_repository):
+        from unittest.mock import AsyncMock
+        return MessageHandler(
+            user_repository=mock_user_repository,
+            conversation_repository=AsyncMock(),
+            text_agent_handler=AsyncMock(),
+            response_delivery=AsyncMock(),
+            bot=AsyncMock(),
+        )
+
+    @pytest.fixture
+    def deferred_user(self):
+        user = MagicMock(spec=User)
+        user.id = uuid4()
+        user.telegram_id = 987654321
+        user.pending_handoff = True
+        user.onboarding_status = "completed"
+        user.onboarding_profile = {"darkness_level": 4}
+        return user
+
+    @pytest.mark.asyncio
+    async def test_execute_pending_handoff_clears_flag_on_success(
+        self, handler, mock_user_repository, deferred_user
+    ):
+        """On success, HandoffManager runs + set_pending_handoff(False) is called."""
+        from nikita.onboarding.models import UserOnboardingProfile
+
+        mock_result = MagicMock(success=True, error=None)
+        with patch(
+            "nikita.onboarding.handoff.HandoffManager"
+        ) as mock_cls:
+            mock_manager = AsyncMock()
+            mock_manager.execute_handoff.return_value = mock_result
+            mock_cls.return_value = mock_manager
+
+            await handler._execute_pending_handoff(deferred_user)
+
+        mock_manager.execute_handoff.assert_awaited_once()
+        kwargs = mock_manager.execute_handoff.call_args.kwargs
+        assert kwargs["user_id"] == deferred_user.id
+        assert kwargs["telegram_id"] == deferred_user.telegram_id
+        assert isinstance(kwargs["profile"], UserOnboardingProfile)
+        assert kwargs["profile"].darkness_level == 4
+        mock_user_repository.set_pending_handoff.assert_awaited_once_with(
+            deferred_user.id, False
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_pending_handoff_preserves_flag_on_failure(
+        self, handler, mock_user_repository, deferred_user
+    ):
+        """If HandoffManager returns success=False, flag stays True (retry next msg)."""
+        mock_result = MagicMock(success=False, error="telegram down")
+        with patch("nikita.onboarding.handoff.HandoffManager") as mock_cls:
+            mock_manager = AsyncMock()
+            mock_manager.execute_handoff.return_value = mock_result
+            mock_cls.return_value = mock_manager
+
+            await handler._execute_pending_handoff(deferred_user)
+
+        mock_manager.execute_handoff.assert_awaited_once()
+        mock_user_repository.set_pending_handoff.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_execute_pending_handoff_swallows_exceptions(
+        self, handler, mock_user_repository, deferred_user
+    ):
+        """Exceptions during handoff are logged but do not propagate; flag stays set."""
+        with patch("nikita.onboarding.handoff.HandoffManager") as mock_cls:
+            mock_manager = AsyncMock()
+            mock_manager.execute_handoff.side_effect = RuntimeError("boom")
+            mock_cls.return_value = mock_manager
+
+            # Should not raise
+            await handler._execute_pending_handoff(deferred_user)
+
+        mock_user_repository.set_pending_handoff.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_execute_pending_handoff_defaults_darkness_level(
+        self, handler, deferred_user
+    ):
+        """Missing darkness_level in profile falls back to the chapter-1 default."""
+        deferred_user.onboarding_profile = None
+        with patch("nikita.onboarding.handoff.HandoffManager") as mock_cls:
+            mock_manager = AsyncMock()
+            mock_manager.execute_handoff.return_value = MagicMock(
+                success=True, error=None
+            )
+            mock_cls.return_value = mock_manager
+
+            await handler._execute_pending_handoff(deferred_user)
+
+        kwargs = mock_manager.execute_handoff.call_args.kwargs
+        assert kwargs["profile"].darkness_level == 3
+
+
 class TestOfferOnboardingChoiceSpec081:
     """Tests for _offer_onboarding_choice() — Spec 081 single-button pattern.
 


### PR DESCRIPTION
## Summary

Closes #198 — tightens city validation across both onboarding paths and fixes the silent-drop when portal onboarding completes before Telegram is linked.

### Fix 2A — City validation (#198)
E2E on 2026-03-30 accepted "hey" as ``location_city``. New shared ``nikita.onboarding.validation.validate_city`` now rejects:
- blank / whitespace-only / too-short (<2) / too-long (>100)
- pure-numeric inputs (``"12345"``, ``"0"``)
- strings containing Unicode Cc/Cf control chars (NUL, ``\x1f``, zero-width space, etc.) — including cases Python's default ``str.strip()`` would silently eat
- a small explicit blocklist: ``hey / hi / test / asdf / foo / bar / none / na / n/a / xxx``

Normalizes runs of 3+ spaces → 1. Used by both ``PortalProfileRequest`` (portal API) and ``OnboardingHandler._validate_location`` (Telegram fallback), keeping rejection rules consistent.

### Fix 2B — Handoff retry mechanism
Previously, ``_trigger_portal_handoff`` silently returned when ``user.telegram_id`` was None → first Nikita message, social circle generation, and pipeline bootstrap were permanently lost. Now:

1. ``users.pending_handoff BOOLEAN NOT NULL DEFAULT false`` added via Supabase MCP (migration stub at ``supabase/migrations/20260413140000_add_pending_handoff_column.sql``).
2. ``_trigger_portal_handoff`` sets ``pending_handoff=True`` instead of dropping.
3. ``MessageHandler._needs_onboarding`` fires ``_execute_pending_handoff`` on the user's first Telegram message once ``telegram_id`` is present. HandoffManager runs synchronously so Nikita's scripted opening arrives before the user's message is processed.
4. Flag clears only on ``HandoffResult.success=True`` — transient failures (Telegram outage, DB hiccup) naturally retry on the next message.
5. Concurrency-safe: ``handle()``'s ``get_by_telegram_id_for_update`` row-locks the user, preventing double-fire on rapid consecutive messages.

## Files changed

| File | Change |
|------|--------|
| ``nikita/onboarding/validation.py`` | NEW — ``validate_city`` shared utility |
| ``nikita/api/routes/onboarding.py`` | Validator wire-up + ``set_pending_handoff`` on missing telegram_id |
| ``nikita/platforms/telegram/onboarding/handler.py`` | ``_validate_location`` delegates to shared validator |
| ``nikita/db/models/user.py`` | ``pending_handoff`` column |
| ``nikita/db/repositories/user_repository.py`` | ``set_pending_handoff()`` method |
| ``nikita/platforms/telegram/message_handler.py`` | ``_execute_pending_handoff`` + hook in ``_needs_onboarding`` |
| ``supabase/migrations/...`` | Stub for the schema change |
| ``tests/onboarding/test_validation.py`` | 29 new cases (accept/reject/normalize) |
| ``tests/api/routes/test_onboarding_profile.py`` | 8 new cases (field + integration) |
| ``tests/db/repositories/test_user_repository.py`` | 3 repo cases |
| ``tests/platforms/telegram/test_message_handler.py`` | 4 handler cases |

**Total**: 620 insertions / 11 deletions across 11 files.

## Test plan

- [x] ``pytest tests/onboarding/test_validation.py`` — 29 pass
- [x] ``pytest tests/api/routes/test_onboarding_profile.py`` — 29 pass
- [x] ``pytest tests/db/repositories/test_user_repository.py`` — all pass
- [x] ``pytest tests/platforms/telegram/test_message_handler.py::TestPendingHandoffRetry`` — 4 pass
- [x] Broader suite ``pytest tests/platforms/telegram/ tests/onboarding/ tests/api/routes/ tests/db/repositories/`` — 1263 pass
- [ ] Full suite (running in background at PR-open time)
- [ ] Manual E2E: reset user, force telegram_id=NULL, complete portal → assert ``pending_handoff=true``; link Telegram, send message → Nikita opening arrives + flag clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)