### PR TITLE
feat(onboarding): phone-conditional handoff routing + voice-callback auto-fallback (Spec 212 PR C)

### DIFF
--- a/nikita/api/routes/onboarding.py
+++ b/nikita/api/routes/onboarding.py
@@ -842,9 +842,17 @@ async def _trigger_portal_handoff(
 
         telegram_id = user.telegram_id
         if not telegram_id:
+            # Spec 212 PR C: structured log for pending branch (no raw phone digits).
             logger.warning(
                 "User %s has no telegram_id, deferring handoff (pending_handoff=True)",
                 user_id,
+                extra={
+                    "event": "portal_handoff.branch",
+                    "branch": "pending",
+                    "user_id": str(user_id),
+                    "phone_present": user.phone is not None,
+                    "telegram_present": False,
+                },
             )
             # PR-2 (GH #198-linked): persist deferred-handoff intent so the
             # MessageHandler fires HandoffManager on the user's first message.
@@ -862,13 +870,42 @@ async def _trigger_portal_handoff(
         from nikita.onboarding.models import UserOnboardingProfile
         profile = UserOnboardingProfile(darkness_level=drug_tolerance)
 
-        handoff = HandoffManager()
-        result = await handoff.execute_handoff(
-            user_id=user_id,
-            telegram_id=telegram_id,
-            profile=profile,
-            user_name="friend",
+        # Spec 212 PR C (T022): phone-conditional handoff routing.
+        # phone_present: bool only — never log raw phone digits.
+        logger.info(
+            "Portal handoff routing for user_id=%s branch=%s",
+            user_id,
+            "voice" if user.phone else "telegram",
+            extra={
+                "event": "portal_handoff.branch",
+                "branch": "voice" if user.phone else "telegram",
+                "user_id": str(user_id),
+                "phone_present": user.phone is not None,
+                "telegram_present": True,
+            },
         )
+
+        handoff = HandoffManager()
+        if user.phone:
+            # Voice callback path: Nikita calls the user back after onboarding.
+            # execute_handoff_with_voice_callback already handles:
+            #   - Success: voice call initiated
+            #   - API returns failure: Telegram text fallback
+            #   - Exception: Telegram text fallback (Spec 212 PR C T023)
+            result = await handoff.execute_handoff_with_voice_callback(
+                user_id=user_id,
+                telegram_id=telegram_id,
+                phone_number=user.phone,
+                profile=profile,
+                user_name="friend",
+            )
+        else:
+            result = await handoff.execute_handoff(
+                user_id=user_id,
+                telegram_id=telegram_id,
+                profile=profile,
+                user_name="friend",
+            )
 
         if result.success:
             logger.info("Portal handoff completed for user_id=%s", user_id)

--- a/nikita/onboarding/handoff.py
+++ b/nikita/onboarding/handoff.py
@@ -783,12 +783,24 @@ class HandoffManager:
                 )
 
         except Exception as e:
-            logger.error(f"Voice handoff failed for user {user_id}: {e}")
-            return HandoffResult(
-                success=False,
+            # Spec 212 PR C (T023): structured log + auto-fallback to Telegram text.
+            # phone_present: bool only — never log raw phone digits.
+            logger.warning(
+                "Voice handoff exception for user %s — falling back to Telegram text",
+                user_id,
+                extra={
+                    "event": "portal_handoff.voice_callback",
+                    "outcome": "failure",
+                    "error_class": type(e).__name__,
+                    "user_id": str(user_id),
+                },
+            )
+            # Auto-fallback: enqueue Telegram text handoff so the user still receives
+            # the first message even when ElevenLabs is unavailable.
+            return await self.execute_handoff(
                 user_id=user_id,
+                telegram_id=telegram_id,
+                profile=profile,
                 call_id=call_id,
-                onboarded_at=onboarded_at,
-                profile_summary=profile_summary,
-                error=str(e),
+                user_name=user_name,
             )

--- a/tests/onboarding/test_handoff_phone_routing.py
+++ b/tests/onboarding/test_handoff_phone_routing.py
@@ -1,0 +1,356 @@
+"""Tests for phone-conditional handoff routing (Spec 212 PR C, T021).
+
+Verifies _trigger_portal_handoff routes correctly:
+- Voice branch: user.phone present + telegram_id present -> execute_handoff_with_voice_callback
+- Telegram branch: user.phone absent + telegram_id present -> execute_handoff
+- Pending branch: telegram_id absent -> early-return with pending_handoff=True
+- Voice-callback exception -> Telegram fallback called
+- Structured log keys present on every branch
+
+Failing until T022/T023 (implementation) are committed.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from nikita.onboarding.handoff import HandoffResult
+from nikita.onboarding.models import UserOnboardingProfile
+
+
+def _make_user(
+    *,
+    user_id: UUID | None = None,
+    telegram_id: int | None = 123456789,
+    phone: str | None = None,
+) -> MagicMock:
+    """Build a mock User ORM object."""
+    user = MagicMock()
+    user.id = user_id or uuid4()
+    user.telegram_id = telegram_id
+    user.phone = phone
+    return user
+
+
+def _make_success_result(user_id: UUID) -> HandoffResult:
+    """Build a successful HandoffResult stub."""
+    return HandoffResult(
+        success=True,
+        user_id=user_id,
+        first_message_sent=False,
+        nikita_callback_initiated=True,
+    )
+
+
+class TestVoiceBranch:
+    """User has phone + telegram_id -> execute_handoff_with_voice_callback."""
+
+    @pytest.mark.asyncio
+    async def test_voice_branch_calls_voice_callback(self, caplog):
+        """Voice branch: execute_handoff_with_voice_callback is called when phone present."""
+        from nikita.api.routes.onboarding import _trigger_portal_handoff
+
+        user_id = uuid4()
+        user = _make_user(user_id=user_id, telegram_id=111222333, phone="+41791234567")
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get = AsyncMock(return_value=user)
+        mock_user_repo.set_pending_handoff = AsyncMock()
+
+        mock_handoff_result = _make_success_result(user_id)
+
+        with patch(
+            "nikita.api.routes.onboarding.HandoffManager"
+        ) as mock_hm_cls:
+            mock_hm = mock_hm_cls.return_value
+            mock_hm.execute_handoff_with_voice_callback = AsyncMock(
+                return_value=mock_handoff_result
+            )
+            mock_hm.execute_handoff = AsyncMock()
+
+            with caplog.at_level(logging.INFO, logger="nikita.api.routes.onboarding"):
+                await _trigger_portal_handoff(
+                    user_id=user_id,
+                    user_repo=mock_user_repo,
+                    drug_tolerance=3,
+                )
+
+        mock_hm.execute_handoff_with_voice_callback.assert_awaited_once()
+        mock_hm.execute_handoff.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_voice_branch_structured_log(self, caplog):
+        """Voice branch: structured log contains branch=voice, phone_present=True."""
+        from nikita.api.routes.onboarding import _trigger_portal_handoff
+
+        user_id = uuid4()
+        user = _make_user(user_id=user_id, telegram_id=111222333, phone="+41791234567")
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get = AsyncMock(return_value=user)
+
+        mock_handoff_result = _make_success_result(user_id)
+
+        with patch(
+            "nikita.api.routes.onboarding.HandoffManager"
+        ) as mock_hm_cls:
+            mock_hm = mock_hm_cls.return_value
+            mock_hm.execute_handoff_with_voice_callback = AsyncMock(
+                return_value=mock_handoff_result
+            )
+            mock_hm.execute_handoff = AsyncMock()
+
+            with caplog.at_level(logging.DEBUG, logger="nikita.api.routes.onboarding"):
+                await _trigger_portal_handoff(
+                    user_id=user_id,
+                    user_repo=mock_user_repo,
+                    drug_tolerance=3,
+                )
+
+        # Verify structured log keys
+        log_records = [r for r in caplog.records if hasattr(r, "event")]
+        branch_records = [r for r in log_records if getattr(r, "event", "") == "portal_handoff.branch"]
+        assert branch_records, "Expected portal_handoff.branch log record"
+        rec = branch_records[0]
+        assert rec.branch == "voice"
+        assert rec.phone_present is True
+        assert rec.telegram_present is True
+        assert str(user_id) == rec.user_id
+
+
+class TestTelegramBranch:
+    """User has NO phone + has telegram_id -> existing execute_handoff."""
+
+    @pytest.mark.asyncio
+    async def test_telegram_branch_calls_execute_handoff(self, caplog):
+        """Telegram branch: execute_handoff is called when phone absent."""
+        from nikita.api.routes.onboarding import _trigger_portal_handoff
+
+        user_id = uuid4()
+        user = _make_user(user_id=user_id, telegram_id=999888777, phone=None)
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get = AsyncMock(return_value=user)
+
+        mock_handoff_result = HandoffResult(
+            success=True,
+            user_id=user_id,
+            first_message_sent=True,
+        )
+
+        with patch(
+            "nikita.api.routes.onboarding.HandoffManager"
+        ) as mock_hm_cls:
+            mock_hm = mock_hm_cls.return_value
+            mock_hm.execute_handoff = AsyncMock(return_value=mock_handoff_result)
+            mock_hm.execute_handoff_with_voice_callback = AsyncMock()
+
+            with caplog.at_level(logging.INFO, logger="nikita.api.routes.onboarding"):
+                await _trigger_portal_handoff(
+                    user_id=user_id,
+                    user_repo=mock_user_repo,
+                    drug_tolerance=2,
+                )
+
+        mock_hm.execute_handoff.assert_awaited_once()
+        mock_hm.execute_handoff_with_voice_callback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_telegram_branch_structured_log(self, caplog):
+        """Telegram branch: structured log contains branch=telegram, phone_present=False."""
+        from nikita.api.routes.onboarding import _trigger_portal_handoff
+
+        user_id = uuid4()
+        user = _make_user(user_id=user_id, telegram_id=999888777, phone=None)
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get = AsyncMock(return_value=user)
+
+        mock_handoff_result = HandoffResult(
+            success=True,
+            user_id=user_id,
+            first_message_sent=True,
+        )
+
+        with patch(
+            "nikita.api.routes.onboarding.HandoffManager"
+        ) as mock_hm_cls:
+            mock_hm = mock_hm_cls.return_value
+            mock_hm.execute_handoff = AsyncMock(return_value=mock_handoff_result)
+            mock_hm.execute_handoff_with_voice_callback = AsyncMock()
+
+            with caplog.at_level(logging.DEBUG, logger="nikita.api.routes.onboarding"):
+                await _trigger_portal_handoff(
+                    user_id=user_id,
+                    user_repo=mock_user_repo,
+                    drug_tolerance=2,
+                )
+
+        log_records = [r for r in caplog.records if hasattr(r, "event")]
+        branch_records = [r for r in log_records if getattr(r, "event", "") == "portal_handoff.branch"]
+        assert branch_records, "Expected portal_handoff.branch log record"
+        rec = branch_records[0]
+        assert rec.branch == "telegram"
+        assert rec.phone_present is False
+        assert rec.telegram_present is True
+
+
+class TestPendingBranch:
+    """User has NO telegram_id -> early-return with pending_handoff=True."""
+
+    @pytest.mark.asyncio
+    async def test_pending_branch_sets_flag(self, caplog):
+        """Pending branch: set_pending_handoff called when telegram_id absent."""
+        from nikita.api.routes.onboarding import _trigger_portal_handoff
+
+        user_id = uuid4()
+        user = _make_user(user_id=user_id, telegram_id=None, phone=None)
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get = AsyncMock(return_value=user)
+        mock_user_repo.set_pending_handoff = AsyncMock()
+
+        with patch(
+            "nikita.api.routes.onboarding.HandoffManager"
+        ) as mock_hm_cls:
+            mock_hm = mock_hm_cls.return_value
+            mock_hm.execute_handoff = AsyncMock()
+            mock_hm.execute_handoff_with_voice_callback = AsyncMock()
+
+            await _trigger_portal_handoff(
+                user_id=user_id,
+                user_repo=mock_user_repo,
+                drug_tolerance=1,
+            )
+
+        mock_user_repo.set_pending_handoff.assert_awaited_once_with(user_id, True)
+        mock_hm.execute_handoff.assert_not_awaited()
+        mock_hm.execute_handoff_with_voice_callback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pending_branch_structured_log(self, caplog):
+        """Pending branch: structured log contains branch=pending."""
+        from nikita.api.routes.onboarding import _trigger_portal_handoff
+
+        user_id = uuid4()
+        user = _make_user(user_id=user_id, telegram_id=None, phone=None)
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get = AsyncMock(return_value=user)
+        mock_user_repo.set_pending_handoff = AsyncMock()
+
+        with patch("nikita.api.routes.onboarding.HandoffManager"):
+            with caplog.at_level(logging.DEBUG, logger="nikita.api.routes.onboarding"):
+                await _trigger_portal_handoff(
+                    user_id=user_id,
+                    user_repo=mock_user_repo,
+                    drug_tolerance=1,
+                )
+
+        log_records = [r for r in caplog.records if hasattr(r, "event")]
+        branch_records = [r for r in log_records if getattr(r, "event", "") == "portal_handoff.branch"]
+        assert branch_records, "Expected portal_handoff.branch log record for pending"
+        rec = branch_records[0]
+        assert rec.branch == "pending"
+        assert rec.phone_present is False
+        assert rec.telegram_present is False
+
+
+class TestVoiceCallbackFallback:
+    """execute_handoff_with_voice_callback raises -> Telegram fallback is queued."""
+
+    @pytest.mark.asyncio
+    async def test_voice_failure_falls_back_to_telegram(self):
+        """When initiate_nikita_callback raises, execute_handoff Telegram fallback is called."""
+        from nikita.onboarding.handoff import HandoffManager
+
+        manager = HandoffManager()
+        user_id = uuid4()
+        telegram_id = 555444333
+        phone_number = "+41791234567"
+        profile = UserOnboardingProfile(darkness_level=3)
+
+        fallback_result = HandoffResult(
+            success=True,
+            user_id=user_id,
+            first_message_sent=True,
+        )
+
+        with patch.object(
+            manager,
+            "initiate_nikita_callback",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("ElevenLabs unreachable"),
+        ), patch.object(
+            manager,
+            "execute_handoff",
+            new_callable=AsyncMock,
+            return_value=fallback_result,
+        ) as mock_execute_handoff, patch(
+            "nikita.onboarding.handoff.generate_and_store_social_circle",
+            new_callable=AsyncMock,
+        ):
+            result = await manager.execute_handoff_with_voice_callback(
+                user_id=user_id,
+                telegram_id=telegram_id,
+                phone_number=phone_number,
+                profile=profile,
+            )
+
+        # Telegram fallback must have been called
+        mock_execute_handoff.assert_awaited_once()
+        call_kwargs = mock_execute_handoff.call_args
+        assert call_kwargs.kwargs.get("user_id") == user_id or call_kwargs.args[0] == user_id
+        assert call_kwargs.kwargs.get("telegram_id") == telegram_id or telegram_id in call_kwargs.args
+
+    @pytest.mark.asyncio
+    async def test_voice_failure_outcome_log(self, caplog):
+        """When voice callback fails, portal_handoff.voice_callback outcome=failure is logged."""
+        from nikita.onboarding.handoff import HandoffManager
+
+        manager = HandoffManager()
+        user_id = uuid4()
+        profile = UserOnboardingProfile(darkness_level=2)
+
+        fallback_result = HandoffResult(
+            success=True,
+            user_id=user_id,
+            first_message_sent=True,
+        )
+
+        with patch.object(
+            manager,
+            "initiate_nikita_callback",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("timeout"),
+        ), patch.object(
+            manager,
+            "execute_handoff",
+            new_callable=AsyncMock,
+            return_value=fallback_result,
+        ), patch(
+            "nikita.onboarding.handoff.generate_and_store_social_circle",
+            new_callable=AsyncMock,
+        ):
+            with caplog.at_level(logging.WARNING, logger="nikita.onboarding.handoff"):
+                await manager.execute_handoff_with_voice_callback(
+                    user_id=user_id,
+                    telegram_id=444333222,
+                    phone_number="+41791234567",
+                    profile=profile,
+                )
+
+        log_records = [r for r in caplog.records if hasattr(r, "event")]
+        outcome_records = [
+            r for r in log_records
+            if getattr(r, "event", "") == "portal_handoff.voice_callback"
+            and getattr(r, "outcome", "") == "failure"
+        ]
+        assert outcome_records, "Expected portal_handoff.voice_callback outcome=failure log"
+        rec = outcome_records[0]
+        assert rec.error_class == "ConnectionError"
+        assert str(user_id) == rec.user_id


### PR DESCRIPTION
## Summary

- Phone-conditional handoff routing in `_trigger_portal_handoff`: phone present → voice callback, absent → Telegram text, no telegram_id → pending
- Fixed silent failure in `execute_handoff_with_voice_callback`: `except Exception` block now auto-falls back to Telegram text instead of silently returning failure
- Structured observability logs on every branch: `portal_handoff.branch` (voice/telegram/pending) + `portal_handoff.voice_callback` (success/failure with error_class)
- No raw phone digits in logs — uses `phone_present: bool` only
- `execute_handoff` signature unchanged (`telegram_id: int`)

Spec 212 PR C of 5. This is the critical PR enabling voice callbacks for portal users.

**Rollback trigger**: voice-callback failure rate > 5% sustained over 1h → revert this PR. Phone persistence (PR B) and portal input (PR A) stay merged — users fall back to Telegram text with no data loss.

## Test plan

- [x] `pytest tests/onboarding/ -x -q` — 327/327 pass (8 new)
- [x] Voice branch: dispatches callback + logs `branch=voice`
- [x] Telegram branch: dispatches text + logs `branch=telegram`
- [x] Pending branch: early-return + logs `branch=pending`
- [x] Voice failure → Telegram fallback queued + `outcome=failure` log
- [x] Structured log keys: event, branch, user_id, phone_present, telegram_present
- [ ] Post-merge + deploy: Simon dogfood with +41787950009 → voice callback within 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>