### PR TITLE
chore(rules): enforce QA loop to absolute zero + /implement mandatory

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,7 +71,8 @@ Queries PROJECT_INDEX.json (988 files indexed, 17ms jq). Refresh with `/index` w
 6. **Agent invocation**: Use Task tool to spawn sdd-coordinator, sdd-*-validator agents. Main context is for orchestration only — delegate validation and research to subagents.
 7. **GATE 2 Analyze-Fix Loop**: After 6 validators complete: (a) user reviews validation-reports/, (b) CRITICAL/HIGH → create GH issues + fix spec + re-validate (max 3 iterations), (c) MEDIUM → create GH issue or document as accepted, (d) LOW → log in validation-findings.md, (e) user approves proceeding to Phase 5, (f) gate fails 3x → escalate, NEVER auto-waive.
 8. **Validation Findings Manifest**: Each spec gets `specs/NNN-*/validation-findings.md` with GH issue numbers for CRITICAL/HIGH, accept/defer decisions for MEDIUM, and user approval checkbox.
-9. **PR mandatory**: Every implementation MUST go through a PR. After `/implement` completes, create PR via `gh pr create`, then run `/qa-review --pr N`. Merge only after 0 blocking + 0 important issues.
+9. **PR mandatory**: Every implementation MUST go through a PR. After `/implement` completes, create PR via `gh pr create`, then run `/qa-review --pr N`. Merge only after a fresh review returns 0 findings across ALL severities (including nitpicks).
+10. **`/implement` mandatory**: After `/audit` GATE 2 passes, invoke `/implement` skill formally to orchestrate TDD implementation. Do NOT bypass by dispatching implementor subagents directly — the skill provides guardrails that raw prompts miss. Speed optimization happens WITHIN the skill framework (parallel PRs), not by skipping it.
 
 **Spec Lifecycle Rules**:
 - Specs are living documents — update when implementation diverges from original plan

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -15,8 +15,8 @@ globs: ["**"]
 1. `git checkout -b {type}/{issue}-{description}`
 2. Implement with TDD (tests first)
 3. `gh pr create --title "..." --body "..."`
-4. `/qa-review --pr N` — auto-dispatch via Agent (subagent), iterate fix → re-review until 0 blocking + 0 important. Never prompt user for permission to run this — it is mandatory per these rules.
-5. Squash merge after QA PASS + CI green
+4. `/qa-review --pr N` — auto-dispatch via Agent (subagent). Fix all findings, then dispatch a NEW review agent (fresh context). Repeat until the fresh review returns **0 findings across ALL severities** (0 blocking + 0 important + 0 nitpick). Never self-certify a fix — the fresh reviewer is the authority. Never prompt user for permission — this loop is mandatory.
+5. Squash merge ONLY after a fresh QA review returns absolute zero findings + CI green
 6. `gh issue close N --comment "Fixed in PR #M"`
 7. Post-merge verification (auto-dispatched subagent): smoke test the deployed change (curl probe, log sweep, or dogfood scenario as appropriate). Do not skip. Do not ask permission.
 


### PR DESCRIPTION
## Summary

- pr-workflow.md step 4: QA loop iterates to 0 findings across ALL severities (including nitpicks) via fresh external review
- pr-workflow.md step 5: merge ONLY after fresh review returns absolute zero
- .claude/CLAUDE.md rule 9: updated to match
- .claude/CLAUDE.md rule 10: /implement skill mandatory after GATE 2

## Test plan

- [x] `wc -l` pr-workflow.md ≤ 80 lines
- [x] `wc -l` .claude/CLAUDE.md ≤ 200 lines
- [ ] Fresh QA review (zero findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>