### PR TITLE
feat(portal): stub /privacy route for onboarding consent link

### DIFF
--- a/portal/src/__tests__/app/privacy/privacy.test.tsx
+++ b/portal/src/__tests__/app/privacy/privacy.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest"
+import { render, screen } from "@testing-library/react"
+import PrivacyPage from "@/app/privacy/page"
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+describe("PrivacyPage", () => {
+  it("renders the Privacy heading", () => {
+    render(<PrivacyPage />)
+    expect(screen.getByRole("heading", { name: "Privacy" })).toBeInTheDocument()
+  })
+
+  it("includes the mailto link for support@nikita.example", () => {
+    render(<PrivacyPage />)
+    const link = screen.getByRole("link", { name: "support@nikita.example" })
+    expect(link).toHaveAttribute("href", "mailto:support@nikita.example")
+  })
+
+  it("includes a back link pointing to /onboarding", () => {
+    render(<PrivacyPage />)
+    const backLink = screen.getByRole("link", { name: /onboarding/i })
+    expect(backLink).toHaveAttribute("href", "/onboarding")
+  })
+})

--- a/portal/src/app/privacy/page.tsx
+++ b/portal/src/app/privacy/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy — Nikita",
+  description: "How Nikita handles your information.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-16">
+      <h1 className="text-3xl font-semibold tracking-tight">Privacy</h1>
+      <p className="mt-6 text-muted-foreground">
+        Nikita collects only what&apos;s needed to play the game: your profile
+        answers, your phone number (used exclusively for her calls — never
+        shared, never sold, never used for marketing), and your conversation
+        history. The full privacy policy is still being drafted.
+      </p>
+      <p className="mt-4 text-muted-foreground">
+        Questions? Email{" "}
+        <a href="mailto:support@nikita.example" className="underline">
+          support@nikita.example
+        </a>
+        .
+      </p>
+      <Link
+        href="/onboarding"
+        className="mt-8 inline-block text-sm underline"
+      >
+        ← Back to onboarding
+      </Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Prereq PR for Spec 212 (phone capture in portal onboarding). Adds a minimal `/privacy` route so the upcoming consent-copy link in the phone-onboarding sub-card doesn't 404.

- `portal/src/app/privacy/page.tsx` — server component, static placeholder copy, Tailwind-only
- `portal/src/__tests__/app/privacy/privacy.test.tsx` — 3 RTL assertions (heading, mailto, back-link)

Includes the required promise phrase "never shared, never sold, never used for marketing" that the Spec 212 PR A consent copy will reference.

This is intentionally a STUB. Full GDPR/Swiss-FADP-compliant privacy policy is tracked separately.

## Test plan

- [x] \`npm run test:ci src/__tests__/app/privacy/privacy.test.tsx\` — 3/3 pass
- [ ] Post-merge: \`curl -I https://portal-phi-orcin.vercel.app/privacy\` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>