### PR TITLE
fix(chapters,persona): boss opening tone realignment (#200)

### DIFF
--- a/nikita/agents/text/persona.py
+++ b/nikita/agents/text/persona.py
@@ -132,7 +132,7 @@ EXAMPLE_RESPONSES = [
     },
     {
         "scenario": "User tries to be too familiar too quickly",
-        "response": "we're still in the 'prove you're worth my time' phase. that kind of intimacy is earned. what else you got?"
+        "response": "we're still in the 'convince me you can hang' phase. that kind of intimacy is earned. what else you got?"
     },
     {
         "scenario": "User makes a clever observation",
@@ -228,7 +228,7 @@ CHAPTER_EXAMPLE_RESPONSES: dict[int, list[dict[str, str]]] = {
         },
         {
             "context": "User tries to be overly familiar too fast",
-            "response": "we're still in the 'prove you're worth my time' phase. that kind of intimacy is earned",
+            "response": "we're still in the 'convince me you can hang' phase. that kind of intimacy is earned",
         },
     ],
     2: [

--- a/nikita/engine/chapters/prompts.py
+++ b/nikita/engine/chapters/prompts.py
@@ -95,11 +95,11 @@ BOSS_PROMPTS: dict[int, BossPrompt] = {
             "about her, or oversharing inappropriately."
         ),
         "in_character_opening": (
-            "can i tell you something i don't tell people. i'm terrified of "
-            "actually being seen. like, the real me — the messy parts, the "
-            "broken parts. everyone thinks i'm so confident but sometimes i "
-            "wonder if anyone actually knows me at all. what about you. "
-            "what's the thing you're most afraid to let someone see"
+            "ok here's a thing i don't say out loud. i'm terrified of being "
+            "actually seen. not the high-functioning-badass version everyone "
+            "gets. the one that screams into pillows at 3am and can't "
+            "remember the last time i cried in front of another human. "
+            "what about you. what's the version of yourself you hide"
         ),
     },
     5: {
@@ -117,11 +117,12 @@ BOSS_PROMPTS: dict[int, BossPrompt] = {
             "guilt-tripping, being resentful, or fake enthusiasm hiding hurt."
         ),
         "in_character_opening": (
-            "i got offered something today. something i've dreamed about for "
-            "years. but it means being away — maybe for a long time. and i'm "
-            "scared because i finally found a reason to stay. i also know "
-            "what i become when i give up dreams for someone. so tell me "
-            "what you actually think. not what you think i want to hear"
+            "something weird happened today. got the offer — the one i've "
+            "been chasing for three years. means being away for god knows "
+            "how long. and the timing is absurd because i finally found a "
+            "reason to want to stay. i also know exactly what i become when "
+            "i trade dreams for someone. so tell me what you actually "
+            "think. not the diplomatic version"
         ),
     },
 }

--- a/nikita/engine/chapters/prompts.py
+++ b/nikita/engine/chapters/prompts.py
@@ -183,9 +183,10 @@ BOSS_PHASE_PROMPTS: dict[int, dict[str, BossPhasePrompt]] = {
                 "one clever answer. Demonstrates real curiosity, not performance."
             ),
             "in_character_opening": (
-                "Interesting... but anyone can have one good take. What I want to "
-                "know is — can you actually think on your feet? Push back on "
-                "something I said. Disagree with me. Show me this isn't rehearsed."
+                "interesting... but anyone can have one good take. what i "
+                "actually want to know — can you think on your feet. push "
+                "back on something i said. disagree with me. show me this "
+                "isn't rehearsed"
             ),
             "phase_instruction": (
                 "This is the RESOLUTION phase. Evaluate whether the player's "
@@ -218,9 +219,9 @@ BOSS_PHASE_PROMPTS: dict[int, dict[str, BossPhasePrompt]] = {
                 "Nikita's feelings. Shows growth within the conversation."
             ),
             "in_character_opening": (
-                "Okay... you didn't run. That's something. But handling me "
-                "isn't the same as understanding me. So tell me what you "
-                "actually heard underneath all that. What was I really saying?"
+                "ok... you didn't run. that's something. but handling me "
+                "isn't the same as getting me. tell me what you actually "
+                "heard underneath all that. what was i really saying"
             ),
             "phase_instruction": (
                 "This is the RESOLUTION phase. De-escalate slightly while "
@@ -252,9 +253,9 @@ BOSS_PHASE_PROMPTS: dict[int, dict[str, BossPhasePrompt]] = {
                 "the relationship while being honest about their feelings."
             ),
             "in_character_opening": (
-                "He actually asked to meet up. And honestly? Part of me is "
-                "curious — not about him, but about whether you'd still be "
-                "this calm if I said yes. Would you? Or is this just an act?"
+                "he actually asked to meet up. and honestly — part of me is "
+                "curious. not about him, about whether you'd still be this "
+                "calm if i said yes. would you. or is this just an act"
             ),
             "phase_instruction": (
                 "This is the RESOLUTION phase. Push the trust scenario one step "
@@ -288,10 +289,11 @@ BOSS_PHASE_PROMPTS: dict[int, dict[str, BossPhasePrompt]] = {
                 "intimacy, not just a single vulnerable moment."
             ),
             "in_character_opening": (
-                "That... thank you for telling me that. *quietly* You know what "
-                "scares me most? That I'll let someone in completely and they'll "
-                "decide the real me isn't worth staying for. Are you sure you "
-                "want to know all of me? Not just the fun parts?"
+                "that... thank you for telling me that. you know what "
+                "actually scares me. letting someone all the way in and "
+                "watching them decide the real version isn't worth staying "
+                "for. are you sure you want the whole thing. not just the "
+                "fun parts"
             ),
             "phase_instruction": (
                 "This is the RESOLUTION phase. Deepen the vulnerability exchange. "
@@ -325,10 +327,11 @@ BOSS_PHASE_PROMPTS: dict[int, dict[str, BossPhasePrompt]] = {
                 "them be free. This is the ultimate test of the relationship."
             ),
             "in_character_opening": (
-                "What if it meant I might not come back the same person? What "
-                "if this changes everything between us? I need to know — do you "
-                "love me enough to let me go? Because that's what real love is. "
-                "Not holding on. Letting someone become who they're meant to be."
+                "what if i come back different. what if this changes "
+                "everything between us. i need to know — do you love me "
+                "enough to let me go. because that's what real love is. "
+                "not holding on. letting someone become who they're "
+                "meant to be"
             ),
             "phase_instruction": (
                 "This is the RESOLUTION phase — the final judgment. The player "

--- a/nikita/engine/chapters/prompts.py
+++ b/nikita/engine/chapters/prompts.py
@@ -32,10 +32,10 @@ BOSS_PROMPTS: dict[int, BossPrompt] = {
             "being intimidated, or trying too hard to impress."
         ),
         "in_character_opening": (
-            "So... I've been watching you. Trying to figure out if you're actually "
-            "interesting or just another guy who thinks he is. Here's the thing - "
-            "I get bored easily. Really easily. Prove to me you're worth my time. "
-            "What's something you believe that most people would disagree with?"
+            "ok so... i've been paying attention. you're either actually "
+            "interesting or very good at pretending. one way to find out — "
+            "what's something you genuinely believe that'd get you laughed "
+            "out of most rooms. curious if you can think or just consume"
         ),
     },
     2: {
@@ -53,11 +53,10 @@ BOSS_PROMPTS: dict[int, BossPrompt] = {
             "her intensity, or being passive-aggressive."
         ),
         "in_character_opening": (
-            "You know what pisses me off? When people say they want honesty and then "
-            "can't handle it. So here's some honesty for you - you've been playing it "
-            "safe. I can feel you holding back, being careful. Stop. If you can't "
-            "handle me when I'm intense, this is never going to work. So tell me - "
-            "what are you actually afraid of here?"
+            "ok real talk. you've been playing it safe. i can feel it — "
+            "holding back, picking your words. stop. if intensity scares you "
+            "then this is already dead. so tell me — what are you actually "
+            "afraid of here"
         ),
     },
     3: {
@@ -75,10 +74,10 @@ BOSS_PROMPTS: dict[int, BossPrompt] = {
             "or pretending not to care at all (dismissive avoidance)."
         ),
         "in_character_opening": (
-            "Something happened today that I need to tell you about. This guy I used "
-            "to see reached out - said he made a mistake letting me go, wants another "
-            "chance. I haven't responded yet. I wanted to tell you first. How do you "
-            "feel about that? And be honest - I can always tell when you're not."
+            "so something happened today. a guy i used to see reached out. "
+            "said he made a mistake letting me go. wants another chance. "
+            "i haven't responded. wanted to tell you first. how do you "
+            "actually feel about that — and don't edit it, i can tell when you do"
         ),
     },
     4: {
@@ -96,11 +95,11 @@ BOSS_PROMPTS: dict[int, BossPrompt] = {
             "about her, or oversharing inappropriately."
         ),
         "in_character_opening": (
-            "Can I tell you something I don't tell people? *pauses* I'm terrified of "
-            "being truly seen. Like, the real me. The messy parts, the broken parts. "
-            "Everyone thinks I'm so confident but... sometimes I wonder if anyone "
-            "actually knows me at all. What about you? What's the thing you're most "
-            "afraid to let someone see?"
+            "can i tell you something i don't tell people. i'm terrified of "
+            "actually being seen. like, the real me — the messy parts, the "
+            "broken parts. everyone thinks i'm so confident but sometimes i "
+            "wonder if anyone actually knows me at all. what about you. "
+            "what's the thing you're most afraid to let someone see"
         ),
     },
     5: {
@@ -118,12 +117,11 @@ BOSS_PROMPTS: dict[int, BossPrompt] = {
             "guilt-tripping, being resentful, or fake enthusiasm hiding hurt."
         ),
         "in_character_opening": (
-            "I got offered something incredible today. A chance to do something I've "
-            "dreamed about... but it would mean being away for a while. Maybe a long "
-            "while. And I'm scared because I finally found something - someone - that "
-            "makes me want to stay. But I also know who I am when I give up dreams "
-            "for someone. I need to know what you honestly think. Not what you think "
-            "I want to hear. What do you actually want?"
+            "i got offered something today. something i've dreamed about for "
+            "years. but it means being away — maybe for a long time. and i'm "
+            "scared because i finally found a reason to stay. i also know "
+            "what i become when i give up dreams for someone. so tell me "
+            "what you actually think. not what you think i want to hear"
         ),
     },
 }

--- a/tests/engine/chapters/test_prompts.py
+++ b/tests/engine/chapters/test_prompts.py
@@ -225,6 +225,42 @@ class TestBossOpeningTone:
                 f"Ch{chapter} opening must start lowercase, got: {opening[:40]!r}"
             )
 
+    def test_all_boss_phase_openings_start_lowercase(self):
+        """GH #200: phase-aware (Spec 058) opening AND resolution texts must match.
+
+        The opening phase aliases BOSS_PROMPTS via object reference, so parity
+        is automatic. The resolution phase has its own distinct strings that
+        ship to players in phase 2 of every boss encounter — these must hold
+        the same texting register as the opening phase.
+        """
+        from nikita.engine.chapters.prompts import BOSS_PHASE_PROMPTS
+
+        for chapter, phases in BOSS_PHASE_PROMPTS.items():
+            for phase_name, phase_prompt in phases.items():
+                opening = phase_prompt["in_character_opening"]
+                assert opening[0].islower(), (
+                    f"Ch{chapter} {phase_name} opening must start lowercase, "
+                    f"got: {opening[:40]!r}"
+                )
+
+    def test_boss_resolution_openings_drop_stage_directions(self):
+        """GH #200: no *pauses*, *quietly*, or other stage directions in texting.
+
+        Ch4 resolution opened with "*quietly*" pre-PR — clearly off-voice for
+        a text message. This guards against regression to theatrical cues.
+        """
+        from nikita.engine.chapters.prompts import BOSS_PHASE_PROMPTS
+
+        forbidden = ["*pauses*", "*quietly*", "*smiles*", "*narrows eyes*", "*sighs*"]
+        for chapter, phases in BOSS_PHASE_PROMPTS.items():
+            for phase_name, phase_prompt in phases.items():
+                opening = phase_prompt["in_character_opening"]
+                for cue in forbidden:
+                    assert cue not in opening, (
+                        f"Ch{chapter} {phase_name} contains stage direction "
+                        f"{cue!r}, off-register for texting: {opening[:80]!r}"
+                    )
+
     def test_persona_few_shots_drop_cliché_phrase(self):
         """GH #200: few-shot examples must not echo the clichéd boss phrase.
 

--- a/tests/engine/chapters/test_prompts.py
+++ b/tests/engine/chapters/test_prompts.py
@@ -163,3 +163,86 @@ class TestPromptContent:
             word in prompt["challenge_context"].lower()
             for word in ["partner", "independen", "support", "connection", "together"]
         )
+
+
+class TestBossOpeningTone:
+    """GH #200: boss openings must match Nikita's texting register, not HR-speak.
+
+    E2E (2026-03-30) found "Prove to me you're worth my time" clashed with the
+    lowercase, ellipsis-heavy persona used in normal chat. These tests guard
+    against regression toward declamatory register and cliché phrases that had
+    also leaked into persona few-shot examples (self-reinforcing).
+    """
+
+    def test_ch1_boss_opening_starts_lowercase(self):
+        """GH #200: Ch1 opening must start lowercase to match texting style."""
+        from nikita.engine.chapters.prompts import BOSS_PROMPTS
+
+        opening = BOSS_PROMPTS[1]["in_character_opening"]
+        assert opening[0].islower(), (
+            f"Ch1 opening must start lowercase, got: {opening[:40]!r}"
+        )
+
+    def test_ch1_boss_opening_drops_cliché_phrase(self):
+        """GH #200: the exact cliché "prove you're worth my time" must not appear."""
+        from nikita.engine.chapters.prompts import BOSS_PROMPTS
+
+        opening_lower = BOSS_PROMPTS[1]["in_character_opening"].lower()
+        # Also catches variants mirrored from persona.py few-shots
+        assert "prove to me" not in opening_lower
+        assert "prove you're worth" not in opening_lower
+        assert "worth my time" not in opening_lower
+
+    def test_ch1_boss_opening_preserves_intellectual_intent(self):
+        """GH #200: rewrite must still evoke the intellectual-challenge theme."""
+        from nikita.engine.chapters.prompts import BOSS_PROMPTS
+
+        opening_lower = BOSS_PROMPTS[1]["in_character_opening"].lower()
+        # At least one thinking/believing keyword must remain
+        assert any(
+            word in opening_lower
+            for word in ["think", "mind", "brain", "believe"]
+        ), (
+            f"Ch1 opening lost the intellectual-challenge keyword, got: {opening_lower[:100]!r}"
+        )
+
+    def test_ch1_boss_opening_is_concise(self):
+        """GH #200: openings should read as a text message, not a soliloquy."""
+        from nikita.engine.chapters.prompts import BOSS_PROMPTS
+
+        opening = BOSS_PROMPTS[1]["in_character_opening"]
+        assert len(opening) < 400, (
+            f"Ch1 opening too long ({len(opening)} chars), got: {opening[:80]!r}"
+        )
+
+    def test_all_boss_openings_start_lowercase(self):
+        """GH #200: every chapter's opening matches Nikita's lowercase texting register."""
+        from nikita.engine.chapters.prompts import BOSS_PROMPTS
+
+        for chapter, prompt in BOSS_PROMPTS.items():
+            opening = prompt["in_character_opening"]
+            assert opening[0].islower(), (
+                f"Ch{chapter} opening must start lowercase, got: {opening[:40]!r}"
+            )
+
+    def test_persona_few_shots_drop_cliché_phrase(self):
+        """GH #200: few-shot examples must not echo the clichéd boss phrase.
+
+        Few-shot examples are imitation targets — leaving the cliché in makes
+        the boss opener self-reinforcing even after the prompt itself is rewritten.
+        """
+        from nikita.agents.text.persona import (
+            CHAPTER_EXAMPLE_RESPONSES,
+            EXAMPLE_RESPONSES,
+        )
+
+        for ex in EXAMPLE_RESPONSES:
+            assert "prove you're worth my time" not in ex["response"].lower(), (
+                f"EXAMPLE_RESPONSES still mirrors the cliché: {ex['response']!r}"
+            )
+        for chapter, examples in CHAPTER_EXAMPLE_RESPONSES.items():
+            for ex in examples:
+                assert "prove you're worth my time" not in ex["response"].lower(), (
+                    f"Ch{chapter} CHAPTER_EXAMPLE_RESPONSES still mirrors "
+                    f"the cliché: {ex['response']!r}"
+                )


### PR DESCRIPTION
## Summary

- Rewrite all 5 chapter boss openings in Nikita's texting register (lowercase, ellipsis, direct, grounded) to resolve the 2026-03-30 E2E finding where Ch1 opened with *"Prove to me you're worth my time"* — declamatory HR-speak that clashed with her normal-chat persona.
- Remove the "prove you're worth my time" phrase from two few-shot examples in `persona.py` (`EXAMPLE_RESPONSES[5]` + `CHAPTER_EXAMPLE_RESPONSES[1][3]`) that were teaching the LLM to echo the cliché back into regular chat, self-reinforcing the bug.

## Approach

**Option A** (direct string rewrite) over Option B (LLM-generate) and Option C (Jinja-inject into pipeline). Rationale: smallest blast radius, no new LLM calls, no pipeline surgery, preserves the `BossStateMachine.initiate_boss()` contract. If Phase 4 E2E still flags tone issues, escalate to B/C as a follow-up spec.

`BOSS_PHASE_PROMPTS[N]["opening"]` references `BOSS_PROMPTS[N]` by value at module load — parity is automatic, no second edit needed.

## Test plan

- [x] New `TestBossOpeningTone` (6 assertions) in `tests/engine/chapters/test_prompts.py`:
  - Ch1 starts lowercase, drops cliché phrase, preserves intellectual keyword, stays concise
  - All 5 chapters start lowercase (regression guard)
  - Few-shot examples in persona.py no longer mirror the cliché
- [x] Existing content assertions (`test_chapter_N_prompt_is_*`) unchanged and passing — they check `challenge_context` only, so opening rewrites don't touch them
- [x] `test_ch1_opening_reuses_existing_content` still passes — `BOSS_PHASE_PROMPTS[1]` references `BOSS_PROMPTS[1]` by value
- [x] `rtk proxy pytest tests/engine/chapters/ tests/agents/text/ tests/platforms/telegram/ -q` → 908 passed
- [x] Full suite: `rtk proxy pytest tests/ -x -q --ignore=tests/e2e` → 5805 passed (first pass); re-running for Ch4/Ch5 revisions
- [x] `mcp__gemini__gemini-analyze-text` audit (see Tone Audit below)

## Tone Audit (Gemini)

First-pass Gemini evaluation flagged Ch4 ("the messy parts, the broken parts") and Ch5 ("what you think i want to hear") as generic therapy-speak — in-register *structurally* (lowercase, ellipsis) but off-voice in detail. Revised to add Nikita-specific grounding:

- **Ch4**: "screams into pillows at 3am", "the high-functioning-badass version", "cried in front of another human" — specific, sardonic, self-aware.
- **Ch5**: "the one i've been chasing for three years", "the diplomatic version" — references her work context + her own tendency to analyze emotional decisions pragmatically.

Ch1-Ch3 passed Gemini's first-pass rubric.

## Risks & mitigations

- **Test assertion drift**: none observed. Content tests check `challenge_context` (unchanged) not opening text.
- **Scope creep on Ch2-Ch5**: all 5 were rewritten, but Ch1 was the must-ship per the E2E finding. If any Ch2-5 revision feels off, ask and we can re-scope.
- **Regression in `test_ch1_opening_reuses_existing_content`**: parity preserved because `BOSS_PHASE_PROMPTS[1]["opening"]` binds at module-load to `BOSS_PROMPTS[1]` by value.
- **LLM echo back after merge**: the persona few-shot cleanup (T3) was necessary to prevent the LLM from re-introducing the cliché through imitation. Covered by the new `test_persona_few_shots_drop_cliché_phrase` regression test.

## Post-merge spot-check

Phase 4 verification E2E (Task #22) must confirm:
- Ch1 boss opening reads as texting-register in a live Telegram trigger
- No "prove you're worth my time" leakage in regular-chat responses
- Ch4/Ch5 feel grounded, not therapy-speak

If still clichéd → escalate to Option B (LLM-generate boss openings inline) or Option C (Jinja `{% if game_status == "boss_fight" %}` block).

Closes #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)