### PR TITLE
fix(delivery): include chat_id in scheduled telegram events (#248)

### DIFF
--- a/.claude/plans/pr-review-ledger-fix-scheduled-delivery-chat-id-248.md
+++ b/.claude/plans/pr-review-ledger-fix-scheduled-delivery-chat-id-248.md
@@ -20,6 +20,10 @@
 | R4 | nikita/agents/text/handler.py | ~405-422 | Correctness | important→nitpick | DOWNGRADED | 1 | external |
 | R5 | nikita/api/routes/tasks.py | ~320 | Type safety | nitpick | SKIPPED | 1 | external |
 | R6 | tests/api/routes/test_tasks.py | ~610 | Testing | nitpick | SKIPPED | 1 | external |
+| R7 | tests/agents/text/test_handler.py | ~449 | Testing | important | FIXED | 2 | external |
+| R8 | tests/api/routes/test_tasks.py | ~637 | Testing | important → rejected | DOCUMENTED | 2 | external |
+| R9 | tests/agents/text/test_handler.py | ~421 | Testing | nitpick | SKIPPED | 2 | external |
+| R10 | nikita/api/routes/tasks.py | ~320 | Correctness | nitpick | SKIPPED | 2 | external |
 
 ## Fix Log
 
@@ -32,3 +36,8 @@
 - R3: replace `"telegram"` literal with `EventPlatform.TELEGRAM.value`.
 - R4: downgrade — handler's `logger.error(...)` already provides the visibility; skip_reason pattern matches existing skip paths at lines 373-379.
 - R5, R6: skip (nitpick below threshold).
+
+### Iteration 2 (external re-review — 2 important, 2 nitpick)
+- R7: FIXED — added `create_event.assert_awaited_once()` + kwarg assertions to `test_calls_repository_create_event_with_session`. Previously zero-assertion shell.
+- R8: REJECTED + DOCUMENTED — empirically the 3 `TestDeliverChatIdHandling` tests pass because the function-local `from ... import ScheduledEventRepository` re-resolves through `sys.modules` each call, so patching the source module is correct. If it weren't, the real repository would be constructed against the mock session and crash on `get_due_events`. Added a long clarifying docstring on `_run_deliver` to preempt future confusion and explicitly warn against the belt-and-suspenders double-patch.
+- R9, R10: skip (nitpick below threshold).

--- a/.claude/plans/pr-review-ledger-fix-scheduled-delivery-chat-id-248.md
+++ b/.claude/plans/pr-review-ledger-fix-scheduled-delivery-chat-id-248.md
@@ -1,0 +1,34 @@
+# Review Ledger — fix/scheduled-delivery-chat-id-248
+
+## Meta
+- PR: #252 — fix(delivery): include chat_id in scheduled telegram events (#248)
+- URL: https://github.com/yangsi7/nikita/pull/252
+- Scope: PR diff (4 files; +236 / -2)
+- Iteration: 0 / 5
+- Severity threshold: important
+- Mode: fix
+- Review type: external (fresh-context)
+- Full suite baseline: 5767 passed, 0 failed (vs 5763 on master)
+
+## Findings
+
+| ID | File | Line | Category | Severity | Status | Iter | Reviewer |
+|----|------|------|----------|----------|--------|------|----------|
+| R1 | tests/agents/text/test_handler.py | ~472 | Testing | important | FIX | 1 | external |
+| R2 | tests/agents/text/test_handler.py | — | Testing | important | FIX | 1 | external |
+| R3 | tests/api/routes/test_tasks.py | ~583 | Testing | important | FIX | 1 | external |
+| R4 | nikita/agents/text/handler.py | ~405-422 | Correctness | important→nitpick | DOWNGRADED | 1 | external |
+| R5 | nikita/api/routes/tasks.py | ~320 | Type safety | nitpick | SKIPPED | 1 | external |
+| R6 | tests/api/routes/test_tasks.py | ~610 | Testing | nitpick | SKIPPED | 1 | external |
+
+## Fix Log
+
+### Iteration 0 (initial self-review)
+- 0 blocking, 0 important at self-assessment. Proceeded directly to external re-review.
+
+### Iteration 1 (external re-review — 4 important, 2 nitpick)
+- R1: simplify double-patch to single source-module patch.
+- R2: add test covering `telegram_id=None` early-return path.
+- R3: replace `"telegram"` literal with `EventPlatform.TELEGRAM.value`.
+- R4: downgrade — handler's `logger.error(...)` already provides the visibility; skip_reason pattern matches existing skip paths at lines 373-379.
+- R5, R6: skip (nitpick below threshold).

--- a/nikita/agents/text/handler.py
+++ b/nikita/agents/text/handler.py
@@ -116,6 +116,7 @@ async def store_pending_response(
     response: str,
     scheduled_at: datetime,
     response_id: UUID,
+    chat_id: int,
     session: "AsyncSession | None" = None,
 ) -> None:
     """
@@ -131,6 +132,10 @@ async def store_pending_response(
         response: The response text to deliver
         scheduled_at: When to deliver the response
         response_id: Unique identifier for this response (used as idempotency key)
+        chat_id: Telegram chat id for delivery. Must match the schema
+            expected by the /tasks/deliver worker
+            (`nikita/api/routes/tasks.py`). GH #248 — missing chat_id
+            caused every scheduled response to fail silently.
         session: Optional async database session. Required for actual DB write.
     """
     if session is None:
@@ -148,6 +153,7 @@ async def store_pending_response(
         platform=EventPlatform.TELEGRAM,
         event_type=EventType.MESSAGE_DELIVERY,
         content={
+            "chat_id": chat_id,
             "text": response,
             "response_id": str(response_id),
         },
@@ -397,12 +403,30 @@ class MessageHandler:
         # Generate response ID for tracking
         response_id = uuid4()
 
-        # Store pending response for later delivery via scheduled_events table
+        # Store pending response for later delivery via scheduled_events table.
+        # deps.user.telegram_id must be set — handler is invoked from the
+        # Telegram webhook path. Guard explicitly against inconsistent data.
+        chat_id = deps.user.telegram_id
+        if chat_id is None:
+            logger.error(
+                "[HANDLER] user %s has no telegram_id; cannot schedule delivery",
+                user_id,
+            )
+            return ResponseDecision(
+                response=response_text,
+                delay_seconds=delay_seconds,
+                scheduled_at=scheduled_at,
+                response_id=response_id,
+                should_respond=False,
+                skip_reason="missing_telegram_id",
+            )
+
         await store_pending_response(
             user_id=user_id,
             response=response_text,
             scheduled_at=scheduled_at,
             response_id=response_id,
+            chat_id=chat_id,
             session=session,
         )
 

--- a/nikita/api/routes/tasks.py
+++ b/nikita/api/routes/tasks.py
@@ -311,10 +311,33 @@ async def deliver_pending_messages(
                         chat_id = event.content.get("chat_id")
                         text = event.content.get("text")
 
+                        # GH #248 defense-in-depth: legacy rows and any
+                        # future producer bug that omits chat_id fall back
+                        # to the owning user's telegram_id (auto-loaded via
+                        # ScheduledEvent.user selectin relationship). The
+                        # WARNING log makes producer regressions observable
+                        # without breaking delivery.
+                        if not chat_id:
+                            fallback = (
+                                event.user.telegram_id
+                                if getattr(event, "user", None)
+                                else None
+                            )
+                            if fallback:
+                                logger.warning(
+                                    "[DELIVER] scheduled_event %s missing chat_id "
+                                    "in content; fell back to user.telegram_id",
+                                    event.id,
+                                )
+                                chat_id = fallback
+
                         if not chat_id or not text:
                             await event_repo.mark_failed(
                                 event.id,
-                                error_message="Missing chat_id or text in content",
+                                error_message=(
+                                    "Missing chat_id (or user.telegram_id) "
+                                    "and/or text in content"
+                                ),
                                 increment_retry=False,
                             )
                             failed += 1

--- a/tests/agents/text/test_handler.py
+++ b/tests/agents/text/test_handler.py
@@ -474,6 +474,13 @@ class TestStorePendingResponse:
                 session=mock_session,
             )
 
+        # Previously this test had zero assertions — removing store_pending_response
+        # internals would have passed silently. Pin the actual contract.
+        mock_repo.create_event.assert_awaited_once()
+        call_kwargs = mock_repo.create_event.call_args.kwargs
+        assert call_kwargs["user_id"] == user_id
+        assert call_kwargs["scheduled_at"] == now
+
     @pytest.mark.asyncio
     async def test_stores_response_text_and_response_id_in_content(self):
         """Content payload must include 'text' and 'response_id'."""

--- a/tests/agents/text/test_handler.py
+++ b/tests/agents/text/test_handler.py
@@ -367,6 +367,61 @@ class TestPendingResponseStorage:
         assert hasattr(decision, "response_id")
         assert decision.response_id == response_id
 
+    @pytest.mark.asyncio
+    async def test_handle_returns_non_responsive_when_user_has_no_telegram_id(
+        self, caplog
+    ):
+        """GH #248 guard: handler must not schedule delivery when telegram_id is None.
+
+        The scheduled_events row would be undeliverable (no chat_id to resolve),
+        so the handler short-circuits with should_respond=False and a clear
+        skip_reason. An ERROR-level log preserves operator visibility.
+        """
+        import logging
+        from nikita.agents.text.handler import MessageHandler
+        from nikita.agents.text.timing import ResponseTimer
+        from nikita.agents.text.skip import SkipDecision
+
+        user_id = uuid4()
+
+        mock_user = MagicMock()
+        mock_user.id = user_id
+        mock_user.chapter = 2
+        mock_user.game_status = "active"
+        mock_user.telegram_id = None  # ← the condition under test
+
+        mock_deps = MagicMock()
+        mock_deps.user = mock_user
+
+        mock_timer = MagicMock(spec=ResponseTimer)
+        mock_timer.calculate_delay.return_value = 60
+
+        mock_skip = MagicMock(spec=SkipDecision)
+        mock_skip.should_skip.return_value = False
+
+        mock_store = AsyncMock()
+
+        with patch(
+            "nikita.agents.text.handler.get_nikita_agent_for_user",
+            new=AsyncMock(return_value=(MagicMock(), mock_deps)),
+        ), patch(
+            "nikita.agents.text.handler.generate_response",
+            new=AsyncMock(return_value="a response"),
+        ), patch(
+            "nikita.agents.text.handler.store_pending_response",
+            new=mock_store,
+        ), caplog.at_level(logging.ERROR, logger="nikita.agents.text.handler"):
+
+            handler = MessageHandler(timer=mock_timer, skip_decision=mock_skip)
+            decision = await handler.handle(user_id, "hey")
+
+        assert decision.should_respond is False
+        assert decision.skip_reason == "missing_telegram_id"
+        mock_store.assert_not_awaited()
+        assert any(
+            "no telegram_id" in rec.message.lower() for rec in caplog.records
+        ), "missing telegram_id must emit an ERROR log for operator visibility"
+
 
 class TestStorePendingResponse:
     """Tests for the store_pending_response function (G7 fix)."""
@@ -404,24 +459,20 @@ class TestStorePendingResponse:
         mock_repo = MagicMock()
         mock_repo.create_event = AsyncMock(return_value=MagicMock())
 
+        # Patch the source module — the function-local import in
+        # ``store_pending_response`` resolves via sys.modules at call time.
         with patch(
             "nikita.db.repositories.scheduled_event_repository.ScheduledEventRepository",
             return_value=mock_repo,
         ):
-            # Patch at the import site inside the function
-            with patch(
-                "nikita.agents.text.handler.ScheduledEventRepository",
-                return_value=mock_repo,
-                create=True,
-            ):
-                await store_pending_response(
-                    user_id=user_id,
-                    response="Hey there",
-                    scheduled_at=now,
-                    response_id=response_id,
-                    chat_id=12345,
-                    session=mock_session,
-                )
+            await store_pending_response(
+                user_id=user_id,
+                response="Hey there",
+                scheduled_at=now,
+                response_id=response_id,
+                chat_id=12345,
+                session=mock_session,
+            )
 
     @pytest.mark.asyncio
     async def test_stores_response_text_and_response_id_in_content(self):
@@ -445,13 +496,13 @@ class TestStorePendingResponse:
 
         # Patch ScheduledEventRepository at the module where it is defined so
         # the local import inside store_pending_response picks up the mock.
+        # Patch at the source module: the function-local
+        # ``from nikita.db.repositories.scheduled_event_repository import
+        # ScheduledEventRepository`` statement resolves through sys.modules
+        # at call time, so patching the source is both sufficient and honest.
         with patch(
             "nikita.db.repositories.scheduled_event_repository.ScheduledEventRepository",
             return_value=mock_repo_instance,
-        ), patch(
-            "nikita.agents.text.handler.ScheduledEventRepository",
-            return_value=mock_repo_instance,
-            create=True,
         ):
             await store_pending_response(
                 user_id=user_id,
@@ -494,13 +545,13 @@ class TestStorePendingResponse:
         mock_repo_instance = MagicMock()
         mock_repo_instance.create_event = fake_create_event
 
+        # Patch at the source module: the function-local
+        # ``from nikita.db.repositories.scheduled_event_repository import
+        # ScheduledEventRepository`` statement resolves through sys.modules
+        # at call time, so patching the source is both sufficient and honest.
         with patch(
             "nikita.db.repositories.scheduled_event_repository.ScheduledEventRepository",
             return_value=mock_repo_instance,
-        ), patch(
-            "nikita.agents.text.handler.ScheduledEventRepository",
-            return_value=mock_repo_instance,
-            create=True,
         ):
             await store_pending_response(
                 user_id=user_id,

--- a/tests/agents/text/test_handler.py
+++ b/tests/agents/text/test_handler.py
@@ -464,3 +464,55 @@ class TestStorePendingResponse:
         content = created_events[0]["content"]
         assert content["text"] == "Test message"
         assert content["response_id"] == str(response_id)
+
+    @pytest.mark.asyncio
+    async def test_stores_chat_id_in_content(self):
+        """Content payload must include 'chat_id' — delivery worker requires it (GH #248).
+
+        Regression guard: previously `store_pending_response` wrote only
+        `{text, response_id}` and the delivery worker in
+        `nikita/api/routes/tasks.py` failed every event with
+        ``Missing chat_id or text in content``.
+        """
+        from nikita.agents.text.handler import store_pending_response
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        user_id = uuid4()
+        response_id = uuid4()
+        now = datetime.now(timezone.utc)
+        mock_session = MagicMock()
+
+        created_events = []
+
+        async def fake_create_event(**kwargs):
+            created_events.append(kwargs)
+            return MagicMock()
+
+        mock_repo_instance = MagicMock()
+        mock_repo_instance.create_event = fake_create_event
+
+        with patch(
+            "nikita.db.repositories.scheduled_event_repository.ScheduledEventRepository",
+            return_value=mock_repo_instance,
+        ), patch(
+            "nikita.agents.text.handler.ScheduledEventRepository",
+            return_value=mock_repo_instance,
+            create=True,
+        ):
+            await store_pending_response(
+                user_id=user_id,
+                response="Test message",
+                scheduled_at=now,
+                response_id=response_id,
+                chat_id=12345,
+                session=mock_session,
+            )
+
+        assert len(created_events) == 1
+        content = created_events[0]["content"]
+        assert content["chat_id"] == 12345, (
+            "chat_id must be written to scheduled_events.content so the "
+            "delivery worker can send the Telegram message"
+        )
+        assert content["text"] == "Test message"
+        assert content["response_id"] == str(response_id)

--- a/tests/agents/text/test_handler.py
+++ b/tests/agents/text/test_handler.py
@@ -386,6 +386,7 @@ class TestStorePendingResponse:
             response="Hello",
             scheduled_at=now,
             response_id=response_id,
+            chat_id=12345,
             session=None,
         )
 
@@ -418,6 +419,7 @@ class TestStorePendingResponse:
                     response="Hey there",
                     scheduled_at=now,
                     response_id=response_id,
+                    chat_id=12345,
                     session=mock_session,
                 )
 
@@ -456,6 +458,7 @@ class TestStorePendingResponse:
                 response="Test message",
                 scheduled_at=now,
                 response_id=response_id,
+                chat_id=12345,
                 session=mock_session,
             )
 

--- a/tests/api/routes/test_tasks.py
+++ b/tests/api/routes/test_tasks.py
@@ -560,3 +560,135 @@ class TestCleanupEndpoint:
                     assert response.status_code == 500  # Unhandled exception before try block
                     # Note: The route calls get_session_maker() BEFORE the try/except,
                     # so DB errors at connection time result in 500, not graceful error
+
+
+class TestDeliverChatIdHandling:
+    """GH #248: the deliver worker must send Telegram messages even when
+    ``content.chat_id`` is absent, by falling back to ``event.user.telegram_id``.
+
+    These tests intentionally exercise the content-parsing branch that
+    prior ``test_deliver_endpoint_exists`` skipped by mocking
+    ``get_due_events`` to ``[]``. That gap is how #248 escaped review.
+    """
+
+    @pytest.fixture
+    def app(self):
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1/tasks")
+        return app
+
+    @staticmethod
+    def _make_event(event_id, user_telegram_id, content):
+        """Build a mock ScheduledEvent with an auto-loaded ``user``."""
+        event = MagicMock()
+        event.id = event_id
+        event.platform = "telegram"  # EventPlatform.TELEGRAM.value
+        event.user_id = f"user-{event_id}"
+        event.content = content
+        event.user = MagicMock()
+        event.user.telegram_id = user_telegram_id
+        return event
+
+    def _run_deliver(self, app, due_events):
+        """Boot a TestClient with all repositories/bot patched for a single /deliver call.
+
+        Returns ``(bot_send_mock, mark_delivered_mock, mark_failed_mock, response)``.
+        """
+        bot_send_mock = AsyncMock()
+        mark_delivered_mock = AsyncMock()
+        mark_failed_mock = AsyncMock()
+
+        with TestClient(app, raise_server_exceptions=False) as client, \
+                patch("nikita.api.routes.tasks._get_task_secret", return_value=None), \
+                patch("nikita.api.routes.tasks.get_session_maker") as mock_session_maker:
+
+            mock_session = AsyncMock()
+            mock_session.commit = AsyncMock()
+            async_cm = AsyncMock()
+            async_cm.__aenter__.return_value = mock_session
+            async_cm.__aexit__.return_value = None
+            mock_session_maker.return_value = MagicMock(return_value=async_cm)
+
+            mock_job_repo = MagicMock()
+            mock_execution = MagicMock()
+            mock_execution.id = "test-execution-id"
+            mock_job_repo.start_execution = AsyncMock(return_value=mock_execution)
+            mock_job_repo.complete_execution = AsyncMock()
+
+            mock_event_repo = MagicMock()
+            mock_event_repo.get_due_events = AsyncMock(return_value=due_events)
+            mock_event_repo.mark_delivered = mark_delivered_mock
+            mock_event_repo.mark_failed = mark_failed_mock
+
+            mock_bot = MagicMock()
+            mock_bot.send_message = bot_send_mock
+            mock_bot.close = AsyncMock()
+
+            with patch(
+                "nikita.api.routes.tasks.JobExecutionRepository",
+                return_value=mock_job_repo,
+            ), patch(
+                "nikita.db.repositories.scheduled_event_repository.ScheduledEventRepository",
+                return_value=mock_event_repo,
+            ), patch(
+                "nikita.platforms.telegram.bot.TelegramBot",
+                return_value=mock_bot,
+            ):
+                response = client.post("/api/v1/tasks/deliver")
+
+        return bot_send_mock, mark_delivered_mock, mark_failed_mock, response
+
+    def test_deliver_telegram_event_with_chat_id_in_content_succeeds(self, app):
+        """Happy path: content.chat_id is present — worker uses it (not the fallback)."""
+        event = self._make_event(
+            event_id="evt-1",
+            user_telegram_id=999,  # intentionally different to prove content wins
+            content={"chat_id": 111, "text": "hello"},
+        )
+        bot_send, mark_delivered, mark_failed, response = self._run_deliver(app, [event])
+
+        assert response.status_code == 200
+        bot_send.assert_awaited_once_with(chat_id=111, text="hello")
+        mark_delivered.assert_awaited_once_with("evt-1")
+        mark_failed.assert_not_awaited()
+
+    def test_deliver_telegram_event_without_chat_id_falls_back_to_user_telegram_id(
+        self, app, caplog
+    ):
+        """GH #248 regression guard: legacy rows lacking chat_id use user.telegram_id."""
+        event = self._make_event(
+            event_id="evt-2",
+            user_telegram_id=222,
+            content={"text": "hello"},  # no chat_id
+        )
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="nikita.api.routes.tasks"):
+            bot_send, mark_delivered, mark_failed, response = self._run_deliver(
+                app, [event]
+            )
+
+        assert response.status_code == 200
+        bot_send.assert_awaited_once_with(chat_id=222, text="hello")
+        mark_delivered.assert_awaited_once_with("evt-2")
+        mark_failed.assert_not_awaited()
+        assert any(
+            "missing chat_id" in rec.message.lower() for rec in caplog.records
+        ), "fallback path must emit a warning for observability"
+
+    def test_deliver_telegram_event_fails_when_no_chat_id_and_no_telegram_id(self, app):
+        """Edge case: no chat_id in content AND user.telegram_id is None → mark_failed, no send."""
+        event = self._make_event(
+            event_id="evt-3",
+            user_telegram_id=None,
+            content={"text": "hello"},
+        )
+        bot_send, mark_delivered, mark_failed, response = self._run_deliver(app, [event])
+
+        assert response.status_code == 200
+        bot_send.assert_not_awaited()
+        mark_delivered.assert_not_awaited()
+        mark_failed.assert_awaited_once()
+        call_kwargs = mark_failed.call_args.kwargs
+        assert call_kwargs.get("increment_retry") is False

--- a/tests/api/routes/test_tasks.py
+++ b/tests/api/routes/test_tasks.py
@@ -599,6 +599,22 @@ class TestDeliverChatIdHandling:
         """Boot a TestClient with all repositories/bot patched for a single /deliver call.
 
         Returns ``(bot_send_mock, mark_delivered_mock, mark_failed_mock, response)``.
+
+        Patch targets: the ``/deliver`` route (``nikita/api/routes/tasks.py``)
+        uses function-local imports
+        (``from nikita.db.repositories.scheduled_event_repository import
+        ScheduledEventRepository``) inside the request handler body. A
+        function-local ``from X import Y`` re-resolves ``Y`` via
+        ``sys.modules[X].Y`` on every invocation, so patching the SOURCE
+        module's attribute is the correct target and is intercepted at
+        call time. Empirically: if this patch did not intercept, the
+        real repository would be constructed with the mock AsyncSession
+        and crash on ``get_due_events`` — the tests pass because the
+        mock IS what gets constructed. The same pattern is used for
+        ``TelegramBot`` below. Do NOT add a second patch on
+        ``nikita.api.routes.tasks.ScheduledEventRepository`` with
+        ``create=True`` — that would silently mask a refactor to a
+        top-level import rather than surface it.
         """
         bot_send_mock = AsyncMock()
         mark_delivered_mock = AsyncMock()

--- a/tests/api/routes/test_tasks.py
+++ b/tests/api/routes/test_tasks.py
@@ -579,10 +579,16 @@ class TestDeliverChatIdHandling:
 
     @staticmethod
     def _make_event(event_id, user_telegram_id, content):
-        """Build a mock ScheduledEvent with an auto-loaded ``user``."""
+        """Build a mock ScheduledEvent with an auto-loaded ``user``.
+
+        Uses ``EventPlatform.TELEGRAM.value`` (not a literal) so the test
+        self-heals if the enum value is ever renamed.
+        """
+        from nikita.db.models.scheduled_event import EventPlatform
+
         event = MagicMock()
         event.id = event_id
-        event.platform = "telegram"  # EventPlatform.TELEGRAM.value
+        event.platform = EventPlatform.TELEGRAM.value
         event.user_id = f"user-{event_id}"
         event.content = content
         event.user = MagicMock()


### PR DESCRIPTION
## Summary

Closes #248. **Severity: CRITICAL** — every delayed text gameplay response was failing silently.

## Root cause

`store_pending_response()` at `nikita/agents/text/handler.py:150` wrote `scheduled_events.content` as `{"text": ..., "response_id": ...}`. The delivery worker at `nikita/api/routes/tasks.py:311` reads `content.get("chat_id")`. Missing key → every event terminally `mark_failed` with `increment_retry=False`. No text responses ever reached users through the scheduled path.

## Fix (defense-in-depth)

1. **Producer** (`handler.py`) — `store_pending_response` now takes a required `chat_id: int` and writes it into the JSONB content alongside `text` + `response_id`. The single caller (`MessageHandler.handle` at `handler.py:424`) passes `deps.user.telegram_id`; if that's somehow `None` (should be impossible on the Telegram webhook path), logs an error and returns a non-responsive decision rather than scheduling an undeliverable event.
2. **Consumer** (`tasks.py`) — if `content.chat_id` is absent (legacy rows; any future producer bug), resolve via `event.user.telegram_id`. The relationship is already auto-loaded via `lazy="selectin"` on `ScheduledEvent.user`, so no extra query. Fallback path emits a `WARNING` log so producer regressions stay observable in Cloud Run logs rather than being silently rescued. If neither is available, still `mark_failed(increment_retry=False)` with a clearer error message.

Total: ~15 production LOC.

## Tests (4 new — TDD-first)

Prior `test_tasks.py` mocked `get_due_events → []` in every test, so the content-parsing branch was unreached (this is how #248 escaped review). New tests exercise it:

- `test_stores_chat_id_in_content` (handler unit) — `content["chat_id"]` is written.
- `test_deliver_telegram_event_with_chat_id_in_content_succeeds` (tasks integration) — happy path; content wins over fallback.
- `test_deliver_telegram_event_without_chat_id_falls_back_to_user_telegram_id` (tasks integration) — legacy-row path; WARNING log asserted.
- `test_deliver_telegram_event_fails_when_no_chat_id_and_no_telegram_id` (tasks integration) — edge: `mark_failed` with `increment_retry=False`, no send.

## Test results

```
5767 passed, 138 deselected (2m43s)
```

Baseline was 5763; +4 new tests; 0 regressions.

## Plan + follow-up

Full planning brief at `.claude/plans/quirky-floating-liskov.md`. The plan also spawns a follow-up spec (test-quality audit) for the systemic "tests that don't test" pattern uncovered by this bug — see the plan's Self-Improvement Loop section.

## Test plan
- [x] Targeted pytest (new tests + existing test_tasks) — 33 passed
- [x] Full suite — 5767 passed, 0 failures
- [ ] Post-merge deploy to Cloud Run
- [ ] Manual E2E: reset test user, send Telegram message, verify Nikita's reply lands + `scheduled_events` row has `status='delivered'` and `content->>'chat_id'` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)