### PR TITLE
fix(voice): pre-call webhook auth — header secret instead of HMAC (#258)

### DIFF
--- a/docs/reference/elevenlabs-configuration.md
+++ b/docs/reference/elevenlabs-configuration.md
@@ -81,12 +81,12 @@ Configure via: `python scripts/configure_meta_nikita_tools.py`
 
 ### Endpoints
 
-| Webhook | URL | Purpose |
-|---------|-----|---------|
-| Pre-call | `{BACKEND_URL}/api/v1/voice/pre-call` | Lookup user by phone, return availability |
-| Server Tool | `{BACKEND_URL}/api/v1/voice/server-tool` | Handle tool calls during conversation |
-| Post-call | `{BACKEND_URL}/api/v1/voice/webhook` | Store transcript, trigger post-processing |
-| Onboarding Tool | `{BACKEND_URL}/api/v1/onboarding/server-tool` | Handle onboarding tool calls |
+| Webhook | URL | Purpose | Auth Type |
+|---------|-----|---------|-----------|
+| Pre-call | `{BACKEND_URL}/api/v1/voice/pre-call` | Lookup user by phone, return availability | Header secret (`x-webhook-secret`) |
+| Server Tool | `{BACKEND_URL}/api/v1/voice/server-tool` | Handle tool calls during conversation | Signed token query param |
+| Post-call | `{BACKEND_URL}/api/v1/voice/webhook` | Store transcript, trigger post-processing | HMAC (`elevenlabs-signature`) |
+| Onboarding Tool | `{BACKEND_URL}/api/v1/onboarding/server-tool` | Handle onboarding tool calls | Signed token query param |
 
 ### Current Backend URL
 
@@ -95,6 +95,36 @@ https://nikita-api-1040094048579.us-central1.run.app
 ```
 
 > **Note**: Update scripts when Cloud Run URL changes.
+
+### Pre-call Webhook Auth (GH #258, ElevenLabs Twilio personalization)
+
+Per [ElevenLabs Twilio personalization docs](https://elevenlabs.io/docs/eleven-agents/customization/personalization/twilio-personalization#security),
+**pre-call webhooks do NOT send the `elevenlabs-signature` HMAC header** — only `post_call_transcription`
+webhooks do. Pre-call auth is via a **custom header secret** configured in the dashboard / workspace
+secrets manager.
+
+**Required dashboard config** (one-time, per environment):
+1. ElevenLabs Dashboard → Agents → Settings → **Workspace secrets**: create a secret named
+   `nikita_precall_webhook_secret` with a strong random value. Document the value in 1Password
+   under "Nikita / ElevenLabs / pre-call webhook secret".
+2. ElevenLabs Dashboard → Agents → **Nikita** (`agent_5801kdr3xza0fxfr2q3hdgbjrh9y`) → Security tab
+   → Enable **"Fetch conversation initiation data for inbound Twilio calls"** with webhook URL
+   `{BACKEND_URL}/api/v1/voice/pre-call`. Add header **`x-webhook-secret`** with value referencing
+   the workspace secret created above.
+3. **Google Secret Manager**: ensure `nikita-elevenlabs-webhook-secret` (project `gcp-transcribe-test`)
+   contains the SAME value as the dashboard workspace secret. Update via:
+   ```bash
+   echo -n "<value>" | gcloud secrets versions add nikita-elevenlabs-webhook-secret \
+     --project=gcp-transcribe-test --data-file=-
+   ```
+4. Redeploy Cloud Run if needed (env vars are pulled fresh on each request).
+
+**Code reference**: `nikita/api/routes/voice.py:968` reads the `x-webhook-secret` header and
+validates with `hmac.compare_digest` against `settings.elevenlabs_webhook_secret`. If the secret
+is unset (local/dev), auth is skipped — production MUST set it.
+
+**Test coverage**: `tests/api/routes/test_voice.py::TestPreCallWebhookAuth` covers no-header,
+valid-header, invalid-header, and no-secret-configured paths.
 
 ## Development Workflow
 

--- a/nikita/api/routes/voice.py
+++ b/nikita/api/routes/voice.py
@@ -7,6 +7,7 @@ Implements:
 Part of Spec 007: Voice Agent (ElevenLabs Conversational AI 2.0).
 """
 
+import hmac
 import json
 import logging
 from decimal import Decimal
@@ -967,37 +968,40 @@ class PreCallResponse(BaseModel):
 )
 async def handle_pre_call(
     request: Request,
-    elevenlabs_signature: str | None = Header(default=None, alias="elevenlabs-signature"),
+    webhook_secret_header: str | None = Header(default=None, alias="x-webhook-secret"),
     _rl=Depends(voice_rate_limit),
 ) -> PreCallResponse:
     """
-    Handle pre-call webhook (T078).
+    Handle pre-call webhook (T078, GH #258 auth fix).
 
     AC-T078.1: Handles Twilio-ElevenLabs pre-call
     AC-T078.2: Returns dynamic_variables and conversation_config_override
     AC-T078.3: Returns empty dynamic_variables for unknown callers
-    AC-T078.4: Validates HMAC signature (SEC-006)
+    AC-T078.4: Validates header secret (NOT HMAC — see auth note below)
+
+    Auth note (GH #258, ElevenLabs Twilio personalization docs):
+    Pre-call webhooks do NOT send the elevenlabs-signature HMAC header
+    (only post_call_transcription webhooks do). Pre-call auth uses a
+    custom header secret configured in the ElevenLabs dashboard via the
+    workspace secrets manager. The dashboard sends `x-webhook-secret`
+    with the value matching settings.elevenlabs_webhook_secret.
+    Reference: https://elevenlabs.io/docs/eleven-agents/customization/personalization/twilio-personalization#security
     """
-    # Read raw body once (needed for both HMAC verification and parsing)
     body = await request.body()
     payload = body.decode("utf-8")
 
-    # SEC-006: Validate HMAC signature (same pattern as post-call webhook)
+    # GH #258: Validate header secret per ElevenLabs Twilio personalization docs
     settings = get_settings()
     if settings.elevenlabs_webhook_secret:
-        if not elevenlabs_signature:
-            logger.warning("[PRE-CALL] Missing elevenlabs-signature header")
-            raise HTTPException(status_code=401, detail="Missing signature header")
-
-        try:
-            if not verify_elevenlabs_signature(
-                payload, elevenlabs_signature, settings.elevenlabs_webhook_secret
-            ):
-                logger.warning("[PRE-CALL] Invalid HMAC signature")
-                raise HTTPException(status_code=401, detail="Invalid signature")
-        except ValueError as e:
-            logger.warning(f"[PRE-CALL] Signature validation failed: {e}")
-            raise HTTPException(status_code=401, detail=str(e))
+        if not webhook_secret_header:
+            logger.warning("[PRE-CALL] Missing x-webhook-secret header")
+            raise HTTPException(status_code=401, detail="Missing webhook secret header")
+        # Constant-time compare to avoid timing-attack side-channels
+        if not hmac.compare_digest(
+            webhook_secret_header, settings.elevenlabs_webhook_secret
+        ):
+            logger.warning("[PRE-CALL] Invalid x-webhook-secret value")
+            raise HTTPException(status_code=401, detail="Invalid webhook secret")
 
     # Parse body into PreCallRequest model
     try:

--- a/nikita/api/routes/voice.py
+++ b/nikita/api/routes/voice.py
@@ -942,7 +942,7 @@ class PreCallResponse(BaseModel):
     "/pre-call",
     response_model=PreCallResponse,
     responses={
-        401: {"model": ErrorResponse, "description": "Invalid signature"},
+        401: {"model": ErrorResponse, "description": "Invalid or missing webhook secret"},
         500: {"model": ErrorResponse, "description": "Server error"},
     },
     summary="Handle Pre-Call Webhook",
@@ -963,7 +963,7 @@ class PreCallResponse(BaseModel):
     AC-T078.1: POST /api/v1/voice/pre-call handles Twilio-ElevenLabs pre-call
     AC-T078.2: Returns dynamic_variables and conversation_config_override
     AC-T078.3: Returns empty dynamic_variables for unknown callers (call still accepted)
-    AC-T078.4: Validates HMAC signature
+    AC-T078.4: Validates x-webhook-secret header (NOT HMAC — see GH #258)
     """,
 )
 async def handle_pre_call(

--- a/nikita/config/settings.py
+++ b/nikita/config/settings.py
@@ -67,7 +67,7 @@ class Settings(BaseSettings):
     )
     elevenlabs_webhook_secret: str | None = Field(
         default=None,
-        description="ElevenLabs webhook secret for HMAC verification (FR-026)",
+        description="ElevenLabs webhook secret: x-webhook-secret header for pre-call auth (GH #258); HMAC for post-call (FR-026)",
     )
     elevenlabs_meta_nikita_agent_id: str | None = Field(
         default=None,

--- a/tests/api/routes/test_voice.py
+++ b/tests/api/routes/test_voice.py
@@ -906,3 +906,133 @@ class TestPreCallWebhook:
 
         # NO extra fields that could confuse ElevenLabs
         assert set(data.keys()) == {"type", "dynamic_variables", "conversation_config_override"}
+
+
+class TestPreCallWebhookAuth:
+    """Tests for pre-call webhook authentication (GH #258).
+
+    Pre-call webhooks (Twilio personalization) authenticate via a custom
+    header secret per ElevenLabs docs:
+    https://elevenlabs.io/docs/eleven-agents/customization/personalization/twilio-personalization#security
+
+    Unlike post_call_transcription webhooks, pre-call webhooks do NOT send
+    the elevenlabs-signature HMAC header. Auth is via a header secret
+    configured in the ElevenLabs dashboard / workspace secrets manager.
+
+    Regression: commit 8247868 (2026-04-07) enforced HMAC on pre-call,
+    which ElevenLabs never sends → all inbound calls returned 401 → hangup.
+    """
+
+    SHARED_SECRET = "test-pre-call-secret-abc123"
+
+    @pytest.fixture
+    def auth_settings(self):
+        """Settings fixture with webhook secret set (production-like)."""
+        from nikita.config.settings import get_settings
+
+        get_settings.cache_clear()
+        with patch("nikita.api.routes.voice.get_settings") as mock_get:
+            mock_settings = MagicMock()
+            mock_settings.elevenlabs_webhook_secret = self.SHARED_SECRET
+            mock_get.return_value = mock_settings
+            yield mock_settings
+        get_settings.cache_clear()
+
+    @pytest.fixture
+    def mock_handler_success(self):
+        """Default successful handler response."""
+        with patch("nikita.agents.voice.inbound.get_inbound_handler") as mock_get_handler:
+            mock_handler = AsyncMock()
+            mock_handler.handle_incoming_call.return_value = {
+                "accept_call": True,
+                "dynamic_variables": {
+                    "user_name": "TestUser",
+                    "chapter": "1",
+                    "relationship_score": "0",
+                    "engagement_state": "UNKNOWN",
+                    "nikita_mood": "neutral",
+                    "nikita_energy": "low",
+                    "time_of_day": "afternoon",
+                    "recent_topics": "",
+                    "open_threads": "",
+                },
+                "conversation_config_override": {"agent": {"first_message": "Hi"}},
+            }
+            mock_get_handler.return_value = mock_handler
+            yield mock_handler
+
+    def _payload(self):
+        return {
+            "caller_id": "+41787950009",
+            "agent_id": "agent_test123",
+            "called_number": "+41445056044",
+            "call_sid": "CA-auth-test",
+        }
+
+    def test_pre_call_no_header_returns_401_when_secret_set(
+        self, client, auth_settings, mock_handler_success
+    ):
+        """When webhook secret is configured, missing header → 401.
+
+        This is the regression test for GH #258: previously the code looked
+        for elevenlabs-signature (HMAC) which ElevenLabs never sends for
+        pre-call. Now we expect a x-webhook-secret header.
+        """
+        response = client.post("/api/v1/voice/pre-call", json=self._payload())
+        assert response.status_code == 401
+        assert "secret" in response.json()["detail"].lower()
+        # Handler must NOT have been called when auth fails
+        mock_handler_success.handle_incoming_call.assert_not_awaited()
+
+    def test_pre_call_valid_header_returns_200(
+        self, client, auth_settings, mock_handler_success
+    ):
+        """Valid x-webhook-secret header → 200 with dynamic_variables.
+
+        This is the happy path that ElevenLabs will exercise in production
+        once the dashboard webhook is configured to send the header.
+        """
+        response = client.post(
+            "/api/v1/voice/pre-call",
+            json=self._payload(),
+            headers={"x-webhook-secret": self.SHARED_SECRET},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["type"] == "conversation_initiation_client_data"
+        assert data["dynamic_variables"]["user_name"] == "TestUser"
+        mock_handler_success.handle_incoming_call.assert_awaited_once_with("+41787950009")
+
+    def test_pre_call_invalid_header_returns_401(
+        self, client, auth_settings, mock_handler_success
+    ):
+        """Wrong x-webhook-secret value → 401 (constant-time compare)."""
+        response = client.post(
+            "/api/v1/voice/pre-call",
+            json=self._payload(),
+            headers={"x-webhook-secret": "wrong-value"},
+        )
+        assert response.status_code == 401
+        assert "secret" in response.json()["detail"].lower()
+        mock_handler_success.handle_incoming_call.assert_not_awaited()
+
+    def test_pre_call_no_secret_configured_skips_check(
+        self, client, mock_handler_success
+    ):
+        """When elevenlabs_webhook_secret is unset, auth is skipped.
+
+        Preserves existing behavior for local/dev environments where the
+        secret may not be configured. Production MUST set the secret.
+        """
+        from nikita.config.settings import get_settings
+
+        get_settings.cache_clear()
+        with patch("nikita.api.routes.voice.get_settings") as mock_get:
+            mock_settings = MagicMock()
+            mock_settings.elevenlabs_webhook_secret = None
+            mock_get.return_value = mock_settings
+            response = client.post("/api/v1/voice/pre-call", json=self._payload())
+        get_settings.cache_clear()
+
+        assert response.status_code == 200
+        mock_handler_success.handle_incoming_call.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Replaces incorrect HMAC enforcement on pre-call webhook with a header-secret check per ElevenLabs Twilio personalization docs (`x-webhook-secret`)
- Closes the regression introduced in commit 8247868 (2026-04-07) that caused 100% inbound-call hangups in production from 2026-04-07 onward
- Adds 4 auth tests (`TestPreCallWebhookAuth`) closing the "tests that don't test" gap that hid the bug

## Root cause
Per [ElevenLabs Twilio personalization docs](https://elevenlabs.io/docs/eleven-agents/customization/personalization/twilio-personalization#security), pre-call webhooks **do not** send the `elevenlabs-signature` HMAC header — only `post_call_transcription` webhooks do. The `nikita/api/routes/voice.py:987` code enforced HMAC ("same pattern as post-call webhook" — wrong assumption), so every pre-call returned 401 → ElevenLabs hung up.

Cloud Run log evidence:
```
2026-04-13T10:33:57Z  POST /api/v1/voice/pre-call HTTP/1.1  401 Unauthorized
2026-04-13T10:33:57Z  WARNING  [PRE-CALL] Missing elevenlabs-signature header
2026-04-13T10:36:01Z  POST /api/v1/voice/pre-call HTTP/1.1  401 Unauthorized
2026-04-13T10:36:01Z  WARNING  [PRE-CALL] Missing elevenlabs-signature header
```

Last successful call before regression: 2026-03-16 (26s, 5 messages).

## Required follow-up (non-code, after merge)
1. ElevenLabs Dashboard → Workspace secrets: create `nikita_precall_webhook_secret` with the same value stored in Google Secret Manager (`nikita-elevenlabs-webhook-secret` in `gcp-transcribe-test`)
2. ElevenLabs Dashboard → Nikita agent (`agent_5801kdr3xza0fxfr2q3hdgbjrh9y`) → Security → enable inbound personalization webhook with header `x-webhook-secret` referencing the workspace secret
3. Verify test inbound call to `+41445056044` connects (no longer hangs up)

## Test plan
- [ ] CI: 493 voice/onboarding tests pass on master merge
- [ ] Manual: dial `+41445056044` after dashboard config — pre-call returns 200, call connects, opening first_message plays
- [ ] Cloud Run logs show `[PRE-CALL] Incoming request: caller_id=…` (not 401)
- [ ] If user has phone in `users.phone`: dynamic_variables populated; if not: unknown-caller branch (still 200)

## Out of scope (separate work)
- Phone-at-onboarding capture in portal (Task #8 / spec 212)
- Doc drift between spec 033 (`+41787950009`) and real dashboard phone (`+41445056044`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)