### PR TITLE
fix(memory): lower dedup threshold to 0.87 (#199)

### DIFF
--- a/nikita/memory/CLAUDE.md
+++ b/nikita/memory/CLAUDE.md
@@ -12,7 +12,7 @@ pgVector-based memory backend using Supabase for Nikita's memory system.
 memory/
 └── supabase_memory.py          ✅ COMPLETE (38 tests)
     └─ SupabaseMemory class
-        ├─ add_fact()           # Cosine-similarity dedup (0.95 threshold)
+        ├─ add_fact()           # Cosine-similarity dedup (DEDUP_SIMILARITY_THRESHOLD, 0.87)
         ├─ search()             # pgVector semantic search
         └─ get_recent()         # Time-ordered retrieval
 # migrate_neo4j_to_supabase.py deleted (DC-003 — unrunnable, graphiti_client gone)
@@ -42,9 +42,10 @@ CREATE INDEX idx_memory_facts_embedding
 - `nikita`: Her simulated life ("Finished 36-hour security audit")
 - `relationship`: Shared history ("We joked about her hacker mug")
 
-**Deduplication**: Cosine-similarity threshold 0.95 (Spec 102 FR-001) — `add_fact()`
-generates ONE embedding and passes it to `find_similar()` internally. If a fact with
-similarity > 0.95 exists, the old fact is superseded (not deleted, `is_active=False`).
+**Deduplication**: Cosine-similarity threshold `DEDUP_SIMILARITY_THRESHOLD` (Spec 102 FR-001,
+0.87 as of GH #199; history: 0.95 → 0.92 → 0.87) — `add_fact()` generates ONE embedding and
+passes it to `find_similar()` internally. If a fact with similarity ≥ threshold exists, the
+old fact is superseded (not deleted, `is_active=False`).
 
 **Search**: pgVector cosine similarity for semantic search
 
@@ -57,7 +58,7 @@ await memory.add_fact(
     user_id=user_id,
     fact_type="user",  # user | nikita | relationship
 )
-# Auto-deduplication via cosine-similarity 0.95 (single embedding, Spec 102 FR-001)
+# Auto-deduplication via DEDUP_SIMILARITY_THRESHOLD (0.87, single embedding, Spec 102 FR-001)
 ```
 
 ### search (supabase_memory.py)

--- a/nikita/memory/supabase_memory.py
+++ b/nikita/memory/supabase_memory.py
@@ -34,6 +34,13 @@ EMBEDDING_DIMS = 1536
 MAX_RETRIES = 3
 RETRY_BACKOFF_BASE = 1  # seconds
 
+# GH #199: Memory dedup threshold — cosine similarity above this suppresses duplicate facts.
+# History: 0.95 (Spec 042) → 0.92 (commit 077d9ee, GH #157) → 0.87 (GH #199).
+# Therapist-fact E2E variants (2026-03-30) embed at ~0.88–0.91; 0.87 catches them while
+# still admitting genuinely-distinct facts (different-occupation examples cluster at 0.82–0.88).
+# Future tightening should land with a new GH issue, a bump here, and an updated comment.
+DEDUP_SIMILARITY_THRESHOLD = 0.87
+
 
 class EmbeddingError(Exception):
     """Raised when embedding generation fails after all retries."""
@@ -169,7 +176,9 @@ class SupabaseMemory:
         embedding = await self._generate_embedding(fact)
 
         # T1.2: Check for duplicates before inserting — pass pre-computed embedding
-        existing = await self.find_similar(fact, threshold=0.92, embedding=embedding)
+        existing = await self.find_similar(
+            fact, threshold=DEDUP_SIMILARITY_THRESHOLD, embedding=embedding
+        )
 
         new_fact = await self._repo.add_fact(
             user_id=self.user_id,
@@ -280,20 +289,20 @@ class SupabaseMemory:
     async def find_similar(
         self,
         text: str,
-        threshold: float = 0.92,
+        threshold: float = DEDUP_SIMILARITY_THRESHOLD,
         embedding: list[float] | None = None,
     ):
         """Find near-duplicate fact by cosine similarity.
 
-        AC-1.2.1: Returns existing fact if similarity > threshold.
-        Cosine distance = 1 - similarity, so threshold 0.92 → max distance 0.08.
+        AC-1.2.1: Returns existing fact if similarity >= threshold.
+        Cosine distance = 1 - similarity, so threshold 0.87 → max distance 0.13.
 
         Spec 102 FR-001: Accepts optional pre-computed embedding to avoid
         double API call when called from add_fact().
 
         Args:
             text: The fact text to compare.
-            threshold: Similarity threshold (default 0.95).
+            threshold: Similarity threshold (default DEDUP_SIMILARITY_THRESHOLD, 0.87 as of GH #199).
             embedding: Optional pre-computed embedding; generated if not provided.
         """
         if embedding is None:

--- a/nikita/pipeline/stages/memory_update.py
+++ b/nikita/pipeline/stages/memory_update.py
@@ -22,8 +22,9 @@ logger = structlog.get_logger(__name__)
 class MemoryUpdateStage(BaseStage):
     """Write extracted facts to Supabase memory_facts table.
 
-    Deduplicates against existing facts (similarity > 0.95).
-    Classifies facts into graph_type (user/relationship/nikita).
+    Deduplicates against existing facts using cosine similarity against the
+    ``DEDUP_SIMILARITY_THRESHOLD`` constant in ``nikita.memory.supabase_memory``
+    (0.87 as of GH #199). Classifies facts into graph_type (user/relationship/nikita).
 
     This is a CRITICAL stage - failure stops the pipeline.
     """

--- a/tests/memory/test_supabase_memory.py
+++ b/tests/memory/test_supabase_memory.py
@@ -434,10 +434,10 @@ class TestFindSimilar:
 
     @pytest.mark.asyncio
     async def test_find_similar_catches_093_similarity(self, memory):
-        """GH #157: 0.93 similarity (distance 0.07) is caught by the 0.92 threshold.
+        """GH #157: 0.93 similarity (distance 0.07) is caught by the default threshold.
 
-        Previously at 0.95 threshold, a fact with 0.93 similarity would slip
-        through. Tightened to 0.92 so near-duplicates are properly deduped.
+        History: 0.95 → 0.92 (GH #157) → 0.87 (GH #199). Distance 0.07 has been
+        caught at every tightening step; this test guards that continuity.
         """
         mock_fact = MagicMock()
         mock_fact.fact = "User enjoys drinking coffee every morning"
@@ -445,7 +445,7 @@ class TestFindSimilar:
 
         with patch.object(memory, "_generate_embedding", new_callable=AsyncMock, return_value=FAKE_EMBEDDING):
             with patch.object(memory, "_repo") as mock_repo:
-                # Distance 0.07 → similarity 0.93 > 0.92 threshold → should match
+                # Distance 0.07 → similarity 0.93 — caught at default threshold
                 mock_repo.semantic_search = AsyncMock(return_value=[(mock_fact, 0.07)])
 
                 result = await memory.find_similar("User loves drinking coffee each morning")
@@ -453,18 +453,123 @@ class TestFindSimilar:
                 assert result.fact == "User enjoys drinking coffee every morning"
 
     @pytest.mark.asyncio
-    async def test_find_similar_rejects_below_092_threshold(self, memory):
-        """Facts with similarity below 0.92 (distance > 0.08) are not flagged as duplicates."""
+    async def test_find_similar_rejects_well_below_threshold(self, memory):
+        """Facts with similarity well below the threshold are not flagged as duplicates.
+
+        GH #199: threshold is 0.87; a fact at 0.80 similarity (distance 0.20) should
+        remain admitted as a genuinely distinct fact. Guards against over-dedup.
+        """
         mock_fact = MagicMock()
         mock_fact.fact = "User likes tea"
 
         with patch.object(memory, "_generate_embedding", new_callable=AsyncMock, return_value=FAKE_EMBEDDING):
             with patch.object(memory, "_repo") as mock_repo:
-                # Distance 0.10 → similarity 0.90 < 0.92 threshold → should NOT match
-                mock_repo.semantic_search = AsyncMock(return_value=[(mock_fact, 0.10)])
+                # Distance 0.20 → similarity 0.80 — below any historical threshold → no match
+                mock_repo.semantic_search = AsyncMock(return_value=[(mock_fact, 0.20)])
 
                 result = await memory.find_similar("User likes coffee")
                 assert result is None
+
+    # ── GH #199: 0.87 threshold edge cases ─────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_find_similar_catches_089_similarity_therapist_variant(self, memory):
+        """GH #199: 0.89 similarity (distance 0.11) is now caught.
+
+        Previously at 0.92 threshold (max_distance=0.08), distance 0.11 slipped
+        through — this was the therapist-fact E2E regression on 2026-03-30 where
+        two near-identical paraphrases of "Nikita sees a therapist" were both stored.
+        At 0.87 threshold (max_distance=0.13), 0.11 <= 0.13 → caught.
+        """
+        from nikita.memory.supabase_memory import DEDUP_SIMILARITY_THRESHOLD
+
+        mock_fact = MagicMock()
+        mock_fact.fact = "Nikita sees a therapist"
+        mock_fact.id = uuid4()
+
+        with patch.object(memory, "_generate_embedding", new_callable=AsyncMock, return_value=FAKE_EMBEDDING):
+            with patch.object(memory, "_repo") as mock_repo:
+                mock_repo.semantic_search = AsyncMock(return_value=[(mock_fact, 0.11)])
+
+                result = await memory.find_similar(
+                    "Nikita is in therapy with Dr. Miriam",
+                    threshold=DEDUP_SIMILARITY_THRESHOLD,
+                )
+                assert result is not None
+                assert result.fact == "Nikita sees a therapist"
+
+    @pytest.mark.asyncio
+    async def test_find_similar_rejects_085_similarity_genuinely_distinct(self, memory):
+        """GH #199: 0.85 similarity (distance 0.15) is rejected at 0.87 threshold.
+
+        Guards against false-positive dedup suppressing meaningfully-distinct facts
+        in the 0.82–0.88 band (different-occupation examples cluster here).
+        """
+        from nikita.memory.supabase_memory import DEDUP_SIMILARITY_THRESHOLD
+
+        mock_fact = MagicMock()
+        mock_fact.fact = "User works at a hospital"
+
+        with patch.object(memory, "_generate_embedding", new_callable=AsyncMock, return_value=FAKE_EMBEDDING):
+            with patch.object(memory, "_repo") as mock_repo:
+                mock_repo.semantic_search = AsyncMock(return_value=[(mock_fact, 0.15)])
+
+                result = await memory.find_similar(
+                    "User works at a bank",
+                    threshold=DEDUP_SIMILARITY_THRESHOLD,
+                )
+                assert result is None
+
+    @pytest.mark.asyncio
+    async def test_find_similar_edge_at_087_threshold_inclusive(self, memory):
+        """GH #199: distance exactly at max_distance (0.13) matches (inclusive boundary).
+
+        The implementation uses `distance <= max_distance`, so 0.13 at threshold 0.87
+        must be treated as a dedup hit.
+        """
+        from nikita.memory.supabase_memory import DEDUP_SIMILARITY_THRESHOLD
+
+        mock_fact = MagicMock()
+        mock_fact.fact = "Boundary fact"
+        mock_fact.id = uuid4()
+
+        with patch.object(memory, "_generate_embedding", new_callable=AsyncMock, return_value=FAKE_EMBEDDING):
+            with patch.object(memory, "_repo") as mock_repo:
+                # max_distance = 1.0 - 0.87 = 0.13 exactly
+                mock_repo.semantic_search = AsyncMock(return_value=[(mock_fact, 0.13)])
+
+                result = await memory.find_similar(
+                    "query", threshold=DEDUP_SIMILARITY_THRESHOLD,
+                )
+                assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_find_similar_just_below_087_threshold_exclusive(self, memory):
+        """GH #199: distance just past max_distance (0.131) does not match (exclusive)."""
+        from nikita.memory.supabase_memory import DEDUP_SIMILARITY_THRESHOLD
+
+        mock_fact = MagicMock()
+        mock_fact.fact = "Just-below fact"
+
+        with patch.object(memory, "_generate_embedding", new_callable=AsyncMock, return_value=FAKE_EMBEDDING):
+            with patch.object(memory, "_repo") as mock_repo:
+                # 0.131 > 0.13 max_distance → no match
+                mock_repo.semantic_search = AsyncMock(return_value=[(mock_fact, 0.131)])
+
+                result = await memory.find_similar(
+                    "query", threshold=DEDUP_SIMILARITY_THRESHOLD,
+                )
+                assert result is None
+
+    def test_dedup_threshold_constant_matches_documented_value(self):
+        """GH #199: regression guard — threshold is 0.87 until intentionally changed.
+
+        Future tightening must come with a new GH issue and bump the comment in
+        supabase_memory.py documenting the change. Drift without intent breaks dedup.
+        """
+        from nikita.memory.supabase_memory import DEDUP_SIMILARITY_THRESHOLD
+
+        assert DEDUP_SIMILARITY_THRESHOLD == 0.87
 
 
 class TestDeduplication:

--- a/tests/memory/test_supabase_memory.py
+++ b/tests/memory/test_supabase_memory.py
@@ -394,7 +394,7 @@ class TestFindSimilar:
 
     @pytest.mark.asyncio
     async def test_find_similar_returns_match(self, memory):
-        """Returns existing fact if similarity > threshold."""
+        """Returns existing fact if similarity ≥ threshold (boundary inclusive, matches impl)."""
         mock_fact = MagicMock()
         mock_fact.fact = "User likes coffee"
         mock_fact.id = uuid4()


### PR DESCRIPTION
## Summary

- Lower `find_similar` dedup threshold from 0.92 to **0.87** to catch near-duplicate facts that slipped through at the tighter bound (2026-03-30 E2E regression: therapist fact stored twice with different phrasing).
- Extract the threshold to `DEDUP_SIMILARITY_THRESHOLD` module-level constant in `nikita/memory/supabase_memory.py` — was a magic number repeated at `add_fact` (line 172) and `find_similar` (line 283).
- Refresh stale docstring in `nikita/pipeline/stages/memory_update.py` (said "similarity > 0.95" pre-GH #157; now references the constant).

## Root cause

Issue title and auto-memory both misdiagnosed this as "exact match." Exploration (2026-04-13) proved the dedup IS already semantic: `supabase_memory.py::add_fact` → `find_similar(threshold=0.92)` → pgVector `cosine_distance` via `memory_fact_repository.py::semantic_search`. The real problem was the 0.92 threshold was too tight: therapist-variant phrasings embed at cosine similarity ~0.88–0.91, below the 0.92 gate.

## Test plan

- [x] 5 new tests added to `tests/memory/test_supabase_memory.py::TestFindSimilar`:
  - `test_find_similar_catches_089_similarity_therapist_variant` — the exact failure mode
  - `test_find_similar_rejects_085_similarity_genuinely_distinct` — guards over-dedup
  - `test_find_similar_edge_at_087_threshold_inclusive` — boundary
  - `test_find_similar_just_below_087_threshold_exclusive` — boundary
  - `test_dedup_threshold_constant_matches_documented_value` — regression guard on 0.87
- [x] 2 retuned existing tests:
  - `test_find_similar_rejects_below_092_threshold` → `_rejects_well_below_threshold` (uses distance 0.20, below any historical threshold)
  - `test_find_similar_catches_093_similarity` — docstring updated to reflect continuity across 0.95 → 0.92 → 0.87
- [x] `rtk proxy pytest tests/memory/ tests/pipeline/ -q` → 349 passed
- [x] `rtk proxy pytest tests/ -x -q --ignore=tests/e2e` → 5799 passed

## Risks & mitigations

- **False-positive dedup**: lowering 0.92 → 0.87 widens the suppression window. The 0.82–0.88 band (different-occupation examples like "hospital" vs "bank") remains admitted. Risk zone is 0.87–0.92 where semantically-close-but-meaningfully-distinct facts sit.
- **Supersession is safe**: when dedup hits, the newest phrasing replaces the old one — paraphrase collapses are benign.
- **Regression guard**: the new `test_dedup_threshold_constant_matches_documented_value` pins 0.87 so future drift requires intentional change + docstring update.

## Post-merge spot-check

Phase 4 verification E2E (Task #22) must confirm no duplicate therapist fact. If still drifting, escalate to FactExtractor-level stage dedup (out of scope here).

Closes #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)