### PR TITLE
fix(api,telegram): SUPABASE_URL guard + extract portal bridge utility (#184, #233)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,39 @@
+---
+globs: ["tests/**"]
+---
+
+# Testing Patterns
+
+## Async Mocks
+- All DB operations use `AsyncMock` — see `tests/conftest.py` for standard fixtures
+- E2E tests use separate `tests/e2e/conftest.py` (ASGI transport, webhook simulator, no-op cleanup)
+- Mock `session.execute()` returning `AsyncMock(scalars=Mock(return_value=Mock(first=...)))` for queries
+
+## Conftest Hierarchy
+- `tests/conftest.py`: Root fixtures (mock_session, mock_settings, sample_user, sample_metrics)
+- `tests/e2e/conftest.py`: E2E-specific (async_client, webhook_simulator, cleanup no-ops)
+- Module-level conftest.py files: Domain fixtures (mock_memory, mock_agent, etc.)
+
+## Singleton Cache-Clearing
+- `get_settings()` is a cached singleton — call `get_settings.cache_clear()` in fixture teardown
+- If tests bleed state, check for unflushed LRU caches on singletons
+
+## Voice Test Patterns
+- Voice tests wrap `asyncio.wait_for` timeouts — unwrap by mocking `asyncio.wait_for` to call coroutine directly
+- Mock `ready_prompt` fixture for server tool tests to avoid PromptBuilderStage dependency
+- ElevenLabs conversation mocks: `AsyncMock(spec=Conversation)` with `wait_for_session_end`
+
+## Marker Exclusions
+- `@pytest.mark.integration`: Skipped in CI (requires live services)
+- `@pytest.mark.slow`: Skipped by default, run with `--slow`
+- `@pytest.mark.e2e`: Full E2E tests, separate from unit suite
+
+## "Tests That Don't Test" — Anti-Pattern (PR #252)
+When a production function iterates over a repository query result, mocking the query to return `[]` means the loop body is NEVER exercised. Coverage metrics pass while the risky branch is 0% covered. GH #248 (silent scheduled-delivery failure) hid in this gap for months despite 11 passing tests in `test_tasks.py`.
+
+**Rules**:
+- **Non-empty fixture required**: Any test covering a worker / consumer / iterator that consumes `repo.get_*()` / `find_*()` / `list_*()` must have at least ONE sibling test providing a non-empty fixture list. Mocking to `[]` tests dispatch only, not behavior.
+- **No zero-assertion shells**: Every `async def test_*` must assert. If mocking a repo call, pair with `mock_repo.method.assert_awaited_once()` + kwarg assertions on the content/shape passed. A test body with zero `assert` / `assert_*` / `pytest.raises` is a LIE — delete or flesh it out.
+- **Patch source module, not importer**: For function-local `from X import Y` imports, patch `X.Y` (source). Function-local imports resolve through `sys.modules` each call; patching the source is sufficient and correct. Double-patching the importer is belt-and-suspenders and obscures intent.
+
+**Example fix** (PR #252 iter 2, `tests/agents/text/test_handler.py::test_calls_repository_create_event_with_session`): previously zero-assertion shell → added `mock_repo.create_event.assert_awaited_once()` + kwarg checks on `content["chat_id"]`, `content["text"]`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -208,8 +208,9 @@ E2E testing, integration wiring, text continuity.
 | 048 | e2e-full-lifecycle | — | 16 phases, 4 bugs fixed |
 | 103 | touchpoint-intelligence | — | Life events, dedup |
 | 112 | portal-e2e-hardening | 125 | Content assertions, auth bypass, data-testid, CI (GH #101, #103) |
+| 210 | test-quality-audit | — | **PLANNED** — Audit 5768 tests for empty-mock + zero-assertion anti-patterns (triggered by PR #252 / GH #248) |
 
-**Domain subtotal: 5 specs, 236 tests**
+**Domain subtotal: 5 specs, 236 tests (210 PLANNED)**
 
 ---
 

--- a/event-stream.md
+++ b/event-stream.md
@@ -1,5 +1,7 @@
 # Event Stream
 <!-- Max 100 lines, prune oldest when exceeded -->
+[2026-04-13T10:00:00Z] ROADMAP: Registered Spec 210 — test-quality-audit (PLANNED, Domain 8). Triggered by PR #252 (GH #248) "tests that don't test" anti-pattern. Also updated .claude/rules/testing.md (+10 lines, 39 total ≤80) and saved project_scheduled_events_delivery.md memory (schema + chat_id≡telegram_id + patch-target convention + PR #252 history).
+[2026-04-12T23:30:00Z] MERGE: PR #252 squash-merged as dd214bb — fix(delivery): include chat_id in scheduled telegram events (#248). 3-iter qa-review convergence (10 findings: 7 fixed, 2 rejected-empirically, 3 skipped). 5 new tests. Closes #248.
 [2026-04-03T22:07:00Z] DEPLOY: Spec 208 landing page → Vercel production (portal-prr4dulry-5meo-inc.vercel.app). PR #209 squash-merged. 58 files, +4,624 lines. 12 components, 276 tests. QA: 2 issues fixed (nav a11y + eslint), 0 blocking. ROADMAP: 208→COMPLETE.
 [2026-03-23T10:30:00Z] DEPLOY: Backend → Cloud Run rev nikita-api-00235-lh8 (us-central1). Health: all services healthy. New endpoint: POST /onboarding/profile. Portal: Vercel auto-deployed from master.
 [2026-03-23T10:00:00Z] MERGE: PR #158 squash-merged as 975a624 — feat(portal): cinematic onboarding experience (Spec 081). 47 files, +7,790 lines. QA: 2 iterations (19→0 issues), 11 Playwright E2E added (96 total), devil's advocate (2 quick fixes + 3 GH issues #159-#161). CI green. ROADMAP: 081→COMPLETE. Vercel auto-deploying.

--- a/nikita/api/main.py
+++ b/nikita/api/main.py
@@ -84,6 +84,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             "Set the TASK_AUTH_SECRET environment variable."
         )
 
+    # GH #184: SUPABASE_URL is required — fail fast at deploy time.
+    # The silent try/except below at Supabase client init was masking missing
+    # config as "supabase: disconnected", allowing broken revisions to go
+    # healthy. Kill the process instead so the revision is caught in CI / deploy.
+    if not settings.supabase_url:
+        raise RuntimeError(
+            "supabase_url must be set. "
+            "Set the SUPABASE_URL environment variable."
+        )
+
     # 1. Validate database connection
     engine = get_async_engine()
     app.state.db_engine = engine

--- a/nikita/platforms/telegram/commands.py
+++ b/nikita/platforms/telegram/commands.py
@@ -17,7 +17,6 @@ from nikita.db.repositories.profile_repository import (
 from nikita.db.repositories.user_repository import UserRepository
 from nikita.platforms.telegram.auth import TelegramAuth
 from nikita.platforms.telegram.bot import TelegramBot
-from nikita.platforms.telegram.otp_handler import OTPVerificationHandler
 
 logger = logging.getLogger(__name__)
 

--- a/nikita/platforms/telegram/commands.py
+++ b/nikita/platforms/telegram/commands.py
@@ -269,16 +269,13 @@ class CommandHandler:
         # Pending or in_progress — generate a fresh portal magic link
         if user.onboarding_status in ("pending", "in_progress"):
             from nikita.config.settings import get_settings
+            from nikita.platforms.telegram.utils import generate_portal_bridge_url
 
             settings = get_settings()
             portal_url = settings.portal_url or "https://portal-phi-orcin.vercel.app"
 
-            # Use OTPVerificationHandler's bridge URL generator (GH #187)
-            otp_handler = OTPVerificationHandler(
-                telegram_auth=self.telegram_auth,
-                bot=self.bot,
-            )
-            magic_link = await otp_handler._generate_portal_bridge_url(
+            # Zero-click portal auth via bridge token (GH #187 / GH #233)
+            magic_link = await generate_portal_bridge_url(
                 user_id=str(user.id),
                 redirect_path="/onboarding",
             )

--- a/nikita/platforms/telegram/message_handler.py
+++ b/nikita/platforms/telegram/message_handler.py
@@ -948,48 +948,6 @@ class MessageHandler:
         logger.debug(f"[ONBOARDING-GATE] User {user_id} has complete profile")
         return False
 
-    async def _generate_portal_bridge_url(
-        self,
-        user_id: str,
-        redirect_path: str = "/onboarding",
-    ) -> str | None:
-        """Generate a time-limited bridge token URL for zero-click portal auth.
-
-        Args:
-            user_id: User's UUID string.
-            redirect_path: Portal path to redirect after auth.
-
-        Returns:
-            Bridge URL string, or None on failure.
-        """
-        try:
-            from nikita.db.database import get_session_maker
-            from nikita.db.repositories.auth_bridge_repository import (
-                AuthBridgeRepository,
-            )
-
-            settings = get_settings()
-            portal_url = settings.portal_url or "https://portal-phi-orcin.vercel.app"
-
-            session_maker = get_session_maker()
-            async with session_maker() as session:
-                repo = AuthBridgeRepository(session)
-                bridge = await repo.create_token(UUID(user_id), redirect_path)
-                await session.commit()
-
-            url = f"{portal_url}/auth/bridge?token={bridge.token}"
-            logger.info(
-                f"Generated bridge URL for user_id={user_id}, "
-                f"redirect_path={redirect_path}"
-            )
-            return url
-
-        except Exception as e:
-            logger.warning(
-                f"Failed to generate bridge URL for user_id={user_id}: {e}"
-            )
-            return None
-
     async def _offer_onboarding_choice(
         self,
         user_id: UUID,
@@ -1009,8 +967,11 @@ class MessageHandler:
         settings = get_settings()
         portal_url = settings.portal_url or "https://portal-phi-orcin.vercel.app"
 
-        # Generate bridge URL for zero-click portal auth (GH #187)
-        magic_link = await self._generate_portal_bridge_url(
+        # Generate bridge URL for zero-click portal auth (GH #187 / GH #233).
+        # Function-local import — patch source at utils module, per testing rule.
+        from nikita.platforms.telegram.utils import generate_portal_bridge_url
+
+        magic_link = await generate_portal_bridge_url(
             user_id=str(user_id),
             redirect_path="/onboarding",
         )

--- a/nikita/platforms/telegram/otp_handler.py
+++ b/nikita/platforms/telegram/otp_handler.py
@@ -323,58 +323,6 @@ class OTPVerificationHandler:
 
             return False
 
-    async def _generate_portal_bridge_url(
-        self,
-        user_id: str,
-        redirect_path: str = "/onboarding",
-    ) -> str | None:
-        """Generate a portal bridge URL for zero-click auth.
-
-        GH #187: Replaces _generate_portal_magic_link() which failed due to
-        PKCE mismatch (server-side generate_link → client-side exchangeCodeForSession
-        requires code_verifier that doesn't exist in the user's browser).
-
-        Creates a short-lived, single-use bridge token in the database.
-        When the user clicks the URL, the portal exchanges the token
-        for a Supabase session via verifyOtp (bypassing PKCE).
-
-        Args:
-            user_id: User's UUID string.
-            redirect_path: Portal path to redirect after auth.
-
-        Returns:
-            Bridge URL string, or None on failure.
-        """
-        try:
-            from uuid import UUID
-
-            from nikita.db.database import get_session_maker
-            from nikita.db.repositories.auth_bridge_repository import (
-                AuthBridgeRepository,
-            )
-
-            settings = get_settings()
-            portal_url = settings.portal_url or "https://portal-phi-orcin.vercel.app"
-
-            session_maker = get_session_maker()
-            async with session_maker() as session:
-                repo = AuthBridgeRepository(session)
-                bridge = await repo.create_token(UUID(user_id), redirect_path)
-                await session.commit()
-
-            url = f"{portal_url}/auth/bridge?token={bridge.token}"
-            logger.info(
-                f"Generated bridge URL for user_id={user_id}, "
-                f"redirect_path={redirect_path}"
-            )
-            return url
-
-        except Exception as e:
-            logger.warning(
-                f"Failed to generate bridge URL for user_id={user_id}: {e}"
-            )
-            return None
-
     async def _offer_onboarding_choice(
         self,
         chat_id: int,
@@ -394,8 +342,13 @@ class OTPVerificationHandler:
         settings = get_settings()
         portal_url = settings.portal_url or "https://portal-phi-orcin.vercel.app"
 
-        # Generate bridge URL for zero-click portal auth (GH #187)
-        magic_link = await self._generate_portal_bridge_url(
+        # Generate bridge URL for zero-click portal auth (GH #187 / GH #233).
+        # Function-local import keeps the patch target as the source module
+        # (nikita.platforms.telegram.utils.generate_portal_bridge_url) per
+        # .claude/rules/testing.md — avoids binding-shadow patch surprises.
+        from nikita.platforms.telegram.utils import generate_portal_bridge_url
+
+        magic_link = await generate_portal_bridge_url(
             user_id=user_id,
             redirect_path="/onboarding",
         )

--- a/nikita/platforms/telegram/utils.py
+++ b/nikita/platforms/telegram/utils.py
@@ -1,0 +1,69 @@
+"""Shared helpers for the Telegram platform layer.
+
+Leaf module. Do NOT import from `nikita.platforms.telegram.*` — only
+from strictly lower layers (`nikita.config`, `nikita.db`). Keeps the
+dependency graph one-way and prevents circular imports from handlers.
+
+GH #233 — extracted to eliminate duplication of `_generate_portal_bridge_url`
+across `otp_handler.py`, `message_handler.py`, and the delegated call in
+`commands.py`. History: originally introduced in GH #187 to replace the
+broken PKCE-mismatched magic-link flow; duplicated when PR #230 added the
+same logic to `message_handler.py` for the slash-command path.
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+from nikita.config.settings import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+async def generate_portal_bridge_url(
+    user_id: str,
+    redirect_path: str = "/onboarding",
+) -> str | None:
+    """Generate a portal bridge URL for zero-click Supabase auth.
+
+    Creates a short-lived, single-use bridge token in the database.
+    The portal exchanges the token for a Supabase session via verifyOtp
+    (bypassing PKCE), then redirects to `redirect_path`.
+
+    Args:
+        user_id: User's UUID string.
+        redirect_path: Portal path to redirect after auth. Defaults to
+            "/onboarding" to match the most common caller.
+
+    Returns:
+        Bridge URL string, or None on any failure (callers fall back to
+        the regular `/login?next=...` URL).
+    """
+    try:
+        from nikita.db.database import get_session_maker
+        from nikita.db.repositories.auth_bridge_repository import (
+            AuthBridgeRepository,
+        )
+
+        settings = get_settings()
+        portal_url = settings.portal_url or "https://portal-phi-orcin.vercel.app"
+
+        session_maker = get_session_maker()
+        async with session_maker() as session:
+            repo = AuthBridgeRepository(session)
+            bridge = await repo.create_token(UUID(user_id), redirect_path)
+            await session.commit()
+
+        url = f"{portal_url}/auth/bridge?token={bridge.token}"
+        logger.info(
+            f"Generated bridge URL for user_id={user_id}, "
+            f"redirect_path={redirect_path}"
+        )
+        return url
+
+    except Exception as e:
+        logger.warning(
+            f"Failed to generate bridge URL for user_id={user_id}: {e}"
+        )
+        return None

--- a/specs/210-test-quality-audit/README.md
+++ b/specs/210-test-quality-audit/README.md
@@ -1,0 +1,51 @@
+# Spec 210 — Test Quality Audit
+
+**Status**: PLANNED
+**Registered**: 2026-04-13
+**Triggered by**: PR #252 (GH #248 hotfix) — discovered the "tests that don't test" anti-pattern in `tests/api/routes/test_tasks.py` (11 tests, 0 effective coverage on the content-parsing branch where the bug lived)
+
+## Problem
+
+Silent test-coverage gaps across the suite. Two confirmed anti-patterns:
+
+1. **Empty-list mock bypass**: Tests mock `repo.get_*()` / `list_*()` / `find_*()` to return `[]`, which means loop bodies in the production function are never exercised. Coverage metrics pass while the risky branch is 0% covered.
+2. **Zero-assertion shell tests**: Test bodies with zero `assert` / `assert_awaited_*` / `pytest.raises` — a passing green that proves nothing (`test_calls_repository_create_event_with_session` in iter 2 of PR #252 was one such).
+
+Hypothesis: across 5768 tests, a non-trivial subset suffers from these patterns. Blast radius unknown.
+
+## Scope
+
+Systematic audit of `tests/` directory + remediation backlog.
+
+**Audit tasks**:
+- Grep for `return_value=[]` / `AsyncMock(return_value=[])` in mock setups; map each to its corresponding production function
+- For each match: check whether ANY sibling test in the file provides a non-empty fixture + asserts on the loop body
+- Grep for `async def test_*` bodies with zero `assert` / `assert_awaited_*` / `pytest.raises`
+- Cross-reference hits with `nikita/` module blast radius (delivery, scoring, decay, boss fights, onboarding handoff, memory dedup, vice, pipeline) — prioritize by production impact
+
+**Deliverables**:
+- Per-module remediation backlog (GH issues per gap cluster)
+- Extended `.claude/rules/testing.md` with stronger enforcement (already seeded by PR #252)
+- Optional: pytest plugin / CI assertion flagging `return_value=[]` without a paired non-empty test
+
+**Out of scope**:
+- E2E tests (`tests/e2e/`) — different assertion model
+- Existing integration-marked / slow-marked tests (already deferred)
+
+## Budget
+
+Estimate 3-5 PRs, parallel-safe across modules. Audit phase ~1 day; per-module remediation variable.
+
+## Dependencies
+
+None (pure quality work).
+
+## References
+
+- PR #252 root cause + fix log: `.claude/plans/pr-review-ledger-fix-scheduled-delivery-chat-id-248.md`
+- Anti-pattern rule: `.claude/rules/testing.md` → "Tests That Don't Test" section
+- Memory: `project_scheduled_events_delivery.md` (auto-memory)
+
+## Next Step
+
+Scope via `/feature 210-test-quality-audit` in a dedicated session (SDD Phase 3 — Socratic spec authoring). Not urgent; runs parallel to Epic 1 sprint.

--- a/tests/api/test_main_lifespan.py
+++ b/tests/api/test_main_lifespan.py
@@ -1,0 +1,71 @@
+"""Tests for FastAPI lifespan startup guards (nikita/api/main.py).
+
+Covers the fail-fast RuntimeError checks that run at deploy time to
+prevent misconfigured revisions from going healthy.
+
+- task_auth_secret guard (BKD-003, PR #118) — pre-existing
+- supabase_url guard (GH #184) — added in this PR
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+
+from nikita.api.main import lifespan
+
+
+@pytest.mark.asyncio
+async def test_lifespan_raises_when_supabase_url_missing():
+    """GH #184: lifespan fails fast when SUPABASE_URL env var is missing.
+
+    Before this guard, the Supabase client init block at lines 102-108
+    caught the SupabaseException silently and set app.state.supabase=None,
+    leaving the app "healthy" but broken. Now the process dies at startup.
+    """
+    app = FastAPI()
+
+    with patch("nikita.api.main.settings") as mock_settings:
+        mock_settings.debug = True  # irrelevant for SUPABASE_URL guard
+        mock_settings.task_auth_secret = "dummy"
+        mock_settings.supabase_url = None  # <-- the condition under test
+        mock_settings.anthropic_api_key = None
+        mock_settings.llm_warmup_enabled = False
+
+        with pytest.raises(RuntimeError, match="supabase_url must be set"):
+            async with lifespan(app):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_lifespan_raises_when_supabase_url_empty_string():
+    """Empty string must be treated as missing (falsy check)."""
+    app = FastAPI()
+
+    with patch("nikita.api.main.settings") as mock_settings:
+        mock_settings.debug = True
+        mock_settings.task_auth_secret = "dummy"
+        mock_settings.supabase_url = ""  # falsy — still missing
+        mock_settings.anthropic_api_key = None
+        mock_settings.llm_warmup_enabled = False
+
+        with pytest.raises(RuntimeError, match="supabase_url must be set"):
+            async with lifespan(app):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_lifespan_guards_run_in_order_task_auth_secret_first():
+    """BKD-003 guard fires before the #184 guard — preserves existing behavior."""
+    app = FastAPI()
+
+    with patch("nikita.api.main.settings") as mock_settings:
+        mock_settings.debug = False  # triggers BKD-003 path
+        mock_settings.task_auth_secret = None
+        mock_settings.supabase_url = None  # also missing
+
+        # Should raise the BKD-003 message, not the SUPABASE_URL one —
+        # proves ordering: task_auth_secret guard runs first.
+        with pytest.raises(RuntimeError, match="task_auth_secret must be set"):
+            async with lifespan(app):
+                pass

--- a/tests/platforms/telegram/test_commands.py
+++ b/tests/platforms/telegram/test_commands.py
@@ -388,14 +388,14 @@ class TestOnboardCommand:
         mock_user.onboarding_status = "pending"
         mock_user_repository.get_by_telegram_id.return_value = mock_user
 
+        # GH #233: commands.py now calls generate_portal_bridge_url directly
+        # (source module patch per .claude/rules/testing.md).
         with patch(
-            "nikita.platforms.telegram.commands.OTPVerificationHandler"
-        ) as MockOTP:
-            mock_otp_instance = MockOTP.return_value
-            mock_otp_instance._generate_portal_bridge_url = AsyncMock(
+            "nikita.platforms.telegram.utils.generate_portal_bridge_url",
+            new=AsyncMock(
                 return_value="https://portal-phi-orcin.vercel.app/auth/bridge?token=abc"
-            )
-
+            ),
+        ):
             await handler.handle(onboard_message)
 
         # Should send keyboard with URL button
@@ -418,13 +418,11 @@ class TestOnboardCommand:
         mock_user_repository.get_by_telegram_id.return_value = mock_user
 
         with patch(
-            "nikita.platforms.telegram.commands.OTPVerificationHandler"
-        ) as MockOTP:
-            mock_otp_instance = MockOTP.return_value
-            mock_otp_instance._generate_portal_bridge_url = AsyncMock(
+            "nikita.platforms.telegram.utils.generate_portal_bridge_url",
+            new=AsyncMock(
                 return_value="https://example.com/auth/bridge?token=xyz"
-            )
-
+            ),
+        ):
             await handler.handle(onboard_message)
 
         mock_bot.send_message_with_keyboard.assert_called_once()
@@ -440,13 +438,9 @@ class TestOnboardCommand:
         mock_user_repository.get_by_telegram_id.return_value = mock_user
 
         with patch(
-            "nikita.platforms.telegram.commands.OTPVerificationHandler"
-        ) as MockOTP:
-            mock_otp_instance = MockOTP.return_value
-            mock_otp_instance._generate_portal_bridge_url = AsyncMock(
-                return_value=None
-            )
-
+            "nikita.platforms.telegram.utils.generate_portal_bridge_url",
+            new=AsyncMock(return_value=None),
+        ):
             await handler.handle(onboard_message)
 
         call_kwargs = mock_bot.send_message_with_keyboard.call_args[1]

--- a/tests/platforms/telegram/test_otp_handler_onboarding.py
+++ b/tests/platforms/telegram/test_otp_handler_onboarding.py
@@ -1,134 +1,17 @@
-"""Tests for OTP handler portal-first onboarding (Spec 081 + GH #187).
+"""Tests for OTP handler portal-first onboarding (Spec 081 + GH #187 + GH #233).
 
-Tests verify the bridge URL generation and portal redirect flow
-that replaces the broken magic link approach (PKCE mismatch fix).
+Tests verify the portal redirect flow. The bridge-URL generation itself is
+now tested in `tests/platforms/telegram/test_utils.py` — it was extracted
+into a module-public free function (GH #233) and no longer lives on the
+handler.
 
 AC Coverage: AC-1.1, AC-1.2, AC-1.3, AC-1.4 (Spec 081)
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from nikita.platforms.telegram.otp_handler import OTPVerificationHandler
-
-
-class TestGeneratePortalBridgeUrl:
-    """Tests for _generate_portal_bridge_url() method (GH #187).
-
-    Replaces TestGeneratePortalMagicLink — the old magic link approach
-    failed due to PKCE code_verifier mismatch.
-    """
-
-    @pytest.fixture
-    def mock_telegram_auth(self):
-        """Mock TelegramAuth."""
-        return AsyncMock()
-
-    @pytest.fixture
-    def mock_bot(self):
-        """Mock TelegramBot."""
-        return AsyncMock()
-
-    @pytest.fixture
-    def handler(self, mock_telegram_auth, mock_bot):
-        """Create handler with mocked deps."""
-        return OTPVerificationHandler(
-            telegram_auth=mock_telegram_auth,
-            bot=mock_bot,
-        )
-
-    @pytest.mark.asyncio
-    async def test_bridge_url_success_returns_portal_url(self, handler):
-        """Returns portal bridge URL with token parameter."""
-        mock_bridge = MagicMock()
-        mock_bridge.token = "test-bridge-token-abc123"
-
-        mock_repo = AsyncMock()
-        mock_repo.create_token.return_value = mock_bridge
-
-        mock_session = AsyncMock()
-        mock_session_ctx = AsyncMock()
-        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
-        mock_session_maker = MagicMock(return_value=mock_session_ctx)
-
-        with (
-            patch(
-                "nikita.platforms.telegram.otp_handler.get_settings"
-            ) as mock_settings,
-            patch(
-                "nikita.db.database.get_session_maker",
-                return_value=mock_session_maker,
-            ),
-            patch(
-                "nikita.db.repositories.auth_bridge_repository.AuthBridgeRepository",
-                return_value=mock_repo,
-            ),
-        ):
-            mock_settings.return_value.portal_url = (
-                "https://portal.vercel.app"
-            )
-            result = await handler._generate_portal_bridge_url(
-                user_id="550e8400-e29b-41d4-a716-446655440000",
-                redirect_path="/onboarding",
-            )
-
-        assert result is not None
-        assert "portal.vercel.app/auth/bridge" in result
-        assert "token=test-bridge-token-abc123" in result
-
-    @pytest.mark.asyncio
-    async def test_bridge_url_returns_none_on_error(self, handler):
-        """Returns None on any failure (doesn't raise)."""
-        with (
-            patch("nikita.platforms.telegram.otp_handler.get_settings") as mock_settings,
-            patch(
-                "nikita.db.database.get_session_maker",
-                side_effect=Exception("DB unavailable"),
-            ),
-        ):
-            mock_settings.return_value.portal_url = (
-                "https://portal.vercel.app"
-            )
-            result = await handler._generate_portal_bridge_url(
-                user_id="550e8400-e29b-41d4-a716-446655440000",
-                redirect_path="/onboarding",
-            )
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_bridge_url_uses_default_portal_url(self, handler):
-        """Uses default portal URL when settings.portal_url is None."""
-        mock_bridge = MagicMock()
-        mock_bridge.token = "tok789"
-
-        mock_repo = AsyncMock()
-        mock_repo.create_token.return_value = mock_bridge
-
-        mock_session = AsyncMock()
-        mock_session_ctx = AsyncMock()
-        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
-        mock_session_maker = MagicMock(return_value=mock_session_ctx)
-
-        with (
-            patch("nikita.platforms.telegram.otp_handler.get_settings") as mock_settings,
-            patch(
-                "nikita.db.database.get_session_maker",
-                return_value=mock_session_maker,
-            ),
-            patch(
-                "nikita.db.repositories.auth_bridge_repository.AuthBridgeRepository",
-                return_value=mock_repo,
-            ),
-        ):
-            mock_settings.return_value.portal_url = None
-            result = await handler._generate_portal_bridge_url(
-                user_id="550e8400-e29b-41d4-a716-446655440000",
-            )
-
-        assert result is not None
-        assert "portal-phi-orcin.vercel.app" in result
 
 
 class TestOfferOnboardingChoice:
@@ -157,12 +40,17 @@ class TestOfferOnboardingChoice:
         self, handler, mock_bot
     ):
         """AC-1.1: After OTP, sends single URL button 'Enter Nikita's World' with bridge URL."""
-        handler._generate_portal_bridge_url = AsyncMock(
-            return_value="https://portal.vercel.app/auth/bridge?token=abc123"
-        )
-        with patch(
-            "nikita.platforms.telegram.otp_handler.get_settings"
-        ) as mock_settings:
+        with (
+            patch(
+                "nikita.platforms.telegram.utils.generate_portal_bridge_url",
+                new=AsyncMock(
+                    return_value="https://portal.vercel.app/auth/bridge?token=abc123"
+                ),
+            ),
+            patch(
+                "nikita.platforms.telegram.otp_handler.get_settings"
+            ) as mock_settings,
+        ):
             mock_settings.return_value.portal_url = (
                 "https://portal.vercel.app"
             )
@@ -190,10 +78,15 @@ class TestOfferOnboardingChoice:
         self, handler, mock_bot
     ):
         """AC-1.4: Falls back to portal_url/login?next=/onboarding when bridge URL returns None."""
-        handler._generate_portal_bridge_url = AsyncMock(return_value=None)
-        with patch(
-            "nikita.platforms.telegram.otp_handler.get_settings"
-        ) as mock_settings:
+        with (
+            patch(
+                "nikita.platforms.telegram.utils.generate_portal_bridge_url",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "nikita.platforms.telegram.otp_handler.get_settings"
+            ) as mock_settings,
+        ):
             mock_settings.return_value.portal_url = (
                 "https://portal.vercel.app"
             )
@@ -215,12 +108,17 @@ class TestOfferOnboardingChoice:
     @pytest.mark.asyncio
     async def test_message_text_matches_spec_copy(self, handler, mock_bot):
         """AC-1.1: Message text includes spec copy about entering Nikita's world."""
-        handler._generate_portal_bridge_url = AsyncMock(
-            return_value="https://portal.vercel.app/auth/bridge?token=xyz"
-        )
-        with patch(
-            "nikita.platforms.telegram.otp_handler.get_settings"
-        ) as mock_settings:
+        with (
+            patch(
+                "nikita.platforms.telegram.utils.generate_portal_bridge_url",
+                new=AsyncMock(
+                    return_value="https://portal.vercel.app/auth/bridge?token=xyz"
+                ),
+            ),
+            patch(
+                "nikita.platforms.telegram.otp_handler.get_settings"
+            ) as mock_settings,
+        ):
             mock_settings.return_value.portal_url = (
                 "https://portal.vercel.app"
             )
@@ -239,12 +137,17 @@ class TestOfferOnboardingChoice:
     @pytest.mark.asyncio
     async def test_no_voice_or_text_buttons(self, handler, mock_bot):
         """AC-1.1: Voice call and text chat buttons are removed."""
-        handler._generate_portal_bridge_url = AsyncMock(
-            return_value="https://portal.vercel.app/auth/bridge?token=xyz"
-        )
-        with patch(
-            "nikita.platforms.telegram.otp_handler.get_settings"
-        ) as mock_settings:
+        with (
+            patch(
+                "nikita.platforms.telegram.utils.generate_portal_bridge_url",
+                new=AsyncMock(
+                    return_value="https://portal.vercel.app/auth/bridge?token=xyz"
+                ),
+            ),
+            patch(
+                "nikita.platforms.telegram.otp_handler.get_settings"
+            ) as mock_settings,
+        ):
             mock_settings.return_value.portal_url = (
                 "https://portal.vercel.app"
             )

--- a/tests/platforms/telegram/test_utils.py
+++ b/tests/platforms/telegram/test_utils.py
@@ -1,0 +1,153 @@
+"""Tests for telegram utils — extracted shared helpers (GH #233).
+
+`generate_portal_bridge_url` was previously duplicated across otp_handler.py
+and message_handler.py. After extraction it lives in
+`nikita.platforms.telegram.utils` as a module-public free function.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestGeneratePortalBridgeUrl:
+    """Direct tests for the extracted free function (GH #233)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_bridge_url_with_token_on_success(self):
+        """Returns portal bridge URL with token query param for a valid user."""
+        from nikita.platforms.telegram.utils import generate_portal_bridge_url
+
+        mock_bridge = MagicMock()
+        mock_bridge.token = "test-bridge-token-abc123"
+
+        mock_repo = AsyncMock()
+        mock_repo.create_token.return_value = mock_bridge
+
+        mock_session = AsyncMock()
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_session_maker = MagicMock(return_value=mock_session_ctx)
+
+        with (
+            patch(
+                "nikita.platforms.telegram.utils.get_settings"
+            ) as mock_settings,
+            patch(
+                "nikita.db.database.get_session_maker",
+                return_value=mock_session_maker,
+            ),
+            patch(
+                "nikita.db.repositories.auth_bridge_repository.AuthBridgeRepository",
+                return_value=mock_repo,
+            ),
+        ):
+            mock_settings.return_value.portal_url = "https://portal.vercel.app"
+            result = await generate_portal_bridge_url(
+                user_id="550e8400-e29b-41d4-a716-446655440000",
+                redirect_path="/onboarding",
+            )
+
+        assert result is not None
+        assert "portal.vercel.app/auth/bridge" in result
+        assert "token=test-bridge-token-abc123" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_exception(self):
+        """Catches all exceptions and returns None (caller handles fallback)."""
+        from nikita.platforms.telegram.utils import generate_portal_bridge_url
+
+        with (
+            patch(
+                "nikita.platforms.telegram.utils.get_settings"
+            ) as mock_settings,
+            patch(
+                "nikita.db.database.get_session_maker",
+                side_effect=Exception("DB unavailable"),
+            ),
+        ):
+            mock_settings.return_value.portal_url = "https://portal.vercel.app"
+            result = await generate_portal_bridge_url(
+                user_id="550e8400-e29b-41d4-a716-446655440000",
+                redirect_path="/onboarding",
+            )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_uses_default_portal_url_when_setting_is_none(self):
+        """Falls back to the hardcoded default portal URL when setting unset."""
+        from nikita.platforms.telegram.utils import generate_portal_bridge_url
+
+        mock_bridge = MagicMock()
+        mock_bridge.token = "fallback-token"
+
+        mock_repo = AsyncMock()
+        mock_repo.create_token.return_value = mock_bridge
+
+        mock_session = AsyncMock()
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_session_maker = MagicMock(return_value=mock_session_ctx)
+
+        with (
+            patch(
+                "nikita.platforms.telegram.utils.get_settings"
+            ) as mock_settings,
+            patch(
+                "nikita.db.database.get_session_maker",
+                return_value=mock_session_maker,
+            ),
+            patch(
+                "nikita.db.repositories.auth_bridge_repository.AuthBridgeRepository",
+                return_value=mock_repo,
+            ),
+        ):
+            mock_settings.return_value.portal_url = None
+            result = await generate_portal_bridge_url(
+                user_id="550e8400-e29b-41d4-a716-446655440000",
+            )
+
+        assert result is not None
+        assert "portal-phi-orcin.vercel.app" in result
+
+    @pytest.mark.asyncio
+    async def test_default_redirect_path_is_onboarding(self):
+        """Default redirect_path is /onboarding — preserves prior signature."""
+        from nikita.platforms.telegram.utils import generate_portal_bridge_url
+
+        mock_bridge = MagicMock()
+        mock_bridge.token = "default-redirect-token"
+
+        mock_repo = AsyncMock()
+        mock_repo.create_token.return_value = mock_bridge
+
+        mock_session = AsyncMock()
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_session_maker = MagicMock(return_value=mock_session_ctx)
+
+        with (
+            patch(
+                "nikita.platforms.telegram.utils.get_settings"
+            ) as mock_settings,
+            patch(
+                "nikita.db.database.get_session_maker",
+                return_value=mock_session_maker,
+            ),
+            patch(
+                "nikita.db.repositories.auth_bridge_repository.AuthBridgeRepository",
+                return_value=mock_repo,
+            ),
+        ):
+            mock_settings.return_value.portal_url = "https://portal.vercel.app"
+            # Call without explicit redirect_path — asserts default arg present.
+            await generate_portal_bridge_url(
+                user_id="550e8400-e29b-41d4-a716-446655440000",
+            )
+
+        from uuid import UUID
+        mock_repo.create_token.assert_awaited_once_with(
+            UUID("550e8400-e29b-41d4-a716-446655440000"), "/onboarding"
+        )


### PR DESCRIPTION
## Summary

Two tiny housekeeping fixes that were claimed complete in PR-1 but never actually landed on master (discovered 2026-04-13 via `rg "SUPABASE_URL" nikita/config/settings.py nikita/api/main.py` → 0 hits, and `rg _generate_portal_bridge_url nikita/` → 3 defs).

- **#184**: Cloud Run deploy dropped `SUPABASE_URL` → app went "healthy" with `supabase=None`, silently breaking all Supabase ops. Now fails fast at lifespan startup with a `RuntimeError` before any request is served. Mirrors the existing BKD-003 `task_auth_secret` pattern exactly.
- **#233**: `_generate_portal_bridge_url` was duplicated across `otp_handler.py` + `message_handler.py` (PR #230 copy-paste). Extract to leaf module `nikita/platforms/telegram/utils.py`. Zero cycle risk. `commands.py` no longer needs to instantiate `OTPVerificationHandler` just to reach the helper — direct call.

## Root cause / why it slipped

Task-ledger entry for PR-1 said completed but the code was never written. Self-Improvement Loop in the plan spawns Spec 211 (task-ledger-truth-audit) to prevent this class of drift.

## Test plan

- [x] 4 new direct tests in `tests/platforms/telegram/test_utils.py` (success, exception→None, default portal URL, default redirect path)
- [x] 3 new lifespan-guard tests in `tests/api/test_main_lifespan.py` (supabase_url=None raises, supabase_url="" raises, guard ordering)
- [x] Rewritten 4 tests in `test_otp_handler_onboarding.py::TestOfferOnboardingChoice` — source-module patches per `.claude/rules/testing.md`
- [x] Rewritten 3 tests in `test_commands.py` (no longer depend on removed `OTPVerificationHandler` delegation)
- [x] `rtk proxy pytest tests/platforms/telegram/ tests/api/` → 797 passed
- [x] `rtk proxy pytest tests/ -x -q --ignore=tests/e2e` → 5772 passed in 3:00

## qa-review Convergence

- **Iter 0 (self-review)**: 0 blocking, 0 important, 2 nitpicks deferred.
- **Iter 1 (external fresh-context)**: 1 important (R1: dangling `OTPVerificationHandler` import in commands.py:20, classic F401) + 2 nitpicks. R1 fixed in commit dc2d9d9. Nitpicks skipped (below threshold).
- **Iter 2 (external fresh-context)**: **CLEAN — 0 blocking, 0 important**. Integration-risk confirmed zero.

Ledger: `.claude/plans/pr-review-ledger-fix-supabase-guard-bridge-extract-184-233.md`

## Notes for reviewers

- `utils.py` uses function-local imports in the callers (otp_handler, message_handler, commands) so patching `nikita.platforms.telegram.utils.generate_portal_bridge_url` intercepts correctly. Top-level imports would shadow the binding and defeat the rule. This convention is documented inline + in `.claude/rules/testing.md`.
- Bundled session housekeeping (first commit): Spec 210 registration (PLANNED), `.claude/rules/testing.md` "tests that don't test" anti-pattern rule from PR #252 reflection, `event-stream.md` entry.

Closes #184
Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)