### PR TITLE
fix(test,voice): dead E2E assertion + PII leak in phone logs (post-audit)

### DIFF
--- a/nikita/onboarding/voice_flow.py
+++ b/nikita/onboarding/voice_flow.py
@@ -592,7 +592,7 @@ class VoiceOnboardingFlow:
         a registered number.
         """
         if self._session is None:
-            logger.info(f"No session: would save phone {phone} for user {user_id}")
+            logger.info("No session: would save phone for user %s (phone_provided=True)", user_id)
             return
 
         from nikita.db.repositories.user_repository import UserRepository
@@ -602,7 +602,7 @@ class VoiceOnboardingFlow:
         if user is not None:
             user.phone = phone
             await self._session.flush()
-            logger.info(f"Saved phone {phone} for user {user_id}")
+            logger.info("Saved phone for user %s (phone_provided=True)", user_id)
         else:
             logger.warning(f"User {user_id} not found for phone save")
 

--- a/nikita/onboarding/voice_flow.py
+++ b/nikita/onboarding/voice_flow.py
@@ -604,7 +604,7 @@ class VoiceOnboardingFlow:
             await self._session.flush()
             logger.info("Saved phone for user %s (phone_provided=True)", user_id)
         else:
-            logger.warning(f"User {user_id} not found for phone save")
+            logger.warning("User %s not found for phone save", user_id)
 
     async def _save_deferred_state(self, user_id: UUID) -> None:
         """Save deferred state to in-memory state + database.
@@ -686,5 +686,5 @@ class VoiceOnboardingFlow:
                 raise Exception(result.get("message", "Outbound call failed"))
 
         except Exception as e:
-            logger.error(f"ElevenLabs call failed for {phone}: {e}")
+            logger.error("ElevenLabs call failed (phone_provided=True): %s", e)
             raise

--- a/portal/e2e/onboarding.spec.ts
+++ b/portal/e2e/onboarding.spec.ts
@@ -238,7 +238,9 @@ test.describe("Onboarding — Phone field", () => {
   test("submitting with a valid phone succeeds and shows transition overlay", async ({ page }) => {
     const TEST_PHONE_E164 = "+41791234567"
 
-    // Capture the POST body to verify phone is included
+    // Register mock routes FIRST, then override profile route (Playwright LIFO: last registered fires first)
+    await mockApiRoutes(page)
+
     let capturedPostBody: string | null = null
     await page.route("**/api/v1/onboarding/profile", async (route) => {
       if (route.request().method() === "POST") {
@@ -250,8 +252,6 @@ test.describe("Onboarding — Phone field", () => {
         body: JSON.stringify({ status: "ok", user_id: "e2e-player-id" }),
       })
     })
-
-    await mockApiRoutes(page)
     await page.goto("/onboarding", { waitUntil: "networkidle" })
 
     const profileSection = page.locator('[data-testid="section-profile"]')
@@ -271,10 +271,9 @@ test.describe("Onboarding — Phone field", () => {
     const missionSection = page.locator('[data-testid="section-mission"]')
     await expect(missionSection.getByText("Opening Telegram...")).toBeVisible({ timeout: 10_000 })
 
-    // Verify phone was in the POST body
-    if (capturedPostBody) {
-      const parsed = JSON.parse(capturedPostBody) as Record<string, unknown>
-      expect(parsed.phone).toBe(TEST_PHONE_E164)
-    }
+    // Verify phone was in the POST body (unconditional — null = test failure)
+    expect(capturedPostBody).not.toBeNull()
+    const parsed = JSON.parse(capturedPostBody!) as Record<string, unknown>
+    expect(parsed.phone).toBe(TEST_PHONE_E164)
   })
 })


### PR DESCRIPTION
## Summary

Post-merge audit of Spec 212 found two issues:

1. **E2E dead assertion** (`portal/e2e/onboarding.spec.ts:275`): QA iter 2 fix for Playwright LIFO route ordering failed to land in PR #266 squash merge. Fixed: mockApiRoutes registered FIRST, capture handler registered SECOND (LIFO priority), assertion is unconditional (`expect(capturedPostBody).not.toBeNull()`).

2. **PII leak** (`nikita/onboarding/voice_flow.py:595,605`): Pre-existing INFO-level logs included raw phone digits. Redacted to `phone_provided=True` boolean.

## Test plan

- [x] E2E assertion now unconditional — will fail if POST body capture misses
- [x] No raw phone digits in voice_flow.py log lines
- [ ] Fresh QA review (zero findings required per updated pr-workflow.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>