### PR TITLE
chore(rules): auto-dispatch mandatory workflow steps to subagents

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,6 +100,7 @@ Types: research, analysis, decision, pattern, bug, integration
 
 - **Parallel agents for noisy tasks**: Delegate documentation reading, code exploration, screenshot analysis to subagents. Main context is precious.
 - **Subagents vs teams**: Default to subagents (Task tool). Use teams (TeamCreate) only when agents must share findings and build on each other's work.
+- **Auto-dispatch mandatory steps**: Workflow steps the rules already mandate — `/qa-review`, post-merge smoke tests, deployment verification, `/e2e`/dogfood runs, live HTTP probes, log-sweep verifications — must auto-dispatch to a fresh subagent. Do NOT ask the user for permission to run them; they are already authorized by the workflow. Two reasons: (a) keeps the noisy review/test transcript out of main context, (b) eliminates confirmation bias by getting fresh-context analysis. Spawn via `Agent` tool with a self-contained prompt that includes target PR/branch, success criteria, and the report shape expected back.
 - **Sub-agent anti-loop**: See `.claude/rules/parallel-agents.md` for execution constraints.
 - **Repository hygiene**: No empty directories, no placeholder files, no floating docs in root. Archive quality content, delete duplicates.
 - **File size enforcement**: Check `wc -l` on state files before session end. Prune if over limits (see root CLAUDE.md State Files table).

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -15,9 +15,10 @@ globs: ["**"]
 1. `git checkout -b {type}/{issue}-{description}`
 2. Implement with TDD (tests first)
 3. `gh pr create --title "..." --body "..."`
-4. `/qa-review --pr N` — fix issues, re-review, repeat until PASS
+4. `/qa-review --pr N` — auto-dispatch via Agent (subagent), iterate fix → re-review until 0 blocking + 0 important. Never prompt user for permission to run this — it is mandatory per these rules.
 5. Squash merge after QA PASS + CI green
 6. `gh issue close N --comment "Fixed in PR #M"`
+7. Post-merge verification (auto-dispatched subagent): smoke test the deployed change (curl probe, log sweep, or dogfood scenario as appropriate). Do not skip. Do not ask permission.
 
 ## Sprint/Batch Exceptions
 - Multiple issues MAY share a branch if tightly coupled (e.g., `test/146-147-boss-engagement`)


### PR DESCRIPTION
## Summary
- Codifies a workflow rule that emerged from PR #259 retro: mandatory steps (qa-review, post-merge smoke tests, e2e/dogfood runs) must auto-dispatch to fresh subagents. No user-permission prompt.
- Two reasons: (a) keep main-agent context clean, (b) eliminate confirmation bias by running review/test in a fresh context.

## Changes
- \`.claude/CLAUDE.md\` — new bullet under "Orchestration Rules" explaining the auto-dispatch pattern with rationale + tool guidance (Agent tool, self-contained prompt).
- \`.claude/rules/pr-workflow.md\` — step 4 rewritten to mandate subagent dispatch for /qa-review; step 7 added for post-merge smoke-test responsibility.

## Context
Session transcript: user explicitly asked for this after observing the main agent pause with "kick off \`/qa-review --pr 259\` next, or pause?" The rules already mandated qa-review; the pause was the bug. Now codified.

## Test plan
- [ ] Self-test: next session's PR flow should spawn qa-review subagent without prompting (verifiable by reviewing the session trace).
- [ ] Line counts preserved: \`.claude/CLAUDE.md\` ≤150 (now 123), \`.claude/rules/pr-workflow.md\` ≤80 (now 30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)