### PR TITLE
feat(onboarding): phone validation + persistence + normalize_phone refactor (Spec 212 PR B)

### DIFF
--- a/nikita/api/routes/onboarding.py
+++ b/nikita/api/routes/onboarding.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, 
 from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from nikita.api.dependencies.auth import get_current_user_id
@@ -664,6 +665,12 @@ class PortalProfileRequest(BaseModel):
     interest: str | None = Field(
         default=None, max_length=200, description="Primary interest (optional)"
     )
+    phone: str | None = Field(
+        default=None,
+        min_length=8,
+        max_length=20,
+        description="Player's phone number in E.164 format (optional, Spec 212)",
+    )
 
     @field_validator("location_city")
     @classmethod
@@ -677,6 +684,25 @@ class PortalProfileRequest(BaseModel):
         from nikita.onboarding.validation import validate_city
 
         return validate_city(v)
+
+    @field_validator("phone", mode="before")
+    @classmethod
+    def validate_phone_field(cls, v: str | None) -> str | None:
+        """Validate and normalize phone via the shared validation module (Spec 212 PR B).
+
+        Runs before Pydantic's own length checks (mode="before") so that
+        raw user input with formatting characters (spaces, dashes) is stripped
+        first. Returns None to signal "no phone" when input is blank or None —
+        this short-circuits Pydantic's min_length check intentionally.
+
+        Pydantic v2 converts any ``ValueError`` raised here into a
+        ``ValidationError`` (HTTP 422).
+        """
+        from nikita.onboarding.validation import validate_phone
+
+        if not v or not str(v).strip():
+            return None
+        return validate_phone(v)
 
 
 class PortalProfileResponse(BaseModel):
@@ -706,6 +732,21 @@ async def save_portal_profile(
     vice_repo: VicePreferenceRepository = Depends(get_vice_repo),
 ) -> PortalProfileResponse:
     """Save player profile submitted from portal onboarding."""
+    # Spec 212 PR B: Write phone BEFORE idempotency guard so that users who
+    # have already completed onboarding can still correct/add their phone number
+    # by resubmitting the profile form (phone-correction use case).
+    # IntegrityError must be caught HERE — before any broad except — to return
+    # a clean 409 instead of a 500, and to prevent _trigger_portal_handoff from
+    # being enqueued when the phone is already registered.
+    if body.phone:
+        try:
+            await user_repo.update_phone(user_id, body.phone)
+        except IntegrityError:
+            logger.warning(
+                "Phone already registered for user_id=%s (duplicate key)", user_id
+            )
+            raise HTTPException(status_code=409, detail="Phone already registered")
+
     try:
         # REL-004: Idempotency guard -- check onboarding_status first
         user = await user_repo.get(user_id)

--- a/nikita/db/repositories/user_repository.py
+++ b/nikita/db/repositories/user_repository.py
@@ -136,6 +136,30 @@ class UserRepository(BaseRepository[User]):
         result = await self.session.execute(stmt)
         return result.unique().scalar_one_or_none()
 
+    async def update_phone(self, user_id: UUID, phone: str) -> None:
+        """Update the user's phone number.
+
+        Fetches the user by ID and sets the phone column. Calls
+        ``session.flush()`` so the write is visible within the current
+        transaction before the session auto-commits.
+
+        Callers must handle ``sqlalchemy.exc.IntegrityError`` if a unique
+        constraint on ``users.phone`` is violated (i.e. the number is already
+        registered to another account).
+
+        Args:
+            user_id: The user's UUID.
+            phone: Normalized E.164 phone string (e.g. "+41791234567").
+
+        Raises:
+            IntegrityError: If the phone number already exists in ``users.phone``
+                (unique partial index ``uq_users_phone`` added in Spec 212 PR B).
+        """
+        user = await self.get(user_id)
+        if user:
+            user.phone = phone
+            await self.session.flush()
+
     async def create_with_metrics(
         self,
         user_id: UUID,

--- a/nikita/onboarding/validation.py
+++ b/nikita/onboarding/validation.py
@@ -11,6 +11,25 @@ from __future__ import annotations
 import re
 import unicodedata
 
+# Swiss default country code for phone normalization.
+# Value: "41" (Switzerland, ITU-T E.164 country code)
+# Prior values: none — new in Spec 212 PR B (GH #TBD, 2026-04-13)
+# Rationale: Nikita's primary user base is Swiss; bare 9/10-digit numbers
+#   without an explicit country prefix are inferred to be Swiss mobile numbers.
+#   E.g. "791234567" → "+41791234567", "0791234567" → "+41791234567".
+#   Non-Swiss numbers supplied with a leading "+" pass through unchanged.
+#   Changing this value requires updating the regression test in
+#   tests/onboarding/test_phone_validation.py::TestDefaultCountryCode
+#   and the tuning-constants comment above.
+DEFAULT_COUNTRY_CODE = "41"
+
+# E.164 pattern: "+" followed by 1-9 (no leading zero in country code),
+# then 7-19 more digits. Total: 8–20 characters including "+".
+_E164_REGEX = re.compile(r"^\+[1-9][0-9]{7,19}$")
+
+# Characters to strip before E.164 validation: spaces, dashes, parentheses.
+_STRIP_PATTERN = re.compile(r"[\s\-\(\)]")
+
 # Small blocklist of obvious placeholder inputs. Covers the concrete cases
 # that leaked through prior validation (issue #198 caught "hey"). Keep this
 # narrow: legitimate city names like "Nice" or "York" must still pass.
@@ -89,3 +108,54 @@ def validate_city(raw: str) -> str:
         raise ValueError("Please enter a real city name")
 
     return v
+
+
+def validate_phone(raw: str | None) -> str | None:
+    """Validate and normalize a phone number to E.164 format.
+
+    Returns None for empty/None input (phone is optional in portal profile).
+    Infers Swiss country code (+41) for bare 9-digit or 0-prefixed 10-digit
+    numbers. Non-Swiss numbers must include a leading "+".
+
+    Rules (applied in order):
+    1. Return None if ``raw`` is None or blank (empty/whitespace-only).
+    2. Strip formatting characters: spaces, dashes, parentheses.
+    3. Infer +41 for 9-digit bare numbers (e.g. "791234567" → "+41791234567").
+    4. Infer +41 for 10-digit leading-zero numbers (e.g. "0791234567" → "+41791234567").
+    5. Reject if result does not start with "+".
+    6. Reject if result does not match the E.164 regex.
+
+    Args:
+        raw: The raw user-supplied phone string, or None.
+
+    Returns:
+        Normalized E.164 phone string, or None if input is blank/None.
+
+    Raises:
+        ValueError: If the input is non-blank but fails E.164 validation.
+            The message is safe to surface in API error responses.
+    """
+    if not raw or not raw.strip():
+        return None
+
+    # Strip spaces, dashes, parentheses
+    cleaned = _STRIP_PATTERN.sub("", raw.strip())
+
+    # Swiss inference: bare 9-digit number (e.g. "791234567")
+    if re.match(r"^[1-9][0-9]{8}$", cleaned):
+        cleaned = f"+{DEFAULT_COUNTRY_CODE}{cleaned}"
+    # Swiss inference: 10-digit with leading zero (e.g. "0791234567")
+    elif re.match(r"^0[1-9][0-9]{8}$", cleaned):
+        cleaned = f"+{DEFAULT_COUNTRY_CODE}{cleaned[1:]}"
+
+    if not cleaned.startswith("+"):
+        raise ValueError(
+            f"Phone number must start with '+' and include a country code. Got: {cleaned!r}"
+        )
+
+    if not _E164_REGEX.match(cleaned):
+        raise ValueError(
+            f"Phone number is not valid E.164 format (e.g. +41791234567). Got: {cleaned!r}"
+        )
+
+    return cleaned

--- a/nikita/onboarding/voice_flow.py
+++ b/nikita/onboarding/voice_flow.py
@@ -149,15 +149,22 @@ class VoiceOnboardingFlow:
         return bool(PHONE_REGEX.match(cleaned))
 
     def normalize_phone(self, phone: str) -> str:
-        """Normalize phone number to E.164-ish format."""
-        cleaned = re.sub(r"[\s\-\(\)]", "", phone)
-        if not cleaned.startswith("+"):
-            # Assume US if no country code
-            if len(cleaned) == 10:
-                cleaned = "+1" + cleaned
-            elif len(cleaned) == 11 and cleaned.startswith("1"):
-                cleaned = "+" + cleaned
-        return cleaned
+        """Normalize phone number to E.164 format.
+
+        Delegates to the shared ``validate_phone`` utility (Spec 212 PR B).
+        Raises ``ValueError`` for invalid input. Returns the normalized string
+        for valid input (including Swiss-inferred numbers).
+
+        Note: Unlike the old US-biased implementation, this method infers +41
+        (Switzerland) for bare 9/10-digit numbers. See
+        ``nikita.onboarding.validation.validate_phone`` for full rules.
+        """
+        from nikita.onboarding.validation import validate_phone
+
+        result = validate_phone(phone)
+        if result is None:
+            raise ValueError(f"Phone number cannot be blank: {phone!r}")
+        return result
 
     async def process_phone_input(self, user_id: UUID, phone: str) -> dict[str, Any]:
         """
@@ -577,23 +584,27 @@ class VoiceOnboardingFlow:
                 logger.error(f"Error persisting onboarding state for {user_id}: {e}")
 
     async def _save_phone_number(self, user_id: UUID, phone: str) -> None:
-        """Save phone number to database."""
+        """Save phone number to database.
+
+        Spec 212 PR B: DB failures propagate to the caller instead of being
+        swallowed. This allows ``process_phone_input`` to surface errors and
+        avoids silent phone-save failures that would leave the user without
+        a registered number.
+        """
         if self._session is None:
             logger.info(f"No session: would save phone {phone} for user {user_id}")
             return
-        try:
-            from nikita.db.repositories.user_repository import UserRepository
 
-            repo = UserRepository(self._session)
-            user = await repo.get(user_id)
-            if user is not None:
-                user.phone = phone
-                await self._session.flush()
-                logger.info(f"Saved phone {phone} for user {user_id}")
-            else:
-                logger.warning(f"User {user_id} not found for phone save")
-        except Exception as e:
-            logger.error(f"Error saving phone for {user_id}: {e}")
+        from nikita.db.repositories.user_repository import UserRepository
+
+        repo = UserRepository(self._session)
+        user = await repo.get(user_id)
+        if user is not None:
+            user.phone = phone
+            await self._session.flush()
+            logger.info(f"Saved phone {phone} for user {user_id}")
+        else:
+            logger.warning(f"User {user_id} not found for phone save")
 
     async def _save_deferred_state(self, user_id: UUID) -> None:
         """Save deferred state to in-memory state + database.

--- a/tests/api/routes/test_onboarding_phone.py
+++ b/tests/api/routes/test_onboarding_phone.py
@@ -1,0 +1,214 @@
+"""Tests for phone field in POST /api/v1/onboarding/profile (Spec 212 PR B).
+
+Tests:
+- T011: Route-level phone validation and persistence
+
+Patching source module per testing.md rule:
+  nikita.db.repositories.user_repository.UserRepository
+
+Non-empty fixtures per testing.md rule (every repo-mock test has
+a sibling with non-empty data). No zero-assertion test bodies.
+
+Failing until T015/T016/T017 (implementation) are committed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+
+USER_ID = UUID("550e8400-e29b-41d4-a716-446655440000")
+
+# Use an explicit test-only Swiss phone constant
+TEST_PHONE = "+41791234567"
+
+_VALID_BODY = {
+    "location_city": "Zurich",
+    "social_scene": "techno",
+    "drug_tolerance": 3,
+    "phone": TEST_PHONE,
+}
+
+_BODY_NO_PHONE = {
+    "location_city": "Zurich",
+    "social_scene": "techno",
+    "drug_tolerance": 3,
+}
+
+
+def _make_app_and_client(mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo):
+    """Build a test FastAPI app with overridden dependencies."""
+    from nikita.api.dependencies.auth import get_current_user_id
+    from nikita.api.routes.onboarding import (
+        get_profile_repo,
+        get_user_repo,
+        get_vice_repo,
+        router,
+    )
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1/onboarding")
+
+    app.dependency_overrides[get_current_user_id] = lambda: USER_ID
+    app.dependency_overrides[get_user_repo] = lambda: mock_user_repo
+    app.dependency_overrides[get_profile_repo] = lambda: mock_profile_repo
+    app.dependency_overrides[get_vice_repo] = lambda: mock_vice_repo
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def mock_user():
+    """Non-empty user fixture (onboarding not yet completed)."""
+    user = MagicMock()
+    user.id = USER_ID
+    user.phone = None
+    user.onboarding_status = "pending"
+    user.telegram_id = 123456789
+    return user
+
+
+@pytest.fixture
+def mock_user_repo(mock_user):
+    """Mock UserRepository with non-empty user return."""
+    repo = AsyncMock()
+    repo.get.return_value = mock_user
+    repo.update_onboarding_status.return_value = None
+    repo.activate_game.return_value = None
+    repo.update_phone.return_value = None
+    repo.set_pending_handoff.return_value = None
+    return repo
+
+
+@pytest.fixture
+def mock_profile_repo():
+    """Mock ProfileRepository — no existing profile."""
+    repo = AsyncMock()
+    repo.get_by_user_id.return_value = None
+    repo.create_profile.return_value = MagicMock()
+    return repo
+
+
+@pytest.fixture
+def mock_vice_repo():
+    """Mock VicePreferenceRepository."""
+    repo = AsyncMock()
+    return repo
+
+
+class TestSavePortalProfilePhone:
+    """Phone field acceptance tests for POST /api/v1/onboarding/profile."""
+
+    def test_valid_phone_returns_200_and_calls_update_phone(
+        self, mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo
+    ):
+        """Valid phone -> 200 OK and update_phone called with normalized value."""
+        client = _make_app_and_client(
+            mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo
+        )
+
+        with patch(
+            "nikita.engine.vice.seeder.seed_vices_from_profile",
+            new_callable=AsyncMock,
+        ):
+            response = client.post("/api/v1/onboarding/profile", json=_VALID_BODY)
+
+        assert response.status_code == 200
+        mock_user_repo.update_phone.assert_awaited_once_with(USER_ID, TEST_PHONE)
+
+    def test_invalid_phone_returns_422(
+        self, mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo
+    ):
+        """Invalid phone 'abc' -> 422 Unprocessable Entity (Pydantic validation)."""
+        client = _make_app_and_client(
+            mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo
+        )
+
+        body = {**_BODY_NO_PHONE, "phone": "abc"}
+        response = client.post("/api/v1/onboarding/profile", json=body)
+
+        assert response.status_code == 422
+        # update_phone must NOT have been called
+        mock_user_repo.update_phone.assert_not_awaited()
+
+    def test_no_phone_field_returns_200_and_does_not_call_update_phone(
+        self, mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo
+    ):
+        """Missing phone field -> 200 OK, update_phone NOT called."""
+        client = _make_app_and_client(
+            mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo
+        )
+
+        with patch(
+            "nikita.engine.vice.seeder.seed_vices_from_profile",
+            new_callable=AsyncMock,
+        ):
+            response = client.post("/api/v1/onboarding/profile", json=_BODY_NO_PHONE)
+
+        assert response.status_code == 200
+        mock_user_repo.update_phone.assert_not_awaited()
+
+    def test_integrity_error_returns_409(
+        self, mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo
+    ):
+        """IntegrityError from update_phone -> 409 with generic detail (no PII)."""
+        mock_user_repo.update_phone.side_effect = IntegrityError(
+            "duplicate key value", {}, Exception()
+        )
+
+        client = _make_app_and_client(
+            mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo
+        )
+
+        response = client.post("/api/v1/onboarding/profile", json=_VALID_BODY)
+
+        assert response.status_code == 409
+        data = response.json()
+        assert data["detail"] == "Phone already registered"
+
+    def test_409_response_body_does_not_leak_pii(
+        self, mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo
+    ):
+        """409 response body must NOT contain UUID or raw phone digits."""
+        mock_user_repo.update_phone.side_effect = IntegrityError(
+            "duplicate key value", {}, Exception()
+        )
+
+        client = _make_app_and_client(
+            mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo
+        )
+
+        response = client.post("/api/v1/onboarding/profile", json=_VALID_BODY)
+
+        assert response.status_code == 409
+        body_text = response.text
+        # Must not contain the raw phone number
+        assert TEST_PHONE not in body_text
+        # Must not contain the UUID
+        assert str(USER_ID) not in body_text
+
+    def test_phone_correction_on_completed_onboarding_calls_update_phone(
+        self, mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo
+    ):
+        """Phone-correction: completed onboarding + new phone -> update_phone still called.
+
+        update_phone is BEFORE the idempotency guard at :712, so even when
+        onboarding_status == 'completed', a new phone can be written.
+        """
+        mock_user.onboarding_status = "completed"
+        mock_user.phone = None  # Has no phone yet
+
+        client = _make_app_and_client(
+            mock_user, mock_user_repo, mock_profile_repo, mock_vice_repo
+        )
+
+        response = client.post("/api/v1/onboarding/profile", json=_VALID_BODY)
+
+        # Idempotency guard returns early, but update_phone should have been called first
+        assert response.status_code == 200
+        mock_user_repo.update_phone.assert_awaited_once_with(USER_ID, TEST_PHONE)

--- a/tests/db/repositories/test_user_repository_phone.py
+++ b/tests/db/repositories/test_user_repository_phone.py
@@ -1,0 +1,92 @@
+"""Tests for UserRepository.update_phone (Spec 212 PR B, T012).
+
+Verifies:
+- session.flush called after phone update
+- user.phone set to the validated value
+- Non-empty user fixture (non-empty data per testing.md rule)
+
+Failing until T016 (update_phone implementation) is committed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+TEST_PHONE = "+41791234567"
+
+
+class TestUserRepositoryUpdatePhone:
+    """Unit tests for update_phone method."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        """Create a mock AsyncSession."""
+        session = AsyncMock(spec=AsyncSession)
+        session.get = AsyncMock()
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    @pytest.fixture
+    def mock_user(self):
+        """Non-empty user fixture with an existing phone=None."""
+        from nikita.db.models.user import User
+
+        user = MagicMock(spec=User)
+        user.id = uuid4()
+        user.phone = None
+        return user
+
+    @pytest.mark.asyncio
+    async def test_update_phone_sets_user_phone(self, mock_session, mock_user):
+        """update_phone sets user.phone to the provided value."""
+        from nikita.db.repositories.user_repository import UserRepository
+
+        user_id = mock_user.id
+
+        # get() uses session.execute — return the mock user
+        mock_result = MagicMock()
+        mock_result.unique.return_value.scalar_one_or_none.return_value = mock_user
+        mock_session.execute.return_value = mock_result
+
+        repo = UserRepository(mock_session)
+        await repo.update_phone(user_id, TEST_PHONE)
+
+        assert mock_user.phone == TEST_PHONE
+
+    @pytest.mark.asyncio
+    async def test_update_phone_calls_session_flush(self, mock_session, mock_user):
+        """update_phone calls session.flush() to persist within transaction."""
+        from nikita.db.repositories.user_repository import UserRepository
+
+        user_id = mock_user.id
+
+        mock_result = MagicMock()
+        mock_result.unique.return_value.scalar_one_or_none.return_value = mock_user
+        mock_session.execute.return_value = mock_result
+
+        repo = UserRepository(mock_session)
+        await repo.update_phone(user_id, TEST_PHONE)
+
+        mock_session.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_update_phone_noop_when_user_not_found(self, mock_session):
+        """update_phone does nothing (no flush) when user is not found."""
+        from nikita.db.repositories.user_repository import UserRepository
+
+        user_id = uuid4()
+
+        mock_result = MagicMock()
+        mock_result.unique.return_value.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        repo = UserRepository(mock_session)
+        await repo.update_phone(user_id, TEST_PHONE)
+
+        mock_session.flush.assert_not_awaited()

--- a/tests/onboarding/test_phone_validation.py
+++ b/tests/onboarding/test_phone_validation.py
@@ -1,0 +1,101 @@
+"""Tests for validate_phone in nikita/onboarding/validation.py (Spec 212 PR B).
+
+Table-driven tests covering:
+- T010: Phone validation and normalization logic
+- DEFAULT_COUNTRY_CODE regression guard (must be "41")
+
+Failing until T014 (validate_phone implementation) is committed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestValidatePhone:
+    """Table-driven tests for validate_phone."""
+
+    def test_e164_passthrough(self):
+        """Full E.164 Swiss number passes through unchanged."""
+        from nikita.onboarding.validation import validate_phone
+
+        assert validate_phone("+41791234567") == "+41791234567"
+
+    def test_nine_digit_bare_swiss_inference(self):
+        """9-digit bare number gets +41 prefix inferred."""
+        from nikita.onboarding.validation import validate_phone
+
+        assert validate_phone("791234567") == "+41791234567"
+
+    def test_ten_digit_leading_zero_swiss_inference(self):
+        """10-digit number starting with 0 strips leading zero and infers +41."""
+        from nikita.onboarding.validation import validate_phone
+
+        assert validate_phone("0791234567") == "+41791234567"
+
+    def test_non_swiss_e164_passthrough(self):
+        """Non-Swiss E.164 number passes through without modification."""
+        from nikita.onboarding.validation import validate_phone
+
+        assert validate_phone("+1234567890") == "+1234567890"
+
+    def test_invalid_raises_value_error(self):
+        """Non-numeric junk raises ValueError."""
+        from nikita.onboarding.validation import validate_phone
+
+        with pytest.raises(ValueError):
+            validate_phone("abc")
+
+    def test_empty_string_returns_none(self):
+        """Empty string returns None (skip validation)."""
+        from nikita.onboarding.validation import validate_phone
+
+        assert validate_phone("") is None
+
+    def test_whitespace_only_returns_none(self):
+        """Whitespace-only string returns None."""
+        from nikita.onboarding.validation import validate_phone
+
+        assert validate_phone("   ") is None
+
+    def test_none_returns_none(self):
+        """None input returns None (null = skip)."""
+        from nikita.onboarding.validation import validate_phone
+
+        assert validate_phone(None) is None
+
+    def test_strips_spaces(self):
+        """Spaces are stripped before validation."""
+        from nikita.onboarding.validation import validate_phone
+
+        assert validate_phone("+41 79 123 45 67") == "+41791234567"
+
+    def test_strips_dashes_swiss_inference(self):
+        """Dashes stripped; 10-digit result with leading 0 gets Swiss inference."""
+        from nikita.onboarding.validation import validate_phone
+
+        assert validate_phone("079-123-45-67") == "+41791234567"
+
+    def test_strips_parentheses(self):
+        """Parentheses are stripped before validation."""
+        from nikita.onboarding.validation import validate_phone
+
+        # After stripping '(', ')': "0791234567" → +41791234567
+        assert validate_phone("(079)1234567") == "+41791234567"
+
+
+class TestDefaultCountryCode:
+    """Regression guard for DEFAULT_COUNTRY_CODE constant."""
+
+    def test_default_country_code_is_41(self):
+        """DEFAULT_COUNTRY_CODE must equal '41' (Switzerland).
+
+        Regression: GH #<TBD> (Spec 212 PR B). Value must not silently drift.
+        Any change requires updating this test AND the tuning-constants comment.
+        """
+        from nikita.onboarding.validation import DEFAULT_COUNTRY_CODE
+
+        assert DEFAULT_COUNTRY_CODE == "41", (
+            f"DEFAULT_COUNTRY_CODE changed from '41' to {DEFAULT_COUNTRY_CODE!r}. "
+            "Update the tuning-constants comment, this assertion, and relevant docs."
+        )

--- a/tests/onboarding/test_voice_flow_phone.py
+++ b/tests/onboarding/test_voice_flow_phone.py
@@ -1,0 +1,90 @@
+"""Tests for voice_flow.py phone refactoring (Spec 212 PR B, T013).
+
+Verifies:
+- normalize_phone delegates to shared validation module (raises ValueError on bad input)
+- _save_phone_number DB failure propagates instead of being swallowed
+
+Failing until T018 (voice_flow refactor) is committed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+
+class TestNormalizePhoneRefactored:
+    """normalize_phone must delegate to the shared validate_phone module."""
+
+    def test_normalize_phone_raises_on_invalid(self):
+        """normalize_phone('abc') must raise ValueError (delegates to validate_phone).
+
+        Before refactor: US-biased fallback returned a mangled string.
+        After refactor: validate_phone raises ValueError for non-numeric junk.
+        """
+        from nikita.onboarding.voice_flow import VoiceOnboardingFlow
+
+        flow = VoiceOnboardingFlow()
+
+        with pytest.raises(ValueError):
+            flow.normalize_phone("abc")
+
+    def test_normalize_phone_valid_swiss_number(self):
+        """normalize_phone passes valid Swiss E.164 through unchanged."""
+        from nikita.onboarding.voice_flow import VoiceOnboardingFlow
+
+        flow = VoiceOnboardingFlow()
+        result = flow.normalize_phone("+41791234567")
+        assert result == "+41791234567"
+
+
+class TestSavePhoneNumberPropagatesErrors:
+    """_save_phone_number must NOT swallow DB exceptions."""
+
+    @pytest.mark.asyncio
+    async def test_save_phone_number_propagates_integrity_error(self):
+        """_save_phone_number propagates IntegrityError — no silent except.
+
+        Before refactor: bare `except Exception as e: logger.error(...)` swallowed
+        the error, making duplicate-phone inserts invisible to the caller.
+        After refactor: the exception propagates to the caller for proper handling.
+        """
+        from nikita.onboarding.voice_flow import VoiceOnboardingFlow
+
+        user_id = uuid4()
+
+        # Build a mock session where flush raises IntegrityError
+        mock_session = AsyncMock()
+        mock_user = MagicMock()
+        mock_user.phone = None
+
+        # Simulate repo.get returning the user, then flush raising
+        with patch(
+            "nikita.db.repositories.user_repository.UserRepository.get",
+            new_callable=AsyncMock,
+            return_value=mock_user,
+        ), patch.object(
+            mock_session,
+            "flush",
+            new_callable=AsyncMock,
+            side_effect=IntegrityError("unique violation", {}, Exception()),
+        ):
+            flow = VoiceOnboardingFlow(session=mock_session)
+
+            # Must propagate — not swallow
+            with pytest.raises(IntegrityError):
+                await flow._save_phone_number(user_id, "+41791234567")
+
+    @pytest.mark.asyncio
+    async def test_save_phone_number_no_session_returns_without_error(self):
+        """_save_phone_number with None session returns silently (no-op path)."""
+        from nikita.onboarding.voice_flow import VoiceOnboardingFlow
+
+        flow = VoiceOnboardingFlow(session=None)
+        user_id = uuid4()
+
+        # Should not raise — the no-session guard should return early
+        await flow._save_phone_number(user_id, "+41791234567")


### PR DESCRIPTION
## Summary

- Shared `validate_phone()` in `nikita/onboarding/validation.py` with Swiss +41 inference, format-char stripping, E.164 regex
- `DEFAULT_COUNTRY_CODE = "41"` named constant with tuning-constants comment + regression test
- `PortalProfileRequest.phone: str | None` (optional) with `@field_validator` delegating to shared module
- `UserRepository.update_phone()` with `flush()`
- Phone write in `save_portal_profile` BEFORE idempotency guard (:712) — enables phone-correction
- `IntegrityError` → HTTP 409 `{"detail": "Phone already registered"}` (caught BEFORE broad except)
- Background task `_trigger_portal_handoff` only on success path
- `voice_flow.normalize_phone` delegates to shared module; `_save_phone_number` silent exception removed
- Migration SQL ready (unique index + CHECK constraint) — will apply via Supabase MCP after merge

Spec 212 PR B of 5. Backend-only, no portal changes.

## Test plan

- [x] `pytest tests/ -x -q` — 5845/5845 pass (25 new)
- [x] IntegrityError → 409 (not 500)
- [x] Phone write before idempotency guard (correction path works)
- [x] Background task not enqueued on 409
- [x] PII non-leakage: 409 body has no UUID/phone digits
- [ ] Post-merge: apply migration via Supabase MCP
- [ ] Post-merge: `pytest tests/ -x -q` still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>