### PR TITLE
fix(onboarding): seed conversation + full profile + pipeline bootstrap

### DIFF
--- a/nikita/api/routes/onboarding.py
+++ b/nikita/api/routes/onboarding.py
@@ -778,6 +778,19 @@ async def save_portal_profile(
             primary_interest=body.interest,
         )
 
+        # Persist profile to users.onboarding_profile JSONB so handoff can read it.
+        # Portal path stores structured data in user_profiles table, but handoff
+        # reads from this JSONB. Without this, portal users get empty JSONB and
+        # the first message falls back to generic templates.
+        # (GH onboarding-pipeline-bootstrap: fixes Bug 2 data gap)
+        await user_repo.update_onboarding_profile(user_id, {
+            "location_city": body.location_city,
+            "social_scene": body.social_scene,
+            "darkness_level": body.drug_tolerance,
+            "life_stage": body.life_stage,
+            "interest": body.interest,
+        })
+
         # Update onboarding status to completed
         await user_repo.update_onboarding_status(user_id, "completed")
 
@@ -866,9 +879,14 @@ async def _trigger_portal_handoff(
                 )
             return
 
-        # Build minimal onboarding profile for message generation
-        from nikita.onboarding.models import UserOnboardingProfile
-        profile = UserOnboardingProfile(darkness_level=drug_tolerance)
+        # Build full onboarding profile from JSONB for message personalization.
+        # Previously only darkness_level was passed, stripping all other fields
+        # (GH onboarding-pipeline-bootstrap: fixes Bug 2).
+        from nikita.onboarding.models import build_profile_from_jsonb
+        profile = build_profile_from_jsonb(
+            user.onboarding_profile or {},
+            fallback_darkness=drug_tolerance,
+        )
 
         # Spec 212 PR C (T022): phone-conditional handoff routing.
         # phone_present: bool only — never log raw phone digits.

--- a/nikita/onboarding/handoff.py
+++ b/nikita/onboarding/handoff.py
@@ -173,6 +173,23 @@ class FirstMessageGenerator:
             if personality_msgs:
                 message = f"{message} {random.choice(personality_msgs)}"
 
+        # GH onboarding-pipeline-bootstrap: City/scene-aware coda.
+        # Makes the first message feel grounded in the player's location.
+        # History: Added in onboarding-pipeline-bootstrap PR (previously unused).
+        CITY_SCENE_PROBABILITY = 0.6  # 60% chance when city is known
+        if profile.city and random.random() < CITY_SCENE_PROBABILITY:
+            scene_flavor: dict[str, str] = {
+                "techno": "heard the underground scene there is wild",
+                "art": "bet the art scene there is interesting",
+                "food": "the food scene there better be as good as they say",
+                "cocktails": "heard the cocktail bars there are no joke",
+                "nature": "jealous of the nature you've got around there",
+            }
+            city_bits = [f"so you're in {profile.city}..."]
+            if profile.social_scene and profile.social_scene in scene_flavor:
+                city_bits.append(scene_flavor[profile.social_scene])
+            message = f"{message} {' — '.join(city_bits)}"
+
         return message
 
 
@@ -400,10 +417,19 @@ class HandoffManager:
 
             logger.info(f"Handoff completed for user {user_id}")
 
+            # GH onboarding-pipeline-bootstrap: Seed conversation for pipeline + continuity
+            seed_conversation_id = await self._seed_conversation(
+                user_id=user_id,
+                platform="telegram",
+                first_message=first_message,
+            )
+
             # Spec 043 T2.2: Pipeline bootstrap — fire-and-forget background task
             async def _bootstrap_pipeline_bg() -> None:
                 try:
-                    await self._bootstrap_pipeline(user_id)
+                    await self._bootstrap_pipeline(
+                        user_id, conversation_id=seed_conversation_id
+                    )
                 except Exception as bootstrap_err:
                     logger.warning(
                         f"Pipeline bootstrap failed for user {user_id}: {bootstrap_err}"
@@ -456,12 +482,81 @@ class HandoffManager:
 
         return "\n".join(parts) if parts else "No profile data collected"
 
-    async def _bootstrap_pipeline(self, user_id: UUID) -> None:
+    async def _seed_conversation(
+        self,
+        user_id: UUID,
+        platform: str,
+        first_message: str,
+    ) -> UUID | None:
+        """Create a Conversation row seeded with the first message.
+
+        GH onboarding-pipeline-bootstrap: Fixes Bug 1 (pipeline found no
+        conversations) and Bug 3 (first message not in conversation context).
+        The seeded conversation is then passed to _bootstrap_pipeline.
+
+        Args:
+            user_id: User's UUID.
+            platform: "telegram" or "voice".
+            first_message: Content of the first message (assistant turn).
+
+        Returns:
+            UUID of the seeded conversation, or None on failure.
+        """
+        try:
+            from nikita.db.database import get_session_maker
+            from nikita.db.repositories.conversation_repository import (
+                ConversationRepository,
+            )
+
+            async with get_session_maker()() as seed_session:
+                conv_repo = ConversationRepository(seed_session)
+                seed_conv = await conv_repo.create_conversation(
+                    user_id=user_id,
+                    platform=platform,
+                    chapter_at_time=1,  # New users start at chapter 1
+                )
+                seed_conv.messages = [
+                    {
+                        "role": "assistant",
+                        "content": first_message,
+                        "timestamp": datetime.now(UTC).isoformat(),
+                    }
+                ]
+                seed_conv.last_message_at = datetime.now(UTC)
+                await seed_session.commit()
+                logger.info(
+                    "Seeded conversation %s (%s) for user %s",
+                    seed_conv.id,
+                    platform,
+                    user_id,
+                )
+                return seed_conv.id
+        except Exception as seed_err:
+            logger.warning(
+                "Conversation seed failed for user %s: %s", user_id, seed_err
+            )
+            return None
+
+    async def _bootstrap_pipeline(
+        self,
+        user_id: UUID,
+        conversation_id: UUID | None = None,
+    ) -> None:
         """Trigger initial pipeline run for newly onboarded user.
 
         Spec 043 T2.2: Generates initial text + voice prompts so the first
         text message after onboarding uses personalized content.
         Non-blocking - failure is logged but does not fail the handoff.
+
+        GH onboarding-pipeline-bootstrap: When conversation_id is provided
+        (from the conversation seed), fetch that specific conversation instead
+        of querying get_recent. This eliminates the race where get_recent
+        returned empty because no conversation existed yet.
+
+        Args:
+            user_id: User's UUID.
+            conversation_id: Specific seeded conversation ID (preferred).
+                Falls back to get_recent if None (backward compat).
         """
         from nikita.config.settings import get_settings
 
@@ -475,10 +570,23 @@ class HandoffManager:
         from nikita.pipeline.orchestrator import PipelineOrchestrator
 
         async with get_session_maker()() as session:
-            # Get most recent conversation for this user
             conv_repo = ConversationRepository(session)
-            recent = await conv_repo.get_recent(user_id, limit=1)
-            if recent:
+
+            # Prefer the seeded conversation_id; fall back to get_recent
+            conversation = None
+            if conversation_id:
+                conversation = await conv_repo.get(conversation_id)
+                if not conversation:
+                    logger.warning(
+                        "Seeded conversation %s not found for user %s",
+                        conversation_id,
+                        user_id,
+                    )
+            if not conversation:
+                recent = await conv_repo.get_recent(user_id, limit=1)
+                conversation = recent[0] if recent else None
+
+            if conversation:
                 from nikita.db.repositories.user_repository import UserRepository
 
                 user_repo = UserRepository(session)
@@ -486,20 +594,23 @@ class HandoffManager:
 
                 orchestrator = PipelineOrchestrator(session)
                 result = await orchestrator.process(
-                    conversation_id=recent[0].id,
+                    conversation_id=conversation.id,
                     user_id=user_id,
                     platform="text",
-                    conversation=recent[0],
+                    conversation=conversation,
                     user=user,
                 )
                 await session.commit()
                 logger.info(
                     f"Pipeline bootstrap complete user={user_id} "
-                    f"success={result.success}"
+                    f"conv={conversation.id} success={result.success}"
                 )
             else:
-                logger.info(
-                    f"No conversations found for pipeline bootstrap user={user_id}"
+                logger.warning(
+                    "No conversations found for pipeline bootstrap user=%s "
+                    "(conversation_id=%s)",
+                    user_id,
+                    conversation_id,
                 )
 
     async def _send_first_message(
@@ -747,6 +858,29 @@ class HandoffManager:
 
             if callback_result.get("success"):
                 logger.info(f"Voice handoff completed for user {user_id}")
+
+                # GH onboarding-pipeline-bootstrap: Seed conversation + bootstrap
+                # pipeline on the voice path too (Bug 4 fix).
+                voice_seed_conversation_id = await self._seed_conversation(
+                    user_id=user_id,
+                    platform="voice",
+                    first_message="[Voice call initiated]",
+                )
+
+                async def _bootstrap_pipeline_voice_bg() -> None:
+                    try:
+                        await self._bootstrap_pipeline(
+                            user_id,
+                            conversation_id=voice_seed_conversation_id,
+                        )
+                    except Exception as bootstrap_err:
+                        logger.warning(
+                            "Pipeline bootstrap (voice) failed for user %s: %s",
+                            user_id,
+                            bootstrap_err,
+                        )
+
+                asyncio.create_task(_bootstrap_pipeline_voice_bg())
 
                 return HandoffResult(
                     success=True,

--- a/nikita/onboarding/handoff.py
+++ b/nikita/onboarding/handoff.py
@@ -26,6 +26,11 @@ from nikita.onboarding.models import (
 
 logger = logging.getLogger(__name__)
 
+# GH onboarding-pipeline-bootstrap: Probability of adding city/scene coda to first message.
+# History: 0.6 (onboarding-pipeline-bootstrap PR, new).
+# Rationale: 60% gives most users a grounded opener without being formulaic.
+CITY_SCENE_PROBABILITY = 0.6
+
 
 @dataclass
 class HandoffResult:
@@ -175,8 +180,6 @@ class FirstMessageGenerator:
 
         # GH onboarding-pipeline-bootstrap: City/scene-aware coda.
         # Makes the first message feel grounded in the player's location.
-        # History: Added in onboarding-pipeline-bootstrap PR (previously unused).
-        CITY_SCENE_PROBABILITY = 0.6  # 60% chance when city is known
         if profile.city and random.random() < CITY_SCENE_PROBABILITY:
             scene_flavor: dict[str, str] = {
                 "techno": "heard the underground scene there is wild",
@@ -510,10 +513,13 @@ class HandoffManager:
 
             async with get_session_maker()() as seed_session:
                 conv_repo = ConversationRepository(seed_session)
+                # chapter_at_time=1: This is called during onboarding handoff,
+                # so the user is always in chapter 1. If this method is ever
+                # reused post-onboarding, fetch user.chapter from the DB instead.
                 seed_conv = await conv_repo.create_conversation(
                     user_id=user_id,
                     platform=platform,
-                    chapter_at_time=1,  # New users start at chapter 1
+                    chapter_at_time=1,
                 )
                 seed_conv.messages = [
                     {

--- a/nikita/onboarding/handoff.py
+++ b/nikita/onboarding/handoff.py
@@ -427,18 +427,27 @@ class HandoffManager:
                 first_message=first_message,
             )
 
-            # Spec 043 T2.2: Pipeline bootstrap — fire-and-forget background task
-            async def _bootstrap_pipeline_bg() -> None:
-                try:
-                    await self._bootstrap_pipeline(
-                        user_id, conversation_id=seed_conversation_id
-                    )
-                except Exception as bootstrap_err:
-                    logger.warning(
-                        f"Pipeline bootstrap failed for user {user_id}: {bootstrap_err}"
-                    )
+            # Spec 043 T2.2: Pipeline bootstrap — fire-and-forget background task.
+            # Only dispatch if seed succeeded — a None conversation_id would
+            # fall back to get_recent, reintroducing the original race condition.
+            if seed_conversation_id:
+                async def _bootstrap_pipeline_bg() -> None:
+                    try:
+                        await self._bootstrap_pipeline(
+                            user_id, conversation_id=seed_conversation_id
+                        )
+                    except Exception as bootstrap_err:
+                        logger.warning(
+                            f"Pipeline bootstrap failed for user {user_id}: "
+                            f"{bootstrap_err}"
+                        )
 
-            asyncio.create_task(_bootstrap_pipeline_bg())
+                asyncio.create_task(_bootstrap_pipeline_bg())
+            else:
+                logger.warning(
+                    "Skipping pipeline bootstrap for user %s — seed failed",
+                    user_id,
+                )
 
             return HandoffResult(
                 success=True,
@@ -521,13 +530,9 @@ class HandoffManager:
                     platform=platform,
                     chapter_at_time=1,
                 )
-                seed_conv.messages = [
-                    {
-                        "role": "assistant",
-                        "content": first_message,
-                        "timestamp": datetime.now(UTC).isoformat(),
-                    }
-                ]
+                # Use the model's add_message() to respect the shared message
+                # contract (timestamp format, dirty-flag tracking).
+                seed_conv.add_message(role="assistant", content=first_message)
                 seed_conv.last_message_at = datetime.now(UTC)
                 await seed_session.commit()
                 logger.info(
@@ -899,7 +904,9 @@ class HandoffManager:
                     nikita_conversation_id=callback_result.get("conversation_id"),
                 )
             else:
-                # Voice callback failed, fall back to text message
+                # Voice callback failed (non-exception), fall back to text message.
+                # GH onboarding-pipeline-bootstrap: seed + bootstrap on this path
+                # too — same pattern as execute_handoff text path.
                 logger.warning(
                     f"Voice callback failed for user {user_id}, falling back to text"
                 )
@@ -909,6 +916,29 @@ class HandoffManager:
                     telegram_id=telegram_id,
                     message=first_message,
                 )
+
+                if send_result.get("success", False):
+                    fallback_seed_id = await self._seed_conversation(
+                        user_id=user_id,
+                        platform="telegram",
+                        first_message=first_message,
+                    )
+
+                    async def _bootstrap_pipeline_fallback_bg() -> None:
+                        try:
+                            await self._bootstrap_pipeline(
+                                user_id,
+                                conversation_id=fallback_seed_id,
+                            )
+                        except Exception as bootstrap_err:
+                            logger.warning(
+                                "Pipeline bootstrap (voice fallback) failed "
+                                "for user %s: %s",
+                                user_id,
+                                bootstrap_err,
+                            )
+
+                    asyncio.create_task(_bootstrap_pipeline_fallback_bg())
 
                 return HandoffResult(
                     success=send_result.get("success", False),

--- a/nikita/onboarding/handoff.py
+++ b/nikita/onboarding/handoff.py
@@ -878,20 +878,26 @@ class HandoffManager:
                     first_message="[Voice call initiated]",
                 )
 
-                async def _bootstrap_pipeline_voice_bg() -> None:
-                    try:
-                        await self._bootstrap_pipeline(
-                            user_id,
-                            conversation_id=voice_seed_conversation_id,
-                        )
-                    except Exception as bootstrap_err:
-                        logger.warning(
-                            "Pipeline bootstrap (voice) failed for user %s: %s",
-                            user_id,
-                            bootstrap_err,
-                        )
+                if voice_seed_conversation_id:
+                    async def _bootstrap_pipeline_voice_bg() -> None:
+                        try:
+                            await self._bootstrap_pipeline(
+                                user_id,
+                                conversation_id=voice_seed_conversation_id,
+                            )
+                        except Exception as bootstrap_err:
+                            logger.warning(
+                                "Pipeline bootstrap (voice) failed for user %s: %s",
+                                user_id,
+                                bootstrap_err,
+                            )
 
-                asyncio.create_task(_bootstrap_pipeline_voice_bg())
+                    asyncio.create_task(_bootstrap_pipeline_voice_bg())
+                else:
+                    logger.warning(
+                        "Skipping pipeline bootstrap (voice) for user %s — seed failed",
+                        user_id,
+                    )
 
                 return HandoffResult(
                     success=True,
@@ -924,21 +930,28 @@ class HandoffManager:
                         first_message=first_message,
                     )
 
-                    async def _bootstrap_pipeline_fallback_bg() -> None:
-                        try:
-                            await self._bootstrap_pipeline(
-                                user_id,
-                                conversation_id=fallback_seed_id,
-                            )
-                        except Exception as bootstrap_err:
-                            logger.warning(
-                                "Pipeline bootstrap (voice fallback) failed "
-                                "for user %s: %s",
-                                user_id,
-                                bootstrap_err,
-                            )
+                    if fallback_seed_id:
+                        async def _bootstrap_pipeline_fallback_bg() -> None:
+                            try:
+                                await self._bootstrap_pipeline(
+                                    user_id,
+                                    conversation_id=fallback_seed_id,
+                                )
+                            except Exception as bootstrap_err:
+                                logger.warning(
+                                    "Pipeline bootstrap (voice fallback) failed "
+                                    "for user %s: %s",
+                                    user_id,
+                                    bootstrap_err,
+                                )
 
-                    asyncio.create_task(_bootstrap_pipeline_fallback_bg())
+                        asyncio.create_task(_bootstrap_pipeline_fallback_bg())
+                    else:
+                        logger.warning(
+                            "Skipping pipeline bootstrap (voice fallback) "
+                            "for user %s — seed failed",
+                            user_id,
+                        )
 
                 return HandoffResult(
                     success=send_result.get("success", False),

--- a/nikita/onboarding/models.py
+++ b/nikita/onboarding/models.py
@@ -238,15 +238,28 @@ def build_profile_from_jsonb(
     Returns:
         Fully populated UserOnboardingProfile.
     """
-    # Clamp darkness_level to 1-5 to prevent Pydantic ValidationError
-    # on corrupted JSONB rows (ge=1, le=5 validator on the model).
-    raw_darkness = int(payload.get("darkness_level", fallback_darkness))
+    # Safely parse darkness_level: handle non-numeric JSONB values (corrupted rows)
+    # and clamp to 1-5 to prevent Pydantic ValidationError.
+    try:
+        raw_darkness = int(payload.get("darkness_level", fallback_darkness))
+    except (ValueError, TypeError):
+        raw_darkness = fallback_darkness
     clamped_darkness = max(1, min(5, raw_darkness))
+
+    # Safely parse personality_type: Pydantic strict mode rejects invalid strings
+    raw_personality = payload.get("personality_type")
+    parsed_personality = None
+    if raw_personality is not None:
+        try:
+            parsed_personality = PersonalityType(raw_personality)
+        except (ValueError, KeyError):
+            parsed_personality = None
+
     return UserOnboardingProfile(
         darkness_level=clamped_darkness,
         occupation=payload.get("occupation"),
         hobbies=payload.get("hobbies", []),
-        personality_type=payload.get("personality_type"),
+        personality_type=parsed_personality,
         hangout_spots=payload.get("hangout_spots", []),
         timezone=payload.get("timezone"),
         city=payload.get("location_city"),

--- a/nikita/onboarding/models.py
+++ b/nikita/onboarding/models.py
@@ -223,7 +223,7 @@ class UserOnboardingProfile(BaseModel):
 def build_profile_from_jsonb(
     payload: dict[str, Any],
     fallback_darkness: int = 3,
-) -> "UserOnboardingProfile":
+) -> UserOnboardingProfile:
     """Build a UserOnboardingProfile from the users.onboarding_profile JSONB.
 
     Shared by both _trigger_portal_handoff (onboarding.py) and

--- a/nikita/onboarding/models.py
+++ b/nikita/onboarding/models.py
@@ -238,8 +238,12 @@ def build_profile_from_jsonb(
     Returns:
         Fully populated UserOnboardingProfile.
     """
+    # Clamp darkness_level to 1-5 to prevent Pydantic ValidationError
+    # on corrupted JSONB rows (ge=1, le=5 validator on the model).
+    raw_darkness = int(payload.get("darkness_level", fallback_darkness))
+    clamped_darkness = max(1, min(5, raw_darkness))
     return UserOnboardingProfile(
-        darkness_level=int(payload.get("darkness_level", fallback_darkness)),
+        darkness_level=clamped_darkness,
         occupation=payload.get("occupation"),
         hobbies=payload.get("hobbies", []),
         personality_type=payload.get("personality_type"),

--- a/nikita/onboarding/models.py
+++ b/nikita/onboarding/models.py
@@ -101,6 +101,29 @@ class UserOnboardingProfile(BaseModel):
         description="Places user likes to hang out",
     )
 
+    # Portal-collected profile fields (GH onboarding-pipeline-bootstrap)
+    # These map from user.onboarding_profile JSONB keys set by save_portal_profile.
+    city: str | None = Field(
+        default=None,
+        description="User's city (from portal location_city field)",
+    )
+    social_scene: str | None = Field(
+        default=None,
+        description="Social scene preference (techno/art/food/cocktails/nature)",
+    )
+    life_stage: str | None = Field(
+        default=None,
+        description="Life stage (tech/finance/creative/student/entrepreneur/other)",
+    )
+    interest: str | None = Field(
+        default=None,
+        description="Primary interest or hobby text",
+    )
+    age: int | None = Field(
+        default=None,
+        description="User's age (not yet collected in portal, future field)",
+    )
+
     # Experience preferences
     darkness_level: int = Field(
         default=3,
@@ -169,6 +192,11 @@ class UserOnboardingProfile(BaseModel):
                 self.personality_type.value if self.personality_type else None
             ),
             "hangout_spots": self.hangout_spots,
+            "city": self.city,
+            "social_scene": self.social_scene,
+            "life_stage": self.life_stage,
+            "interest": self.interest,
+            "age": self.age,
             "darkness_level": self.darkness_level,
             "pacing_weeks": self.pacing_weeks,
             "conversation_style": self.conversation_style.value,
@@ -190,6 +218,39 @@ class UserOnboardingProfile(BaseModel):
         return (
             "Intense (4 weeks)" if self.pacing_weeks == 4 else "Relaxed (8 weeks)"
         )
+
+
+def build_profile_from_jsonb(
+    payload: dict[str, Any],
+    fallback_darkness: int = 3,
+) -> "UserOnboardingProfile":
+    """Build a UserOnboardingProfile from the users.onboarding_profile JSONB.
+
+    Shared by both _trigger_portal_handoff (onboarding.py) and
+    _execute_pending_handoff (message_handler.py) to ensure field parity.
+    Prevents the profile-stripping bug (GH onboarding-pipeline-bootstrap)
+    where only darkness_level was extracted.
+
+    Args:
+        payload: The raw users.onboarding_profile JSONB dict.
+        fallback_darkness: Default darkness_level when JSONB has no value.
+
+    Returns:
+        Fully populated UserOnboardingProfile.
+    """
+    return UserOnboardingProfile(
+        darkness_level=int(payload.get("darkness_level", fallback_darkness)),
+        occupation=payload.get("occupation"),
+        hobbies=payload.get("hobbies", []),
+        personality_type=payload.get("personality_type"),
+        hangout_spots=payload.get("hangout_spots", []),
+        timezone=payload.get("timezone"),
+        city=payload.get("location_city"),
+        social_scene=payload.get("social_scene"),
+        life_stage=payload.get("life_stage"),
+        interest=payload.get("interest"),
+        age=payload.get("age"),
+    )
 
 
 class ProfileFieldUpdate(BaseModel):

--- a/nikita/platforms/telegram/message_handler.py
+++ b/nikita/platforms/telegram/message_handler.py
@@ -810,11 +810,11 @@ class MessageHandler:
         """
         try:
             from nikita.onboarding.handoff import HandoffManager
-            from nikita.onboarding.models import UserOnboardingProfile
+            from nikita.onboarding.models import build_profile_from_jsonb
 
-            profile_payload = user.onboarding_profile or {}
-            darkness_level = int(profile_payload.get("darkness_level", 3))
-            profile = UserOnboardingProfile(darkness_level=darkness_level)
+            # Build full profile from JSONB — shared helper ensures parity
+            # with _trigger_portal_handoff (GH onboarding-pipeline-bootstrap).
+            profile = build_profile_from_jsonb(user.onboarding_profile or {})
 
             manager = HandoffManager()
             result = await manager.execute_handoff(

--- a/tests/onboarding/test_handoff.py
+++ b/tests/onboarding/test_handoff.py
@@ -230,7 +230,7 @@ class TestFirstMessageGenerator:
         self, generator: FirstMessageGenerator
     ) -> None:
         """GH onboarding-pipeline-bootstrap: City personalization."""
-        import random
+        from unittest.mock import patch
 
         profile = UserOnboardingProfile(
             city="Tokyo",
@@ -238,13 +238,12 @@ class TestFirstMessageGenerator:
             darkness_level=3,
         )
 
-        # Run multiple times — city appears with 60% probability
-        random.seed(42)
-        messages = [generator.generate(profile, user_name="Test") for _ in range(20)]
+        # Mock random to guarantee the city branch is taken
+        # (random.random() < CITY_SCENE_PROBABILITY where CITY_SCENE_PROBABILITY=0.6)
+        with patch("nikita.onboarding.handoff.random.random", return_value=0.1):
+            message = generator.generate(profile, user_name="Test")
 
-        # At least some should contain the city name
-        city_messages = [m for m in messages if "Tokyo" in m]
-        assert len(city_messages) > 0, "City should appear in at least some messages"
+        assert "Tokyo" in message, f"City 'Tokyo' should appear in: {message}"
 
     def test_generate_without_city_does_not_raise(
         self, generator: FirstMessageGenerator
@@ -683,6 +682,8 @@ class TestVoiceHandoffIntegration:
             hobbies=["coding"],
         )
         captured_user_name = None
+        manager._seed_conversation = AsyncMock(return_value=uuid4())
+        manager._bootstrap_pipeline = AsyncMock()
 
         async def capture_callback(*args, **kwargs):
             nonlocal captured_user_name
@@ -708,6 +709,8 @@ class TestVoiceHandoffIntegration:
         """Falls back to text message when voice callback fails."""
         user_id = uuid4()
         profile = UserOnboardingProfile(occupation="Engineer")
+        manager._seed_conversation = AsyncMock(return_value=uuid4())
+        manager._bootstrap_pipeline = AsyncMock()
 
         with patch.object(
             manager, "initiate_nikita_callback", return_value={"success": False, "error": "Failed"}
@@ -723,7 +726,8 @@ class TestVoiceHandoffIntegration:
                     callback_delay_seconds=0,
                 )
 
-        # Should fall back to text
+        # Should fall back to text with seed + bootstrap
         assert result.first_message_sent is True
         assert result.nikita_callback_initiated is False
         mock_send.assert_called_once()
+        manager._seed_conversation.assert_called_once()  # Seed on fallback path

--- a/tests/onboarding/test_handoff.py
+++ b/tests/onboarding/test_handoff.py
@@ -53,6 +53,7 @@ class TestHandoffManager:
             mock_send.return_value = {"success": True}
             with patch("nikita.onboarding.handoff.generate_and_store_social_circle"):
                 with patch.object(manager, "_bootstrap_pipeline"):
+                    manager._seed_conversation = AsyncMock(return_value=None)
                     result = await manager.execute_handoff(
                         user_id=user_id,
                         telegram_id=123456789,
@@ -74,6 +75,7 @@ class TestHandoffManager:
             mock_send.return_value = {"success": True}
             with patch("nikita.onboarding.handoff.generate_and_store_social_circle"):
                 with patch.object(manager, "_bootstrap_pipeline"):
+                    manager._seed_conversation = AsyncMock(return_value=None)
                     result = await manager.execute_handoff(
                         user_id=user_id,
                         telegram_id=123456789,
@@ -120,6 +122,7 @@ class TestHandoffManager:
             mock_send.side_effect = Exception("Telegram API error")
             with patch("nikita.onboarding.handoff.generate_and_store_social_circle"):
                 with patch.object(manager, "_bootstrap_pipeline"):
+                    manager._seed_conversation = AsyncMock(return_value=None)
                     result = await manager.execute_handoff(
                         user_id=user_id,
                         telegram_id=123456789,
@@ -140,6 +143,7 @@ class TestHandoffManager:
             mock_send.return_value = {"success": True, "message_id": 12345}
             with patch("nikita.onboarding.handoff.generate_and_store_social_circle"):
                 with patch.object(manager, "_bootstrap_pipeline"):
+                    manager._seed_conversation = AsyncMock(return_value=None)
                     result = await manager.execute_handoff(
                         user_id=user_id,
                         telegram_id=123456789,
@@ -222,6 +226,73 @@ class TestFirstMessageGenerator:
         assert all(m is not None for m in messages)
 
 
+    def test_generate_with_city_includes_city_name(
+        self, generator: FirstMessageGenerator
+    ) -> None:
+        """GH onboarding-pipeline-bootstrap: City personalization."""
+        import random
+
+        profile = UserOnboardingProfile(
+            city="Tokyo",
+            social_scene="techno",
+            darkness_level=3,
+        )
+
+        # Run multiple times — city appears with 60% probability
+        random.seed(42)
+        messages = [generator.generate(profile, user_name="Test") for _ in range(20)]
+
+        # At least some should contain the city name
+        city_messages = [m for m in messages if "Tokyo" in m]
+        assert len(city_messages) > 0, "City should appear in at least some messages"
+
+    def test_generate_without_city_does_not_raise(
+        self, generator: FirstMessageGenerator
+    ) -> None:
+        """GH onboarding-pipeline-bootstrap: Null city handled gracefully."""
+        profile = UserOnboardingProfile(city=None, social_scene=None)
+
+        message = generator.generate(profile, user_name="Test")
+        assert message is not None
+        assert len(message) > 0
+
+    def test_build_profile_from_jsonb_full_fields(self) -> None:
+        """GH onboarding-pipeline-bootstrap: build_profile_from_jsonb
+        reconstructs all fields from JSONB."""
+        from nikita.onboarding.models import build_profile_from_jsonb
+
+        payload = {
+            "location_city": "Berlin",
+            "social_scene": "techno",
+            "darkness_level": 4,
+            "occupation": "doctor",
+            "hobbies": ["music", "travel"],
+            "life_stage": "creative",
+            "interest": "photography",
+        }
+
+        profile = build_profile_from_jsonb(payload)
+
+        assert profile.city == "Berlin"
+        assert profile.social_scene == "techno"
+        assert profile.darkness_level == 4
+        assert profile.occupation == "doctor"
+        assert profile.hobbies == ["music", "travel"]
+        assert profile.life_stage == "creative"
+        assert profile.interest == "photography"
+
+    def test_build_profile_from_jsonb_empty_payload(self) -> None:
+        """GH onboarding-pipeline-bootstrap: Empty JSONB uses defaults."""
+        from nikita.onboarding.models import build_profile_from_jsonb
+
+        profile = build_profile_from_jsonb({})
+
+        assert profile.darkness_level == 3  # default fallback
+        assert profile.city is None
+        assert profile.occupation is None
+        assert profile.hobbies == []
+
+
 class TestGenerateFirstNikitaMessage:
     """Tests for the generate_first_nikita_message function."""
 
@@ -274,6 +345,7 @@ class TestHandoffResultFields:
             mock_send.return_value = {"success": True}
             with patch("nikita.onboarding.handoff.generate_and_store_social_circle"):
                 with patch.object(manager, "_bootstrap_pipeline"):
+                    manager._seed_conversation = AsyncMock(return_value=None)
                     result = await manager.execute_handoff(
                         user_id=user_id,
                         telegram_id=123456789,
@@ -295,6 +367,7 @@ class TestHandoffResultFields:
             mock_send.return_value = {"success": True}
             with patch("nikita.onboarding.handoff.generate_and_store_social_circle"):
                 with patch.object(manager, "_bootstrap_pipeline"):
+                    manager._seed_conversation = AsyncMock(return_value=None)
                     result = await manager.execute_handoff(
                         user_id=user_id,
                         telegram_id=123456789,
@@ -314,6 +387,7 @@ class TestHandoffResultFields:
             mock_send.return_value = {"success": True}
             with patch("nikita.onboarding.handoff.generate_and_store_social_circle"):
                 with patch.object(manager, "_bootstrap_pipeline"):
+                    manager._seed_conversation = AsyncMock(return_value=None)
                     result = await manager.execute_handoff(
                         user_id=user_id,
                         telegram_id=123456789,
@@ -350,6 +424,7 @@ class TestHandoffIntegration:
             mock_send.return_value = {"success": True, "message_id": 999}
             with patch("nikita.onboarding.handoff.generate_and_store_social_circle"):
                 with patch.object(manager, "_bootstrap_pipeline"):
+                    manager._seed_conversation = AsyncMock(return_value=None)
                     result = await manager.execute_handoff(
                         user_id=user_id,
                         telegram_id=123456789,
@@ -375,6 +450,7 @@ class TestHandoffIntegration:
             mock_send.return_value = {"success": True}
             with patch("nikita.onboarding.handoff.generate_and_store_social_circle"):
                 with patch.object(manager, "_bootstrap_pipeline"):
+                    manager._seed_conversation = AsyncMock(return_value=None)
                     result = await manager.execute_handoff(
                         user_id=user_id,
                         telegram_id=123456789,
@@ -398,6 +474,7 @@ class TestHandoffIntegration:
             mock_send.return_value = {"success": True}
             with patch("nikita.onboarding.handoff.generate_and_store_social_circle"):
                 with patch.object(manager, "_bootstrap_pipeline"):
+                    manager._seed_conversation = AsyncMock(return_value=None)
                     result = await manager.execute_handoff(
                         user_id=user_id,
                         telegram_id=123456789,

--- a/tests/onboarding/test_handoff_phone_routing.py
+++ b/tests/onboarding/test_handoff_phone_routing.py
@@ -33,6 +33,7 @@ def _make_user(
     user.id = user_id or uuid4()
     user.telegram_id = telegram_id
     user.phone = phone
+    user.onboarding_profile = {"darkness_level": 3}
     return user
 
 

--- a/tests/onboarding/test_pipeline_bootstrap.py
+++ b/tests/onboarding/test_pipeline_bootstrap.py
@@ -38,6 +38,9 @@ class TestPipelineBootstrap:
         manager._update_user_status = AsyncMock()
         manager._get_user_telegram_id = AsyncMock(return_value=12345)
         manager._bootstrap_pipeline = AsyncMock()
+        # GH onboarding-pipeline-bootstrap: mock the conversation seed
+        seed_conv_id = uuid4()
+        manager._seed_conversation = AsyncMock(return_value=seed_conv_id)
 
         result = await manager.execute_handoff(
             user_id=user_id,
@@ -51,7 +54,10 @@ class TestPipelineBootstrap:
         await asyncio.sleep(0)
 
         assert result.success is True
-        manager._bootstrap_pipeline.assert_called_once_with(user_id)
+        manager._seed_conversation.assert_called_once()
+        manager._bootstrap_pipeline.assert_called_once_with(
+            user_id, conversation_id=seed_conv_id
+        )
 
     @pytest.mark.asyncio
     async def test_pipeline_failure_does_not_fail_handoff(self, manager, user_id):
@@ -62,6 +68,7 @@ class TestPipelineBootstrap:
         manager._bootstrap_pipeline = AsyncMock(
             side_effect=Exception("Pipeline exploded")
         )
+        manager._seed_conversation = AsyncMock(return_value=uuid4())
 
         result = await manager.execute_handoff(
             user_id=user_id,
@@ -148,3 +155,182 @@ class TestPipelineBootstrap:
 
             # Should return without error, no pipeline triggered
             await manager._bootstrap_pipeline(user_id)
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_pipeline_with_conversation_id_skips_get_recent(
+        self, user_id
+    ):
+        """GH onboarding-pipeline-bootstrap: When conversation_id is provided,
+        fetch by ID directly — skip get_recent."""
+        manager = HandoffManager()
+
+        mock_conv = MagicMock()
+        mock_conv.id = uuid4()
+
+        mock_conv_repo = AsyncMock()
+        mock_conv_repo.get = AsyncMock(return_value=mock_conv)
+        mock_conv_repo.get_recent = AsyncMock()  # Should NOT be called
+
+        mock_user = MagicMock()
+        mock_user.id = user_id
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get = AsyncMock(return_value=mock_user)
+
+        mock_orchestrator = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_orchestrator.process = AsyncMock(return_value=mock_result)
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock()
+
+        with patch(
+                 "nikita.config.settings.get_settings"
+             ) as mock_settings_fn, \
+             patch(
+                 "nikita.db.database.get_session_maker"
+             ) as mock_gsm, \
+             patch(
+                 "nikita.db.repositories.conversation_repository.ConversationRepository",
+                 return_value=mock_conv_repo,
+             ), \
+             patch(
+                 "nikita.db.repositories.user_repository.UserRepository",
+                 return_value=mock_user_repo,
+             ), \
+             patch(
+                 "nikita.pipeline.orchestrator.PipelineOrchestrator",
+                 return_value=mock_orchestrator,
+             ):
+            mock_settings = MagicMock()
+            mock_settings.unified_pipeline_enabled = True
+            mock_settings_fn.return_value = mock_settings
+
+            mock_gsm.return_value = MagicMock(return_value=mock_session)
+
+            await manager._bootstrap_pipeline(
+                user_id, conversation_id=mock_conv.id
+            )
+
+        # get() called with the conversation_id, NOT get_recent()
+        mock_conv_repo.get.assert_called_once_with(mock_conv.id)
+        mock_conv_repo.get_recent.assert_not_called()
+        mock_orchestrator.process.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_pipeline_without_conversation_id_uses_get_recent(
+        self, user_id
+    ):
+        """GH onboarding-pipeline-bootstrap: Backward compat — when no
+        conversation_id, fall back to get_recent."""
+        manager = HandoffManager()
+
+        mock_conv = MagicMock()
+        mock_conv.id = uuid4()
+
+        mock_conv_repo = AsyncMock()
+        mock_conv_repo.get_recent = AsyncMock(return_value=[mock_conv])
+
+        mock_user = MagicMock()
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get = AsyncMock(return_value=mock_user)
+
+        mock_orchestrator = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_orchestrator.process = AsyncMock(return_value=mock_result)
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock()
+
+        with patch(
+                 "nikita.config.settings.get_settings"
+             ) as mock_settings_fn, \
+             patch(
+                 "nikita.db.database.get_session_maker"
+             ) as mock_gsm, \
+             patch(
+                 "nikita.db.repositories.conversation_repository.ConversationRepository",
+                 return_value=mock_conv_repo,
+             ), \
+             patch(
+                 "nikita.db.repositories.user_repository.UserRepository",
+                 return_value=mock_user_repo,
+             ), \
+             patch(
+                 "nikita.pipeline.orchestrator.PipelineOrchestrator",
+                 return_value=mock_orchestrator,
+             ):
+            mock_settings = MagicMock()
+            mock_settings.unified_pipeline_enabled = True
+            mock_settings_fn.return_value = mock_settings
+
+            mock_gsm.return_value = MagicMock(return_value=mock_session)
+
+            # No conversation_id — uses get_recent
+            await manager._bootstrap_pipeline(user_id)
+
+        mock_conv_repo.get_recent.assert_called_once_with(user_id, limit=1)
+        mock_orchestrator.process.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_handoff_seeds_conversation_before_bootstrap(
+        self, manager, user_id
+    ):
+        """GH onboarding-pipeline-bootstrap: execute_handoff calls
+        _seed_conversation before _bootstrap_pipeline."""
+        call_order = []
+
+        async def mock_seed(*args, **kwargs):
+            call_order.append("seed")
+            return uuid4()
+
+        async def mock_bootstrap(*args, **kwargs):
+            call_order.append("bootstrap")
+
+        manager._send_first_message = AsyncMock(return_value={"success": True})
+        manager._seed_conversation = mock_seed
+        manager._bootstrap_pipeline = mock_bootstrap
+
+        result = await manager.execute_handoff(
+            user_id=user_id,
+            telegram_id=12345,
+            profile=MagicMock(),
+            user_name="TestUser",
+        )
+
+        await asyncio.sleep(0)  # Let background task complete
+
+        assert result.success is True
+        assert call_order[0] == "seed"  # Seed runs before bootstrap
+
+    @pytest.mark.asyncio
+    async def test_voice_handoff_triggers_pipeline_bootstrap(self, manager, user_id):
+        """GH onboarding-pipeline-bootstrap Bug 4 fix: voice callback
+        path now triggers _bootstrap_pipeline."""
+        manager._seed_conversation = AsyncMock(return_value=uuid4())
+        manager._bootstrap_pipeline = AsyncMock()
+
+        with patch.object(
+            manager,
+            "initiate_nikita_callback",
+            return_value={"success": True, "conversation_id": "conv_voice"},
+        ):
+            result = await manager.execute_handoff_with_voice_callback(
+                user_id=user_id,
+                telegram_id=12345,
+                phone_number="+14155551234",
+                profile=MagicMock(),
+                callback_delay_seconds=0,
+            )
+
+        await asyncio.sleep(0)
+
+        assert result.success is True
+        assert result.nikita_callback_initiated is True
+        manager._seed_conversation.assert_called_once()
+        manager._bootstrap_pipeline.assert_called_once()


### PR DESCRIPTION
## Summary
- Fixes 4 structural bugs that broke the post-portal-migration onboarding experience
- Seeds a Conversation row before pipeline bootstrap (Bug 1 + 3: pipeline was silently skipping, Nikita had no memory of her first message)
- Passes full onboarding profile (not just darkness_level) to FirstMessageGenerator (Bug 2: first message was generic)
- Adds pipeline bootstrap to voice callback success path (Bug 4: voice path skipped pipeline entirely)
- Adds city/scene-aware personalization to first message
- Shared `build_profile_from_jsonb()` helper ensures field parity between portal and deferred handoff paths

## Test plan
- [x] 9 new tests covering conversation seed, profile construction, city personalization, voice bootstrap
- [x] All 41 onboarding tests pass
- [x] Full suite: 5857 passed, 0 failed
- [ ] `/qa-review` convergence to 0 blocking + 0 important
- [ ] Manual smoke: portal onboarding → verify personalized first message in Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)