### PR TITLE
feat(onboarding): Spec 213 PR 213-1 — frozen contract surface (contracts.py + tuning.py + adapters.py)

### DIFF
--- a/.claude/plans/onboarding-overhaul-brief.md
+++ b/.claude/plans/onboarding-overhaul-brief.md
@@ -1,0 +1,366 @@
+# Planning Brief: Onboarding Overhaul — Backend Foundation + Portal Wizard Redesign
+
+## Meta
+- **Date**: 2026-04-14
+- **Approach selected**: C (Backend-first → Portal-UX) — expert panel vote 2-1
+- **Decomposition**: 2 SDD specs (Spec 213 backend, Spec 214 portal UX) + 1 recovery PR
+- **Status**: PROPOSED — awaiting `/feature` invocation
+
+## Problem
+
+Portal onboarding is structurally broken + aesthetically downgraded. User reports "5 → 1 experience" + Telegram evidence: Nikita opens with generic meta-message, then denies saying it when user quotes her back — zero conversation continuity. Four structural bugs + lost engagement features + cheap UI compared to landing page.
+
+**Why now**: PR #273 (commit `350a717` / merge `70dff5c`) fixed 4 of the structural bugs but was **force-push-wiped** from master during Spec 212 recovery. Current master tip `87938db` does NOT contain any of #273's fixes. Production is serving the broken code.
+
+## Confirmed Requirements
+
+1. **R1 — Recover PR #273**: 4 structural bugfixes (pipeline bootstrap seed, profile JSONB persistence, conversation continuity, voice-path pipeline gap). 7 files, +495/-18 LOC, clean cherry-pick from `origin/fix/onboarding-pipeline-bootstrap`.
+2. **R2 — Expand profile fields across THREE layers** (critical — devil's advocate C1/C2):
+   - **R2a DB migration**: add nullable columns `name TEXT`, `occupation TEXT`, `age SMALLINT` to `user_profiles` table (`nikita/db/models/profile.py`). Nullable so existing users don't break. RLS: user can read/write own row only.
+   - **R2b Pydantic domain model**: add `name`, `age` fields to `UserOnboardingProfile` (`nikita/onboarding/models.py:76`) — `occupation` already exists. Update `ProfileFieldUpdate.validate_field_name` allow-list at `:204-219`.
+   - **R2c API request schema**: extend `PortalProfileRequest` (`nikita/api/routes/onboarding.py:647`) with `name`, `age`, `occupation` optional fields. Wire into `_trigger_portal_handoff` profile construction.
+   - **Restored by #273** (NOT net-new — comes back via cherry-pick): `city`, `social_scene`, `life_stage`, `interest`, `age` on `UserOnboardingProfile`.
+   - **Net-new in Spec 213**: `name` (both layers), `age` + `occupation` (DB columns), PortalProfileRequest extension.
+3. **R3 — Wire engagement services to portal**: `VenueResearchService.research_venues(city, scene)` + `BackstoryGeneratorService.generate_scenarios(profile, venues)` exist in `nikita/services/` but are Telegram-only. Must plumb to portal submit path.
+4. **R4 — Pipeline readiness gate**: User cannot interact with Nikita until pipeline bootstrap completes. Requires `/pipeline-ready` poll or SSE endpoint + UI spinner with timeout.
+5. **R5 — Portal wizard redesign**: One-thing-at-a-time step flow (not scroll-snap). Match landing aesthetic (`text-[clamp(3rem,7vw,6rem)]`, `font-black`, `tracking-tighter`, void-ambient, glass cards, rose primary `oklch(0.75 0.15 350)`, aurora-orbs, falling-pattern).
+6. **R6 — Progressive game-element introduction**: During onboarding, reveal scoring, chapters, friends (from backstory) — make the game start during onboarding, not after.
+7. **R7 — Dynamic first message**: First Telegram message to use ALL collected data (city, scene, occupation, backstory scenario, selected friends).
+
+8. **R8 — Conversation continuity (user's #1 complaint)**: "Nikita denies sending the first message when user quotes her back." Fix path:
+   - Cherry-pick 350a717 restores `_seed_conversation()` which creates a `Conversation` row with `messages[0] = {role: "assistant", content: first_message}` BEFORE the user's first reply.
+   - **Acceptance criterion**: after onboarding, user replies with the exact first-message text; Nikita's next response acknowledges (does not deny) the prior turn. Testable via E2E.
+   - This is a pipeline memory/history problem, not a first-message-generation problem. R7 (dynamic message) and R8 (continuity) are independent — both must be verified.
+
+### Type-layer disambiguation (load-bearing)
+- `UserOnboardingProfile` = Pydantic model, lives in `nikita/onboarding/models.py`, persisted as JSONB on `users.onboarding_profile`.
+- `UserProfile` = SQLAlchemy ORM model, lives in `nikita/db/models/profile.py`, persists to `user_profiles` table.
+- `BackstoryGeneratorService.generate_scenarios(profile, venues)` at `:81` accepts `UserProfile` (ORM), NOT `UserOnboardingProfile` (Pydantic).
+- Spec 213 MUST provide an adapter (in `portal_onboarding.py` facade) to bridge Pydantic → ORM before invoking the backstory service. Do not assume they are interchangeable.
+
+## Research Summary (file:line evidence)
+
+### Backend surface
+- `nikita/onboarding/handoff.py:336` `execute_handoff`, `:459` `_bootstrap_pipeline` (BROKEN — queries empty conversation), `:505` `_send_first_message`, `:532` `execute_handoff_with_voice_callback`
+- `nikita/api/routes/onboarding.py:647` `PortalProfileRequest`, `:726` `save_portal_profile`, `:822` `_trigger_portal_handoff`, `:871` **profile-stripping bug** (builds `UserOnboardingProfile(darkness_level=drug_tolerance)` only)
+- `nikita/onboarding/models.py:76` `UserOnboardingProfile` (current fields: `timezone`, `occupation`, `hobbies`, `personality_type`, `hangout_spots`, `darkness_level`, `pacing_weeks`, `conversation_style`). `ProfileFieldUpdate.validate_field_name` at `:204-219` — **allow-list must be updated for each new field**.
+- `nikita/services/venue_research.py:79` `VenueResearchService` — Firecrawl + 30-day `VenueCache`, timeout fallback
+- `nikita/services/backstory_generator.py:81` `BackstoryGeneratorService` — Pydantic AI + Claude, 3 tones (romantic/intellectual/chaotic)
+- `nikita/platforms/telegram/onboarding/handler.py` — OLD wiring reference (Telegram-only)
+- `nikita/pipeline/orchestrator.py:31` — 11-stage pipeline
+
+### Portal surface
+- `portal/src/app/onboarding/onboarding-cinematic.tsx` — 5-section scroll-snap (to be replaced)
+- `portal/src/app/onboarding/sections/profile-section.tsx` — collects city/scene/darkness/phone only
+- `portal/src/app/onboarding/schemas.ts` — zod has `life_stage` + `interest` but UI doesn't collect them
+- `portal/src/components/glass/glass-card.tsx` — 4 variants
+- `portal/src/components/landing/hero-section.tsx` — typography reference
+- `portal/src/components/landing/{aurora-orbs,falling-pattern,glow-button,pitch-section,stakes-section}.tsx` — reusable atmosphere components
+- `portal/src/app/onboarding/components/ambient-particles.tsx` — canvas atmosphere
+
+### Hygiene state (must clean BEFORE spec)
+- 6 orphaned worktrees in `.claude/worktrees/` (will conflict with new parallel agents)
+- 8 stale open PRs (#261, #249, #185, #212, #210, #206, #205, #186) — all superseded
+- `specs/212-phone-capture-onboarding-ux/` missing (Spec 212 landed without spec dir)
+- `specs/081-onboarding-redesign-progressive-discovery/` not archived (will be superseded by Spec 214)
+- ROADMAP.md stale: tests_total 5533 → actual 5857+; last_deploy 2026-03-23 → actual 2026-04-14; Cloud Run 00235-lh8 → actual 00248-7vp; missing Specs 210, 212; 213/214 not yet registered
+
+### Test surface gaps
+- Zero tests exist for: city research from portal path, backstory from portal path, `age`/`occupation` fields, multi-step wizard navigation
+- `test_pipeline_bootstrap.py::test_bootstrap_skipped_if_flag_disabled` — zero-assertion shell
+- `test_bootstrap_pipeline_processes_conversation` — no sibling for EMPTY-recent case (production path)
+- Portal: `tsc --noEmit` not chained into `next build` — PR #272's type-failure risk persists
+- E2E: 13 `networkidle` occurrences in `onboarding.spec.ts` — will stall on async polling
+
+## Approach Selection — Approach C (Backend-First → Portal-UX)
+
+**Why (from approach evaluator panel 2-1)**:
+- **Architect**: clean separation, each PR single blast radius, API contract forced upfront
+- **SRE**: backend stream tested in isolation before portal traffic — `_bootstrap_pipeline`, service timeouts, fallback paths load-tested safely
+- **UX (dissenting)**: prefers incremental wizard rollout; mitigated by shipping Spec A behind flag + short internal dogfood before Spec B merges
+
+Rejected B (strangler fig) — wrapper-of-wrapper creates hidden coupling via shared `useForm` FormContext; doubles integration test surface.
+
+Rejected A (big-bang v2 route) — single PR > 400 LOC; no incremental confidence signal; Firecrawl degradation on launch-day hangs every submit.
+
+## Decomposition
+
+```
+Phase 0: Hygiene cleanup (non-SDD, pre-spec)
+    ├── Cherry-pick 350a717 → master via 1 small PR (PR RESTORE)
+    ├── Close 8 stale PRs
+    ├── Prune 6 orphaned worktrees
+    ├── Archive specs/081 → specs/archive/081
+    ├── Create specs/212 directory (post-hoc, from landed code)
+    └── Sync ROADMAP.md
+
+Spec 213 — Onboarding Backend Foundation (SDD-driven)
+    ├── R2: Model fields (age, name, occupation)
+    ├── ProfileFieldUpdate allow-list update
+    ├── R3: Wire VenueResearchService + BackstoryGeneratorService to portal path
+    ├── Timeout guards + fallbacks (NEW: per-service budgets)
+    ├── R4: /pipeline-ready poll endpoint + readiness gate
+    ├── R7 backend: FirstMessageGenerator uses full profile + backstory
+    └── Tests: unit + integration + @pytest.mark.integration for services
+
+Spec 214 — Portal Onboarding Wizard (SDD-driven)
+    ├── Requires: Spec 213 merged + API contract frozen
+    ├── R5: One-at-a-time wizard using landing aesthetic
+    ├── R6: Progressive game element introduction
+    ├── New fields collected: age, name, occupation
+    ├── Pipeline-ready gate with spinner + timeout UI
+    ├── Fix networkidle + add tsc --noEmit to build step
+    └── Archives specs/081
+```
+
+## Wizard Steps (Spec 214) — Enumerated — DOSSIER FORM APPROACH (revised after UX review)
+
+**Approach**: "The Dossier Form" — panel vote 2-1 (Frontend + Backend) over "The Drop" (chat) and "The Audition" (full-screen Nikita video). Persona framing: Nikita is building a classified file on the user. Power dynamic: she's evaluating. Each field is a dossier entry.
+
+**Reorder principle**: backstory reveal is the emotional climax and MUST precede phone ask (ride peak investment).
+
+| # | Step | Field(s) / content | Gate / service call |
+|---|---|---|---|
+| 1 | Landing (dossier entry) | — | "Nikita has been watching. She wants to know if you're worth it." → magic link login |
+| 2 | Auth | `email` | Nikita-voiced magic link email. Subject: "Someone wants to talk to you (it's me)." |
+| 3 | Dossier header | — | Full-width classified file. Scores shown as REAL `50/50/50/50` (not fake 75/100). Copy: "Prove me wrong." |
+| 4 | Location (dossier field) | `location_city` | Async VenueResearch fires on blur → inline venue preview appears below ("She found: Berghain, Tresor..."); poll `venue_research_status` via /pipeline-ready |
+| 5 | Scene | `social_scene` | Pre-filled guess "Suspected: techno?" — user confirms/corrects |
+| 6 | Darkness | `darkness_level` | Slider 1-5 with Nikita narration: "I'll know if you're lying about this." |
+| 7 | Identity (dossier fields) | `name`, `age`, `occupation` | Three fields, Nikita-voiced. Occupation informs backstory. |
+| 8 | **Backstory reveal (CLIMAX)** | user picks scenario | Portal calls `POST /onboarding/preview-backstory` (FR-4a). Shows 3 scenarios. Dossier stamps "ANALYZED". |
+| 9 | Phone ask (post-climax) | `phone` | Dossier field "Direct line: [I want to call you]". Binary: [Give number] (voice = premium) vs [Start in Telegram] (default) |
+| 10 | Pipeline ready gate | — | POST `/onboarding/profile` with `cache_key` (reuses preview cache) → poll `/pipeline-ready` → dossier stamps "CLEARANCE: CLEARED" → 20s timeout degrades to "PROVISIONAL" |
+| 11 | Handoff | — | "Application... accepted. Barely." Telegram deeplink + QR (desktop→mobile). Voice path: call countdown UI. Text: "Open Telegram" CTA. |
+
+Note: steps 1-2 are pre-wizard; 3 is dossier header (no input); 4-9 are 6 data-collection dossier fields; 10-11 are handoff.
+
+## New Requirements (added from UX review)
+
+These must be reflected in Spec 213 (backend) or Spec 214 (portal) scope:
+
+| ID | Requirement | Owner | Status |
+|---|---|---|---|
+| **NR-1** | Wizard state persistence: partial profile + current step persist to `users.onboarding_profile.wizard_step` JSONB + localStorage keyed by user_id. Resume from last step on return (tab close, network loss, mobile interruption). | Spec 214 | ADD |
+| **NR-2** | `/pipeline-ready` response exposes `venue_research_status` + `backstory_available` fields (for step-4 inline preview + step-8 reveal gate) | Spec 213 (added as FR-2a) | ADDED ✓ |
+| **NR-3** | Phone country validation pre-flight: client-side check against ElevenLabs supported regions BEFORE submit. If unsupported → show inline + offer Telegram fallback | Spec 214 | ADD |
+| **NR-4** | QRHandoff component for desktop→mobile Telegram handoff. No service dep, uses qrcode.react or similar. Shows alongside Telegram deeplink button on step 11. | Spec 214 | ADD |
+| **NR-5** | Voice fallback polling UI: if phone provided, portal polls handoff result and shows appropriate state (calling → connected → ended OR call failed → Telegram fallback with explanation). No silent degradation. | Spec 214 | ADD |
+| **NR-6** | `POST /onboarding/preview-backstory` endpoint (FR-4a) — portal-wizard step 8 backstory reveal BEFORE profile POST | Spec 213 (added as FR-4a) | ADDED ✓ |
+
+## Copy Guidelines (Nikita Voice — Persona Consistency)
+
+All portal copy in Nikita's voice. NO sterile SaaS language. Per `.claude/rules/review-findings.md` few-shot echo rule: grep all persona/prompt files when changing canonical phrases.
+
+Examples (draft, refine during Spec 214 /feature):
+- Button: "Show her" NOT "Get started"
+- Field label: "Location: [REDACTED]" NOT "City"
+- Slider label: "How far can I push you?" NOT "Darkness level"
+- Stamp: "CLEARANCE: PENDING" → "CLEARED" / "PROVISIONAL" NOT "Processing..."
+- Landing hero: "Nikita has been watching." NOT "Welcome to Nikita"
+- Email subject: "Someone wants to talk to you (it's me)" NOT "Your magic link"
+- Post-submit: "Application... accepted. Barely." NOT "Profile saved successfully"
+
+## Pre-Spec-214 Standalone Fixes (ship independently, don't block on full redesign)
+
+Per UX expert ROI top-5, these can ship as standalone portal PRs BEFORE Spec 214:
+1. **Voice vs Telegram overlay split** — current shows identical "Opening Telegram..." for both paths → split into voice-countdown UI vs Telegram deeplink UI. Portal-only, 1 PR.
+2. **Real demo scores** — ScoreSection currently shows hardcoded 75/100 + 68-76% bars → show 50/50/50/50 with "where you start" label. Portal-only, 1-line change.
+3. **Pending_handoff trigger on /start** — Telegram `/start` handler doesn't check `pending_handoff`. Add explicit check after OTP verification → fire handoff immediately. Backend only, 1 PR.
+4. **1500ms → 3000ms redirect + iOS fallback button immediately** — small portal change.
+5. **Nikita-voiced copy rewrite** — pure text change, no logic. Can ship per-section incrementally.
+
+## Edge-Case Decisions Needed (record in spec.md)
+
+| Scenario | Decision |
+|---|---|
+| City research times out | Spec: 15s budget; on timeout, first message uses scene-only flavor. Log `portal_handoff.venue_research` outcome. |
+| Backstory generation fails | Spec: 20s budget; on fail, cache-bust + pipeline uses default persona prompt (not scenario-specific). Log `portal_handoff.backstory` outcome. |
+| Mobile tab-switch mid-wizard | Spec: persist step state to `users.onboarding_profile.wizard_step` JSONB key. Resume from last completed step on remount. |
+| Phone 409 mid-wizard | Spec: phone step validates on step-advance (not final submit). 409 → inline error on phone field + rewind to that step. |
+| Re-onboarding (existing partial) | Spec: detect via `users.onboarding_completed_at IS NULL AND onboarding_profile IS NOT NULL` → resume; else fresh start. |
+| Pipeline gate timeout (>20s) | Spec: show "Nikita is getting ready..." spinner 0-15s, "Almost there..." 15-25s, then let user proceed with graceful message if 25s+. Log `pipeline_ready.timeout`. |
+| Voice-first user (has phone) | Same wizard UI through step 9 (city research + backstory still relevant for voice prompt personalization); on step 10 pipeline gate, route to voice callback instead of Telegram (per Spec 212 routing). Voice agent receives same enriched profile + backstory. |
+| Existing user re-onboarding (partial profile) | Detect via `users.onboarding_completed_at IS NULL AND users.onboarding_profile IS NOT NULL`. Resume from step matching last JSONB key written. Backfill missing new fields (`name`/`age`/`occupation`) by asking again. |
+| New user on existing `user_profiles` row | Migration adds nullable columns (`name`, `age`, `occupation` default NULL). Re-onboarding prompts fill them. No data loss for completed-onboarding users. |
+| Pipeline gate feature flag OFF | Fall back to 1s optimistic pass-through (not old no-gate behavior) — so rollback preserves wait-for-readiness UX. Flag governs gate TIMEOUT, not existence. |
+| BackstoryGenerator cache | Key on `(city, scene, darkness_level, life_stage, interest, age_bucket, occupation_bucket)` — age bucketed to decade (20s/30s/40s/etc.), occupation bucketed to category (tech/arts/finance/service/other). 30-day TTL. |
+
+## Verification Strategy
+
+1. **Recovery smoke**: after `git cherry-pick 350a717`, run `pytest tests/onboarding/ -x -q` — green before touching anything else.
+2. **Spec 213 integration contract**: `@pytest.mark.integration` test — mock Firecrawl + Claude, assert `research → scenarios → FirstMessageGenerator output` chain produces personalized text containing city + scene + backstory hook.
+3. **Spec 213 contract freeze**: publish `OnboardingV2ProfileRequest` / `OnboardingV2ProfileResponse` as Pydantic schemas; Spec 214 imports them.
+4. **Spec 214 visual**: Playwright screenshot (reference image) + explicit `waitForSelector('[data-testid="pipeline-ready"]')` replacing `networkidle`.
+5. **Spec 214 UX**: Playwright full-journey test — start wizard → complete all 8 steps → pipeline gate → first Telegram message arrives → contains city + scene + occupation.
+6. **Stochastic budget**: per `rules/stochastic-models.md`, if any timeout becomes a named distribution (e.g., `VENUE_RESEARCH_TIMEOUT_S: Final[float]`), add rationale comment with prior values + regression test.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `UserOnboardingProfile` schema change ripples to 15+ modules (voice agents, text agents) | Add fields as `Optional[T] = None`; no existing call sites break. |
+| Pydantic vs ORM type confusion in `portal_onboarding.py` facade | Facade has ONE responsibility: accept `UserOnboardingProfile` + user_id, load/create `UserProfile` ORM row, call services, return scenarios. Canonical mapping table documented in spec.md. |
+| BackstoryGenerator Claude cost explodes with onboarding volume | 30-day scenario cache keyed on `(city, scene, darkness, life_stage, interest, age_bucket, occupation_bucket)`; one Claude call per unique profile shape. Budget: <$0.05/unique profile shape; Anthropic docs: Haiku at $0.25/MTok input. |
+| VenueResearchService Firecrawl cost on new cities | 30-day `VenueCache` already exists; new cities cost ~$0.02/scrape via Firecrawl. Budget alert if >100 unique cities/day. |
+| PII exposure in logs/telemetry | `name`, `age`, `occupation`, `phone` are PII. Spec 213 MUST include: (a) Supabase RLS: user reads/writes only own `user_profiles` row, (b) log redaction — logger extras contain `user_id` only, never PII, (c) no PII in exception `%s` echoes (prior bug in `voice_flow.py` per PR #270). |
+| Cherry-pick 350a717 conflicts with `87938db`-era changes to same files | Branch `origin/fix/onboarding-pipeline-bootstrap` confirmed reachable. Run `git cherry-pick 350a717` locally; on conflict, re-apply from diff (495 LOC already reviewed and merged once — known-good). |
+| SSE pipeline-ready endpoint connection churn on Cloud Run scale-to-zero | Use poll (2s interval, 20s max) instead of SSE — simpler + robust to cold start. |
+| Wizard state-preservation introduces XSS if JSONB rendered unsanitized | Never render `wizard_step` payload directly; treat as internal state only. |
+| Spec 214 merges before Spec 213 contract is truly frozen | Spec 213 publishes `OnboardingV2ProfileRequest` / `OnboardingV2ProfileResponse` / `BackstoryOption` to a shared `nikita/onboarding/contracts.py` module EARLY (first Spec 213 PR). Spec 214 can stub against this module immediately — recovers parallelism UX reviewer wanted. |
+| Pipeline gate flag-off regresses to "Nikita forgets first message" (user's #1 complaint) | Feature flag controls TIMEOUT only, not gate existence. Flag-off = 1s optimistic pass-through. Gate itself is permanent. |
+| R8 (continuity) not independently testable from R7 (dynamic message) | E2E asserts: user replies with first-message text verbatim → Nikita's response references it ("yes, I did say that...") rather than denying. Mock pipeline with known first-message fixture. |
+
+## Dependency DAG
+
+```
+  [Worktree prune]  ←  ONLY true blocker to /feature 213
+         │
+         ▼
+  [PR RESTORE: cherry-pick 350a717]  (critical — fixes production bug)
+         │                                                │
+         ├──── parallel ──────────────────────────┐       │
+         ▼                                        ▼       ▼
+  [Close 8 stale PRs]      [Archive specs/081]  [Sync ROADMAP.md]
+                                                          │
+  ┌──────────────────────────────────────────────────────┘
+  ▼
+  [Spec 213: /feature → /plan → /tasks → /audit]
+         │
+         ▼
+  [Spec 213 PR #1: contract module — `nikita/onboarding/contracts.py`] ← early freeze
+         │                                                             │
+         │ ────────────────────────── parallel possible ───────────────┤
+         ▼                                                             ▼
+  [Spec 213 PRs #2-N: TDD impl]                            [Spec 214: /feature → /plan → /tasks]
+         │                                                             │
+         ▼                                                             ▼
+  [Merge Spec 213 + dogfood 1 day]                   [Spec 214 audit blocks on 213 merge]
+         │                                                             │
+         └──────────────────────────────┬──────────────────────────────┘
+                                        ▼
+                            [Spec 214 /implement — imports contracts]
+                                        │
+                                        ▼
+                         [Spec 214 PRs — TDD loop, 2s poll gate]
+                                        │
+                                        ▼
+                        [Merge Spec 214 + Cloud Run + Vercel deploy]
+                                        │
+                                        ▼
+                        [E2E: full wizard + R7 + R8 verification]
+```
+
+**Critical path correction**: only worktree pruning blocks `/feature 213`. Closing stale PRs, archiving 081, syncing ROADMAP are hygiene parallels, not prerequisites.
+
+## Files Most Likely Touched
+
+### Spec 213
+- `nikita/onboarding/contracts.py` (NEW — shared Pydantic types: `OnboardingV2ProfileRequest`, `OnboardingV2ProfileResponse`, `BackstoryOption`, `PipelineReadyState`) — ships FIRST so Spec 214 can stub against it
+- `nikita/onboarding/models.py` (+2 fields `name`, `age` on `UserOnboardingProfile`; +allow-list entries at `:204-219`; `build_profile_from_jsonb` helper from #273 already handles this)
+- `nikita/db/models/profile.py` (+3 nullable columns `name`, `occupation`, `age` on `user_profiles`)
+- Supabase migration via MCP (`mcp__supabase__apply_migration`) — `alter_user_profiles_add_name_occupation_age`
+- `nikita/api/routes/onboarding.py` (extend `PortalProfileRequest:647` with new fields; new `/pipeline-ready` endpoint; update `_trigger_portal_handoff:822` to call facade)
+- `nikita/services/portal_onboarding.py` (NEW — thin facade: accepts `UserOnboardingProfile` + `user_id`, loads/creates `UserProfile` ORM row via `user_profile_repo`, invokes `VenueResearchService.research_venues` with 15s budget, invokes `BackstoryGeneratorService.generate_scenarios` with 20s budget, returns `list[BackstoryOption]`)
+- `nikita/services/venue_research.py`, `nikita/services/backstory_generator.py` (add `asyncio.wait_for` timeout wrappers; extend cache key in backstory for new fields)
+- `nikita/onboarding/handoff.py` (FirstMessageGenerator enhanced to reference backstory scenario; R8 continuity already covered by `_seed_conversation` from #273)
+- `nikita/onboarding/tuning.py` (NEW — `VENUE_RESEARCH_TIMEOUT_S: Final[float] = 15.0`, `BACKSTORY_GEN_TIMEOUT_S: Final[float] = 20.0`, `PIPELINE_GATE_POLL_INTERVAL_S`, `PIPELINE_GATE_MAX_WAIT_S` — per `.claude/rules/tuning-constants.md`)
+- `tests/onboarding/test_portal_onboarding.py` (NEW — facade unit + integration)
+- `tests/services/test_venue_research_portal.py` (NEW — timeout + fallback)
+- `tests/services/test_backstory_generator_portal.py` (NEW — cache key + timeout + PII-safe logs)
+- `tests/api/routes/test_onboarding_pipeline_ready.py` (NEW — poll semantics)
+- `tests/onboarding/test_r8_conversation_continuity.py` (NEW — E2E-style: seed message acknowledged, not denied)
+- `tests/onboarding/test_tuning_constants.py` (regression guard on timeouts)
+
+### Spec 214
+- `portal/src/app/onboarding/onboarding-wizard.tsx` (NEW, replaces cinematic)
+- `portal/src/app/onboarding/steps/` (NEW directory: 8 step components)
+- `portal/src/app/onboarding/schemas.ts` (expanded)
+- `portal/src/app/onboarding/hooks/use-pipeline-ready.ts` (NEW — poll hook)
+- `portal/src/app/onboarding/components/wizard-progress.tsx` (NEW)
+- `portal/src/components/landing/` (import atmosphere components — no modification)
+- `portal/package.json` (add `"prebuild": "tsc --noEmit"` to prevent PR #272 recurrence)
+- `portal/e2e/onboarding.spec.ts` (rewrite — fix networkidle + add wizard navigation)
+
+## Next Action
+
+Executable sequence:
+
+```bash
+# 0. Verify recovery target is reachable
+git log origin/fix/onboarding-pipeline-bootstrap --oneline | head -5
+# expect: 350a717 fix(onboarding): seed conversation before pipeline bootstrap + full profile passthrough
+
+# 1. Worktree prune (only true blocker)
+git worktree list
+# for each stale worktree path:
+git worktree remove --force <path>
+git worktree prune
+
+# 2. PR RESTORE (critical production recovery)
+git checkout -b fix/restore-pr-273-onboarding-pipeline master
+git cherry-pick 350a717
+pytest tests/onboarding/ -x -q   # must be green
+gh pr create --title "fix(onboarding): restore PR #273 (pipeline bootstrap + profile + continuity)" \
+  --body "PR #273 was force-push-wiped from master during Spec 212 recovery. Cherry-picks commit 350a717 back onto master. Restores 4 structural fixes: pipeline bootstrap seed, profile JSONB persistence, conversation continuity, voice-path pipeline gap."
+# then: /qa-review --pr N → 0/0/0 → squash merge
+
+# 3. Parallel hygiene (non-blocking)
+gh pr close 261 --comment "Superseded by Spec 210 (b0f7e7a)"
+gh pr close 249 --comment "Superseded by PRs #252 + #253"
+gh pr close 185 --comment "Landed via Spec 212"
+gh pr close 212 --comment "Pre-sprint, stale"
+gh pr close 210 --comment "Pre-sprint, stale (portal testing overhaul)"
+gh pr close 206 --comment "Stale docs (Tier 2 diagrams)"
+gh pr close 205 --comment "Superseded by Spec 210 v2 (b0f7e7a)"
+gh pr close 186 --comment "Stale (deployment docs + E2E migration)"
+git mv specs/081-onboarding-redesign-progressive-discovery specs/archive/081-onboarding-redesign-progressive-discovery
+# Backfill specs/212 post-hoc from commit history (optional but recommended)
+# Run /roadmap sync (or manual edit to match actual state)
+
+# 4. Spec 213 SDD chain
+/roadmap add 213 onboarding-backend-foundation
+/feature 213   # author spec.md with R1-R8, edge cases, wizard step 1-11 (backend parts)
+/plan 213
+/tasks 213
+/audit 213     # 6 parallel sdd-*-validator agents until PASS
+/implement 213 # mandatory skill — not raw subagent dispatch
+
+# 5. Spec 214 SDD chain (can start /feature + /plan while 213 implements, but /audit blocks on 213 merge)
+/roadmap add 214 portal-onboarding-wizard
+/feature 214   # imports contracts from Spec 213
+/plan 214
+/tasks 214
+# wait for Spec 213 merged
+/audit 214
+/implement 214
+
+# 6. Deploy + E2E
+gcloud run deploy nikita-api --source . --region us-central1 --project gcp-transcribe-test --allow-unauthenticated
+cd portal && npm run build && vercel --prod
+# Run /e2e full — verify R1-R8 end-to-end
+```
+
+## References
+- `~/.claude/plans/quirky-floating-liskov.md` — prior plan (user-home, covers WS-1 = PR RESTORE scope) — `ls ~/.claude/plans/` to verify
+- `.claude/plans/post-compaction-handoff.md` — handoff state (contained incorrect claim that #273 was on master — confirmed orphaned)
+- `specs/081-onboarding-redesign-progressive-discovery/spec.md` — prior portal onboarding spec (to archive)
+- `specs/212-phone-capture-onboarding-ux/` — **missing directory** (Spec 212 landed without spec dir); backfill recommended but not blocking
+- `.claude/rules/testing.md`, `.claude/rules/tuning-constants.md`, `.claude/rules/stochastic-models.md`, `.claude/rules/pr-workflow.md`, `.claude/rules/review-findings.md`, `.claude/rules/subagent-safety.md`
+
+## Reviewer Findings Addressed
+- **Devil's Advocate C1** (Pydantic vs ORM confusion): R2 split into R2a/R2b/R2c; type disambiguation block added.
+- **Devil's Advocate C2** (PortalProfileRequest extension missing from Spec 213): R2c explicitly in Spec 213.
+- **Devil's Advocate C3** (conversation continuity not tied to R7): R8 added with independent AC.
+- **Devil's Advocate H1** (migration strategy): nullable columns in R2a + re-onboarding edge case.
+- **Devil's Advocate H2** (ORM adapter): explicit in `portal_onboarding.py` facade description.
+- **Devil's Advocate H3** (PII): risk row added; log redaction + RLS requirements.
+- **Devil's Advocate H4** (DAG serialization): contracts.py ships in first 213 PR — enables parallel 214 development.
+- **Devil's Advocate H5** (cache key): new key includes all personalization inputs.
+- **Process P1** (8 steps unenumerated): wizard steps 1-11 table added.
+- **Process P2** (350a717 reachability): verification command in Next Action step 0.
+- **Process P3** (edge table header): "Decision required" → "Decision".
+- **Process P4** (portal_onboarding.py missing from tasks): added to Spec 213 Files Touched.
+- **Process P5** (R2 overlap confusing): split into restored-via-cherry-pick vs net-new.
+- **Process P6** (hygiene blocking): DAG redrawn — only worktree prune is critical path.
+- **Process P7** (Playwright not executable): spec.md authors will specify exact commands during /feature 214.

--- a/.claude/plans/post-compaction-handoff.md
+++ b/.claude/plans/post-compaction-handoff.md
@@ -1,0 +1,141 @@
+# Post-Compaction Handoff — 2026-04-14T19:00Z
+
+## What Just Happened
+
+**1. Production recovery (done, deployed):**
+- PR #277 merged — cherry-picked PR #273 (`350a717`) that was force-push-wiped from master during Spec 212 cleanup. 4 structural onboarding bugs restored: pipeline bootstrap seed, profile JSONB persistence, conversation continuity (R8), voice-path pipeline gap. All 337 `tests/onboarding/` pass.
+- PR #278 merged — hygiene (ROADMAP sync tests 5933→5934, last_deploy 2026-04-13, Cloud Run `nikita-api-00249-mdv`; archive Spec 081 to `specs/archive/`; register Spec 210 MERGED, Specs 212 COMPLETE, 213/214 PLANNED).
+- 8 stale PRs closed (#261, #249, #185, #212, #210, #206, #205, #186).
+- 6 orphaned worktrees pruned.
+
+**2. Spec 213 SDD GATE 2 PASS (10 iterations total, absolute zero):**
+- **Spec**: `specs/213-onboarding-backend-foundation/spec.md` (~1050 lines, 14 FRs + 2 iter-6 amendments, 7 user stories, 30 ACs with test-file names)
+- **Journey**: iter-1 60 findings → iter-2 14 → iter-3 4 → iter-4 1 → iter-5 CLEAN (first convergence) → UX review triggered amendments → iter-6 14 new findings → iter-7 7 → iter-8 3 → iter-9 2 → **iter-10 CLEAN (final)**
+- All 6 validators PASS at absolute zero: frontend, auth, data-layer, testing, architecture, API
+- **Amendments from UX review** (FR-2a + FR-4a): `/pipeline-ready` exposes `venue_research_status` + `backstory_available`; NEW `POST /onboarding/preview-backstory` endpoint for backstory reveal BEFORE phone ask (emotional climax → commitment order).
+
+**3. UX iteration completed (post GATE-2 iter-5, pre iter-6):**
+- Dispatched: `pr-codebase-intel`, `tree-of-thought-agent` (current diagram), UX expert (research + 3 approaches), `pr-approach-evaluator` (panel 2-1 vote), `tree-of-thought-agent` (target diagram).
+- **Approach selected**: Approach B "The Dossier Form" (reuses existing FormProvider shell, adds classified-file metaphor + Nikita-voiced copy + real 50/50 scores + backstory-before-phone reorder).
+- 5 new requirements added to Spec 214 brief: NR-1 wizard state persistence, NR-3 phone country pre-flight, NR-4 QRHandoff, NR-5 voice fallback polling, dossier styling system.
+
+**4. Diagrams written**:
+- `docs/diagrams/onboarding-journey-current.md` (~1050 lines) — current state with all forks + smells
+- `docs/diagrams/onboarding-journey-target.md` (~1050 lines) — Approach B Dossier Form target state with NR mappings
+
+## Current State (verify before acting)
+
+```bash
+git log origin/master --oneline | head -5   # should show PRs #277 + #278 merged
+git status --short                          # expected untracked plan/diagram files only
+gcloud run revisions list --service=nikita-api --region=us-central1 --project=gcp-transcribe-test --limit=1
+# expected: nikita-api-00249-mdv (last deploy 2026-04-13 Spec 212; no Spec 213 deploy yet)
+```
+
+## Where We Are in SDD Flow
+
+Spec 213 passed **GATE 2 (Validation)** — absolute zero across all 6 validators.
+
+**Next phase: Phase 4.5 — User spec walkthrough + approval**.
+
+Per CLAUDE.md SDD rule 7 + `.claude/skills/sdd/phases/04.5-spec-review.md`: user reviews spec.md end-to-end and approves before chaining to `/plan 213`. No tool action required until user approves (or requests changes).
+
+**After user approves**:
+1. `/plan 213` → Phase 5 → plan.md with 5-PR decomposition (PR 213-1 through 213-5, each ≤400 LOC)
+2. `/tasks 213` → Phase 6 → TDD task pairs
+3. `/audit 213` → Phase 7 → final audit (must PASS before Phase 8)
+4. `/implement 213` → Phase 8 — **formal skill invocation, NOT raw subagent dispatch** per SDD rule 10
+5. Each PR through `/qa-review` → absolute-zero across all severities (incl nitpicks) → squash merge
+6. Parallel: `/feature 214` can start once PR 213-1 (contracts.py) lands — Spec 214 imports frozen contracts
+
+## Spec 213 PR Decomposition (to be written during /plan 213)
+
+| PR | Scope | Depends On |
+|---|---|---|
+| **213-1** | `contracts.py` + `tuning.py` + `adapters.py` + tests (FROZEN contract — unblocks Spec 214) | — |
+| **213-2** | Migration (user_profiles columns + backstory_cache + RLS hardening) + ORM + repository | 213-1 |
+| **213-3** | Facade `portal_onboarding.py` + preview endpoint + pre-existing PII fixes at `onboarding.py:154,239` | 213-1, 213-2 |
+| **213-4** | Route file `portal_onboarding.py` + `/pipeline-ready` + `PATCH /profile` + FR-14 session pattern | 213-1, 213-3 |
+| **213-5** | FirstMessageGenerator FR-6 + R8 regression test + e2e + ROADMAP sync to COMPLETE | 213-1..4 |
+
+## Pending Tasks (from task tracker)
+
+- #40 Run `/plan 213` → `/tasks 213` → `/audit 213` (pending user approval of spec.md)
+- #41 Invoke `/implement 213` (formal skill, per SDD rule 10)
+- #42 E2E verification + deploy post-merge
+
+## Critical Context for Continuation
+
+### What the user cares about
+- User originally rated onboarding "5 → 1". Core complaints: Nikita forgets first message, generic opener, pipeline never runs, sterile form-fill UX, phone-before-backstory is backwards.
+- User policy: **ABSOLUTE ZERO** across all severities (CRITICAL + HIGH + MEDIUM + LOW) on SDD validators AND `/qa-review`. Nitpicks count.
+- User authorized >3 SDD iterations (we used 10 on Spec 213). Convergence clearly >3-iter requirement in CLAUDE.md is obsolete.
+- User wants dossier metaphor + Nikita-voiced copy + real scores (not fake 75/100 demo) + backstory BEFORE phone.
+
+### What NOT to do
+- Don't skip `/implement` skill — SDD rule 10 mandates formal invocation (documented feedback memory).
+- Don't merge any PR with open findings (nitpicks count — memory feedback).
+- Don't commit directly to master — PR + `/qa-review` mandatory (pr-workflow.md).
+- Don't touch out-of-scope Spec 081 (archived). Don't revert the PR #273 cherry-pick (PR #277 is the authoritative recovery).
+
+### Architecture insights (hard-won over 10 iterations)
+- `UserOnboardingProfile` (Pydantic, JSONB) ≠ `UserProfile` (SQLAlchemy ORM) — they have DIFFERENT field names. `BackstoryGeneratorService` reads `.city` + `.primary_passion` (NOT `location_city`/`primary_interest`) via duck-typing. Adapter `ProfileFromOnboardingProfile` returns `BackstoryPromptProfile` dataclass with the generator's attribute names.
+- `users.onboarding_completed_at` column DOES NOT EXIST — FR-9 uses existing `onboarding_status` field.
+- `cast(value, JSONB)` is INVALID for string values — must use `cast(json.dumps(value), JSONB)` (PostgreSQL rejects bare `'pending'`).
+- `DatabaseRateLimiter._get_minute_window()` has NO user_id param (not `_minute_window_key(user_id)`) — `_PreviewRateLimiter` subclass must override the correct method.
+- `BackstoryCacheRepository` returns raw `list[dict]` envelope `{scenarios, venues_used}`, NOT domain types. Facade deserializes.
+- `name` in `users.onboarding_profile` JSONB is the canonical key (NOT `user_name` — legacy read sites at `onboarding.py:458-460, 556-557` need update with one-cycle fallback).
+
+### Convergent findings (shouldn't regress)
+These issues were flagged by multiple validators in iter-1, all resolved:
+- `pipeline_state` JSONB write contract (API + Auth + Data-layer + Architecture all flagged)
+- 403 body shape (Frontend + API + Auth)
+- Pydantic↔ORM adapter (API + Architecture)
+- Contract type definitions (Frontend + API)
+
+## Reference Files (all current)
+
+### Spec 213 artifacts
+- `specs/213-onboarding-backend-foundation/spec.md` — spec (13 FRs + 2 amendments, 7 stories, 30 ACs, 17 test files named)
+- `specs/213-onboarding-backend-foundation/validation-findings.md` — findings manifest (all iters, final = 0/0/0/0)
+- `specs/213-onboarding-backend-foundation/validation-reports/{frontend,auth,data-layer,api,testing,architecture}.md` — 6 validator reports per iteration
+
+### Plan + brief
+- `.claude/plans/onboarding-overhaul-brief.md` — planning brief (dossier 11-step journey + 5 NRs + Nikita-voice copy guidelines + pre-214 standalone fixes)
+- `~/.claude/plans/quirky-floating-liskov.md` — top-level plan (WS-1 complete, WS-2 in progress, WS-3 planned, 10-iter GATE 2 record)
+
+### UX iteration
+- `docs/diagrams/onboarding-journey-current.md` — current state with smells
+- `docs/diagrams/onboarding-journey-target.md` — Approach B target state
+
+### Other
+- `ROADMAP.md` — Domain 4 registered Specs 213 + 214; tests 5934; Cloud Run 00249-mdv
+- `.claude/rules/testing.md` / `tuning-constants.md` / `pr-workflow.md` / `stochastic-models.md` / `review-findings.md` — all referenced in spec
+
+## Lessons Logged (permanent)
+
+- **Passing 6 SDD validators doesn't mean the UX is right** — iter-5 was CLEAN but UX review surfaced 19 additional smells (4 blockers) that code-level validators can't see.
+- **Drawing the end-to-end user journey surfaces logical forks feature-specs miss** — e.g., desktop-to-mobile handoff, voice-agent-down fallback, phone-unsupported-country, wizard abandonment, re-onboarding inconsistency.
+- **Multi-validator GATE 2 catches 5-10× more than self-review** — 60 findings vs ~10 estimated.
+- **Spec rewrites introduce NEW findings** — iter-2 added 12, iter-6 added 14. Budget ≥3 iterations; real-world reached 10.
+- **Convergent findings (flagged by N validators) are must-fix signals**.
+- **Force-push recovery can silently wipe merged PRs** — always verify `gh pr view N --json mergeCommit` + `git branch --contains <commit>` before assuming state.
+
+## How to Resume in a Fresh Session
+
+1. Read this file first.
+2. Read `specs/213-onboarding-backend-foundation/spec.md` (the spec awaiting user approval).
+3. Run the Current-State verification block at the top.
+4. Ask user: "Spec 213 passed GATE 2 (absolute zero across 10 iterations). Ready to approve for `/plan 213`?"
+5. On approval → `/plan 213` → `/tasks 213` → `/audit 213` → `/implement 213` (formal skill).
+6. Parallel `/feature 214` can start after PR 213-1 (contracts.py) merges — Spec 214 consumes frozen contracts + the 5 NRs + dossier journey diagram.
+7. Per SDD rule 10: never dispatch implementor subagents directly — always `/implement` skill.
+8. Every PR: `/qa-review --pr N` to absolute zero across all severities before merge.
+9. Post-merge per rule: auto-dispatch smoke test via fresh subagent.
+
+## Quick Sanity Checks Before First Write
+
+- `ls specs/213-onboarding-backend-foundation/spec.md` — should exist
+- `grep -c "CLEAN" specs/213-onboarding-backend-foundation/validation-reports/*.md` — should show clean markers per iter
+- `git log -5 --oneline` — expect recent commits = PR #277 + #278 (no Spec 213 impl yet)
+- `gh pr list --state open --limit 5` — expect PR #276 active (portal-systems-tour, unrelated), no onboarding PRs

--- a/.sdd/audit-trail.md
+++ b/.sdd/audit-trail.md
@@ -12,3 +12,29 @@
 - **Branch** `feat/210-kill-skip-variable-response` created from `origin/master`.
 - **Correction vs brief:** 6 SDD validators exist (not 5 as brief claimed). `sdd-api-validator` IS present. GATE 2 will run all 6 in parallel.
 - **Next:** Phase 4.5 (Spec Review) — mandatory user walkthrough before GATE 2.
+
+## 2026-04-14T19:20Z — Spec 213 Phase 4.5 user approval → Phase 5 start
+- User approved specs/213-onboarding-backend-foundation/spec.md after 10-iteration GATE 2 journey (60 findings → 0)
+- Chaining to /plan 213 (Phase 5) → /tasks → /audit → /implement per SDD workflow
+- 5-PR decomposition defined in spec's Implementation Notes: 213-1 contracts, 213-2 migration+ORM, 213-3 facade, 213-4 routes, 213-5 FirstMessage+e2e
+
+## 2026-04-14T19:30Z — Spec 213 Phase 5 complete
+- plan.md authored (specs/213-onboarding-backend-foundation/plan.md)
+- Synthesizes 14 FRs + 2 amendments into 5-PR decomposition with explicit task DAG
+- Covers all 7 USs with 36 tasks (29 + 7 cross-cutting), 12 [P] parallel markers
+- Includes 3 mermaid diagrams: module deps, PR DAG, request flows
+- All constitutional articles addressed
+- Next: Phase 6 /tasks 213
+
+## 2026-04-14T19:40Z — Spec 213 Phase 6 complete
+- tasks.md authored (47 tasks total: 29 US-mapped + 12 cross-cutting + TG-1..7 + TD-1)
+- TDD steps per impl task (R→V1→G→V2→B→C1→C2)
+- 7 parallelization groups marked
+- Dependency DAG verified acyclic
+- Next: Phase 7 /audit 213
+
+## 2026-04-14T19:50Z — Spec 213 Phase 7 audit PASS
+- audit-report.md: 11/11 articles PASS, 100% FR coverage (21/21), 100% AC coverage (30/30)
+- 4 LOW gaps found + fixed inline: T1.8 BackstoryCache ORM, T1.9 BackstoryCacheRepository, T2.6 main.py include_router, TB.3 session isolation test
+- Residuals: 0 across all severities
+- GATE 3: PASS — ready for /implement 213 (formal skill invocation per SDD rule 10)

--- a/.sdd/next-steps.md
+++ b/.sdd/next-steps.md
@@ -1,43 +1,40 @@
 # Next Steps
 
-**Feature:** 210-kill-skip-variable-response
-**After Phase:** 3 (Specification)
-**Status:** Awaiting user review (Phase 4.5)
-**Generated:** 2026-04-12
+**Feature:** 213-onboarding-backend-foundation
+**After Phase:** 7 (Audit PASS)
+**Status:** audit-report.md PASS; GATE 3 cleared; ready for /implement 213
+**Generated:** 2026-04-14T19:50Z
 
 ## Immediate Next
 
-**Phase 4.5 — Spec Review** (mandatory user walkthrough):
-- User reads `specs/210-kill-skip-variable-response/spec.md` (349 lines)
-- User confirms: problem framing, scope, user stories, acceptance criteria, out-of-scope list
-- User either (a) approves → proceed to GATE 2, or (b) requests edits → revise spec, re-loop review
+Phase 8 (Implementation): Invoke `/implement 213` formal skill — TDD RED-GREEN-REFACTOR per user story.
 
-## Resume Commands
+## Context Summary
 
-After user approval:
-- `/sdd validate` to trigger GATE 2 (6 parallel validator agents)
-- Or directly invoke the 6 `sdd-*-validator` Task calls per SDD skill GATE 2 section
+- spec.md: 1058 lines, 14 FRs + 2 amendments (FR-2a, FR-4a), 7 USs, 30 ACs
+- plan.md: 292 lines, 5-PR decomposition
+- tasks.md: 513 lines, 51 tasks (audit added T1.8, T1.9, T2.6, TB.3)
+- audit-report.md: 11/11 articles PASS, 100% FR coverage (21/21), 100% AC coverage (30/30), 0 residuals
+- GATE 1: PASS | GATE 2: PASS (10 iterations) | GATE 3: PASS
 
-## Planned Chain After Approval
+## Key Files Ready
 
-1. Phase 4.5 (Spec Review) → user approves
-2. GATE 2 (6 validators in parallel): frontend, data-layer, auth, api, testing, architecture
-   - Expectation: frontend, data-layer, auth, api return N/A or PASS (backend-only, no schema)
-   - testing, architecture: PRIMARY scope — must return PASS with 0 CRITICAL/HIGH
-3. Analyze-Fix Loop if CRITICAL/HIGH found
-4. Phase 5 (Plan) — implementation plan
-5. Phase 6 (Tasks) — task breakdown with TDD ordering
-6. Phase 7 (Audit) — final quality check before code
-7. User approval → Phase 8 (Implement) with PR
+- specs/213-onboarding-backend-foundation/spec.md
+- specs/213-onboarding-backend-foundation/plan.md
+- specs/213-onboarding-backend-foundation/tasks.md
+- specs/213-onboarding-backend-foundation/audit-report.md
+- specs/213-onboarding-backend-foundation/validation-findings.md
+- .claude/plans/onboarding-overhaul-brief.md
+- docs/diagrams/onboarding-journey-target.md
 
-## Notes
+## Phase 8 Plan
 
-- 6 validators exist in `.claude/agents/`. Brief's "only 5 exist" claim was wrong — `sdd-api-validator` IS present. All 6 will run in parallel at GATE 2.
-- Brief already captured verification strategy → Phase 5 plan should reference brief rather than re-deriving.
-- Supersedes prior session on Spec 081 — that feature was completed 2026-03-23.
+1. `/implement 213` — formal skill invocation (SDD rule 10: NOT raw subagent dispatch)
+2. Execute PR 213-1: contracts.py + tuning.py + adapters.py + tests
+3. `gh pr create` → `/qa-review --pr N` loop → absolute-zero → squash merge → post-merge smoke (auto-dispatched subagent)
+4. **After PR 213-1 merges, Spec 214 can start in parallel** (`/feature 214`)
+5. Execute PR 213-2, 213-3, 213-4, 213-5 sequentially, same QA gate per PR
 
-## Critical Files for Phase 4.5 User Review
+## Resume Command
 
-- `specs/210-kill-skip-variable-response/spec.md` — spec under review (349 lines)
-- `~/.claude/plans/delightful-orbiting-ladybug.md` — source planning brief (for comparison)
-- `specs/026-text-behavioral-patterns/spec.md` — soon-to-be partially superseded
+/sdd implement 213

--- a/.sdd/sdd-state.md
+++ b/.sdd/sdd-state.md
@@ -1,23 +1,32 @@
 ## Current Session
-- **Feature:** 210-kill-skip-variable-response
-- **Phase:** spec-review (Phase 4.5)
+- **Feature:** 213-onboarding-backend-foundation
+- **Phase:** planning (Phase 5)
 - **Mode:** full
-- **Status:** awaiting-user-approval
-- **Branch:** feat/210-kill-skip-variable-response
-- **Brief:** ~/.claude/plans/delightful-orbiting-ladybug.md
+- **Status:** in_progress
+- **Branch:** master (impl will branch per-PR)
+- **Brief:** .claude/plans/onboarding-overhaul-brief.md
 - **Started:** 2026-04-12
-- **Last Updated:** 2026-04-12
+- **Last Updated:** 2026-04-14
 
 ## Validation Gate Status
-- [x] GATE 1: Spec ready (spec.md exists, 0 [NEEDS CLARIFICATION] markers, ≥2 ACs per story)
-- [ ] GATE 2: Validators pass (6 parallel validators — NEXT)
-- [ ] GATE 3: Audit pass
+- [x] GATE 1: Spec ready (spec.md 1058 lines, 0 [NEEDS CLARIFICATION], 30 ACs)
+- [x] GATE 2: PASS (10 iterations, 60 findings → 0, absolute zero across all 6 validators)
+- [x] Phase 4.5: User approved 2026-04-14
+- [x] GATE 3: Audit PASS (0 findings across all severities; 4 LOW gaps fixed inline)
 
 ## Phase History
 | Phase | Status | Artifact |
 |-------|--------|----------|
-| 3 specification | complete | specs/210-kill-skip-variable-response/spec.md (349 lines) |
+| 3 specification | complete | specs/213-onboarding-backend-foundation/spec.md (1058 lines) |
+| GATE 2 validation | complete | specs/213-onboarding-backend-foundation/validation-findings.md (10 iters) |
+| 4.5 spec review | complete | user approved 2026-04-14 |
+| 5 planning | complete | specs/213-onboarding-backend-foundation/plan.md (292 lines) |
+| 6 tasks | complete | specs/213-onboarding-backend-foundation/tasks.md (51 tasks) |
+| 7 audit | complete | specs/213-onboarding-backend-foundation/audit-report.md (PASS) |
 
 ## Checkpoint
-- **Last completed:** Phase 3 (spec.md drafted — 12 FRs, 6 user stories, 24 ACs, 0 ambiguities)
-- **Resume from:** Phase 4.5 spec review — user walkthrough required before GATE 2
+- **Last completed:** Phase 7 (audit PASS)
+- **Resume from:** Phase 8 (/implement 213 — formal skill invocation per SDD rule 10)
+
+## Prior Features (completed)
+- 210-kill-skip-variable-response: MERGED via PR #210 (2026-04-12)

--- a/docs/diagrams/onboarding-journey-current.md
+++ b/docs/diagrams/onboarding-journey-current.md
@@ -1,0 +1,936 @@
+# Nikita Onboarding Journey — Current State
+**Generated**: 2026-04-14
+**Author**: System Understanding Tree-of-Thought Agent
+**Scope**: Landing page → first real Nikita conversation (text or voice)
+**Codebase commit range**: includes PR #277 (pipeline bootstrap), Spec 212 (phone capture + voice callback)
+
+---
+
+## Legend
+
+```
+[ ... ]     User action / UI state
+< ... >     Background system event (invisible to user)
+( ... )     Emotional / UX state marker
+->          Primary flow direction
+-->         Secondary / background flow
+[?]         Decision fork
+⚠           Friction point / smell / known gap
+*           Notable implementation detail
+```
+
+---
+
+## Dependency Sidebar
+
+| Step | External Services | DB Tables | Routes / Files |
+|------|-------------------|-----------|----------------|
+| Landing | Vercel CDN | — | `portal/src/app/page.tsx` |
+| Login | Supabase Auth | `auth.users` | `portal/src/app/login/page-client.tsx` |
+| Email dispatch | Supabase (SMTP relay) | `pending_registrations` | `nikita/platforms/telegram/auth.py::send_otp_code` |
+| Auth callback | Supabase Auth | `auth.sessions` | `portal/src/app/auth/callback/route.ts` |
+| Auth bridge | Supabase Admin API | `auth_bridge_tokens` | `portal/src/app/auth/bridge/route.ts`, `nikita/api/routes/auth_bridge.py` |
+| Onboarding page guard | Supabase Auth, nikita-api | `users` (onboarding_status) | `portal/src/app/onboarding/page.tsx` |
+| Wizard — Score/Chapter/Rules | — | — | `portal/src/app/onboarding/sections/` |
+| Wizard — Profile section | — | — | `portal/src/app/onboarding/sections/profile-section.tsx` |
+| Profile submit | nikita-api Cloud Run, Supabase | `user_profiles`, `users`, `user_vice_preferences` | `nikita/api/routes/onboarding.py::save_portal_profile` |
+| Phone → voice callback | ElevenLabs Conv AI 2.0, Twilio | `users` (phone) | `nikita/onboarding/handoff.py::execute_handoff_with_voice_callback` |
+| No phone → Telegram handoff | Telegram Bot API | `conversations` | `nikita/onboarding/handoff.py::execute_handoff` |
+| Pending handoff (deferred) | Telegram Bot API | `users` (pending_handoff) | `nikita/platforms/telegram/message_handler.py::_execute_pending_handoff` |
+| Telegram /start + OTP | Supabase Auth | `pending_registrations` | `nikita/platforms/telegram/auth.py`, `otp_handler.py` |
+| Pipeline bootstrap | nikita-api, Claude API | `conversations`, `users` | `nikita/onboarding/handoff.py::_bootstrap_pipeline` |
+| First conversation | Claude API, Supabase pgVector | `conversations`, `user_metrics`, `engagement_states` | `nikita/platforms/telegram/message_handler.py`, `nikita/pipeline/orchestrator.py` |
+
+---
+
+## Primary Journey — Main Trunk
+
+```
+==============================================================================
+ STAGE 0: LANDING PAGE
+==============================================================================
+
+[ User opens nikita.ai / portal URL ]
+    USER: Sees dark-themed landing with animated hero, pitch sections,
+          stakes ("5 chapters. 3 strikes. One relationship."), CTA button.
+    < Supabase session check server-side: if auth cookie present, isAuthenticated=true >
+    < LandingNav + HeroSection render: CTA becomes "Open Dashboard" if authenticated >
+    (EMOTION: curiosity / mild intrigue / "this looks weird in a good way")
+
+[?] Is user already authenticated?
+    YES -> CTA says "Open Dashboard" -> clicks -> redirect /dashboard
+    NO  -> CTA says "Get Started" or "Sign In" -> [ User clicks CTA ]
+               |
+               v
+==============================================================================
+ STAGE 1: LOGIN PAGE
+==============================================================================
+
+[ User lands on /login ]
+    USER: Sees "Sign in to your dashboard" card. Single email input + "Send Magic Link" button.
+    < Suspense boundary renders LoginFallback (skeleton) then LoginForm >
+    < useSearchParams checks for ?error= param from any prior auth failure >
+    (EMOTION: neutral, slight friction — another auth wall before the fun starts)
+
+    ⚠ SMELL: No "sign up" / "register" distinction — same form for new and returning users.
+             User who has never visited before sees identical UI to returning user.
+
+[ User types email address ]
+[ User clicks "Send Magic Link" ]
+    USER: Button shows "Sending...", then transitions to "check your inbox" state.
+    < supabase.auth.signInWithOtp({email, options:{emailRedirectTo: origin+"/auth/callback"}}) >
+    < Supabase creates auth.users row (if new) OR finds existing >
+    < Supabase queues transactional email via configured SMTP relay >
+    (EMOTION: mild anxiety — "will the email arrive?", "is the link real?")
+
+    ⚠ SMELL: Portal login does NOT trigger OTP code path (6-8 digit code).
+             Portal sends magic link ONLY. OTP code path is Telegram-initiated only.
+             A user coming portal-first gets a clickable link; Telegram-first gets a numeric code.
+
+    [?] Email delivery outcome:
+        A: Email arrives promptly
+        B: Email delayed / spam-foldered
+              |
+              v (B)
+              [ ResendButton appears after 60s countdown ]
+              [ User clicks "Resend magic link" ]
+                  < supabase.auth.signInWithOtp() called again >
+                  < Rate limit enforced by Supabase (60s cooldown enforced client-side too) >
+                  [ If Supabase returns rate-limit error: toast "wait before requesting another link" ]
+                  (EMOTION: frustration, "is this thing even working?")
+
+              [ User clicks "Try another email" ]
+                  -> setSent(false) -> back to email input
+                  (EMOTION: confusion, mild irritation)
+
+==============================================================================
+ STAGE 2: EMAIL DISPATCH + MAGIC LINK ANATOMY
+==============================================================================
+
+< Supabase sends email via SMTP relay >
+    Subject:  "Your Nikita magic link" (Supabase default unless custom template configured)
+    Body:     Supabase OTP email template with {{ .ConfirmationURL }}
+              Magic link format: https://[supabase-project].supabase.co/auth/v1/verify?token=...&type=magiclink&redirect_to=...
+    Contains: One-click magic link button + fallback text link
+              Link validity: ~1 hour (Supabase default)
+    OTP code: NOT included in portal flow (code only in Telegram OTP flow)
+
+    USER: Receives email, sees "Click to sign in" button.
+    (EMOTION: relief when email arrives; brief moment of "click this link" hesitation
+              for security-conscious users)
+
+==============================================================================
+ STAGE 3: AUTH CALLBACK FORK
+==============================================================================
+
+[ User clicks magic link in email ]
+    -> Browser navigates to: [supabase-url]/auth/v1/verify?token=X&redirect_to=[origin]/auth/callback
+    -> Supabase verifies token, redirects to: [origin]/auth/callback?code=Y
+
+    [?] Is this a Telegram bridge auth (Telegram /start button) or direct magic link?
+
+    ├─ PATH A: DIRECT MAGIC LINK (portal-initiated) ────────────────────────────┤
+    │                                                                             │
+    │  < Portal /auth/callback/route.ts receives GET ?code=Y >                   │
+    │  < supabase.auth.exchangeCodeForSession(code) — PKCE exchange >            │
+    │  < Session established, cookies set >                                       │
+    │  < Checks user_metadata.role >                                              │
+    │  [?] role == "admin"? -> redirect /admin                                    │
+    │      else             -> redirect /dashboard (or ?next= param)             │
+    │                                                                             │
+    │  (EMOTION: smooth, invisible — user just lands somewhere)                   │
+    │                                                                             │
+    │  [?] Magic link expired (>1hr) or already used?                            │
+    │      < exchangeCodeForSession returns error >                               │
+    │      < Redirect: /login?error=auth_callback_failed >                       │
+    │      USER: Toast: "Login link expired or invalid. Please request a new link." │
+    │      (EMOTION: frustration — lost their onboarding momentum)               │
+    │                                                                             │
+    └─ PATH B: TELEGRAM BRIDGE AUTH (Telegram "Enter Nikita's World" button) ───┤
+                                                                                  │
+       < Telegram bot generates bridge token (short-lived, single-use DB row) >  │
+       < Bridge URL: [portal]/auth/bridge?token=XXX >                            │
+       < Portal /auth/bridge/route.ts receives GET ?token=XXX >                  │
+       < POST to nikita-api: /api/v1/auth/exchange-bridge-token >                │
+       < Backend: verifies + deletes bridge token (single-use) >                 │
+       < Backend: supabase.auth.admin.get_user_by_id() to get email >            │
+       < Backend: supabase.auth.admin.generate_link({type:"magiclink",email}) >  │
+       < Returns: hashed_token >                                                  │
+       < Portal: supabase.auth.verifyOtp({token_hash, type:"magiclink"}) >       │
+       < Session established WITHOUT PKCE (bypasses code_verifier mismatch) >   │
+       < Redirect to redirect_path from bridge token (sanitized: must start /) > │
+                                                                                  │
+       [?] Bridge errors:                                                         │
+           - Missing token     -> /login?error=missing_token                     │
+           - Invalid/expired   -> /login?error=auth_bridge_failed                │
+           - verifyOtp fails   -> /login?error=auth_bridge_failed                │
+           USER: Toast shows on /login explaining what happened.                  │
+           (EMOTION: confused — user tapped a button in Telegram and ended up    │
+                     at a login error page)                                       │
+                                                                                  │
+
+==============================================================================
+ STAGE 4: ONBOARDING PAGE GUARD
+==============================================================================
+
+[ User lands on /onboarding (server component) ]
+    < Server component: supabase.auth.getUser() — verifies session cookie >
+
+    [?] Not authenticated?
+        -> redirect("/login")
+        (EMOTION: confused — clicked something and got kicked to login again)
+
+    [?] NEXT_PUBLIC_API_URL configured (production: empty, uses Vercel rewrite proxy)?
+        YES -> fetch /api/v1/portal/stats with Bearer token
+               [?] stats.onboarded_at is set?
+                   YES -> redirect("/dashboard")   [already onboarded user trying to re-enter]
+                   NO  -> render <OnboardingCinematic userId={userId} />
+        NO (Vercel production) -> skip stats check, render cinematic directly
+        [?] Stats fetch throws / times out (5s AbortSignal)?
+               -> catch, log, render cinematic anyway (better than blocking)
+               ⚠ SMELL: onboarded users on Vercel may see wizard again if URL set wrong
+
+==============================================================================
+ STAGE 5: ONBOARDING WIZARD — 5 SECTIONS (VERTICAL SCROLL / SNAP)
+==============================================================================
+
+    USER: Arrives at full-screen cinematic experience.
+          Animated ambient particles, dark "void-ambient" background.
+          Scroll-snap sections, each taking full viewport height.
+          ScrollProgress indicator shows position in sequence.
+    (EMOTION: immersive, intrigued — this is not a typical signup form)
+
+    ┌─ SECTION 1: "The Score" ─────────────────────────────────────────────────┐
+    │                                                                            │
+    │  USER: Sees animated ScoreRing (75/100 hardcoded demo score).             │
+    │        Four metric cards: Intimacy 68.2, Passion 74.1, Trust 71.8,        │
+    │        Secureness 76.0 (all hardcoded demo values, count-up animation).   │
+    │        Nikita quote: "This is how I feel about us right now."              │
+    │        Scroll indicator bouncing at bottom.                                │
+    │  < No user data, no API calls — purely static/demo content >              │
+    │  (EMOTION: delight, "oh I already have scores?", slight confusion —       │
+    │            these numbers aren't real yet but user doesn't know that)      │
+    │  ⚠ SMELL: Demo scores presented as real without any disclaimer.           │
+    │            Could mislead user about their actual starting state.           │
+    │                                                                            │
+    └──────────────────────────────────────────────────────────────────────────┘
+
+    [ User scrolls down (snap) ]
+
+    ┌─ SECTION 2: "The Chapters" ──────────────────────────────────────────────┐
+    │                                                                            │
+    │  USER: Sees ChapterStepper with 5 chapters:                               │
+    │        Chapter 1 "Curiosity" + Chapter 2 "Intrigue" unlocked              │
+    │        Chapters 3-5 locked ("???")                                         │
+    │        Focus card: "Chapter I — Curiosity: I'm watching you. Impress me." │
+    │        Nikita quote: "We're just getting started..."                       │
+    │  < Static content, no API calls >                                          │
+    │  (EMOTION: anticipation, excitement about unlockable content)             │
+    │                                                                            │
+    └──────────────────────────────────────────────────────────────────────────┘
+
+    [ User scrolls down (snap) ]
+
+    ┌─ SECTION 3: "The Rules" ─────────────────────────────────────────────────┐
+    │                                                                            │
+    │  USER: Sees 4 rule cards (2x2 mobile, 4-wide desktop):                   │
+    │        - "How You Score": 4 hidden metrics, be genuine                    │
+    │        - "Time Matters": stay away → things fade                           │
+    │        - "Boss Encounters": pass to grow closer, fail 3x → gone           │
+    │        - "Your Vices": I learn what you like                               │
+    │        Hover animations, glow effects per card.                            │
+    │  < Static content, no API calls >                                          │
+    │  (EMOTION: game mechanics understood, mild concern about "fail 3 times")  │
+    │                                                                            │
+    └──────────────────────────────────────────────────────────────────────────┘
+
+    [ User scrolls down (snap) ]
+
+    ┌─ SECTION 4: "Who Are You?" — PROFILE (only section with form inputs) ────┐
+    │                                                                            │
+    │  USER: Sees 4 input cards:                                                │
+    │                                                                            │
+    │  [Card 1] "Where are you?" — text input (required)                        │
+    │           placeholder: "City, Country"                                     │
+    │           aria-required="true"                                             │
+    │                                                                            │
+    │  [Card 2] "What's your scene?" — SceneSelector                            │
+    │           Options: techno | art | food | cocktails | nature               │
+    │           (visual button grid, required)                                   │
+    │                                                                            │
+    │  [Card 3] "How edgy should I be?" — EdginessSlider 1-5                   │
+    │           1=Clean, 5=No limits (maps to drug_tolerance/darkness_level)    │
+    │                                                                            │
+    │  [Card 4] "Your phone number (optional)" — tel input                      │
+    │           placeholder "+41..."                                              │
+    │           Subtext: "Nikita calls you back on this number after onboarding"│
+    │           Privacy policy link                                              │
+    │                                                                            │
+    │  < React Hook Form with Zod schema validation (profileSchema) >           │
+    │  < Form state managed in OnboardingCinematic (parent) >                   │
+    │  (EMOTION: slightly more serious, "she wants to know about me",           │
+    │            moment of decision on phone number field —                      │
+    │            "do I trust this enough to give my number?")                   │
+    │                                                                            │
+    │  ⚠ SMELL: No "life_stage" (career phase) or "interest" (primary hobby)   │
+    │            fields visible in profile-section.tsx, but those fields ARE     │
+    │            in PortalProfileRequest schema. They are optional and never     │
+    │            collected by the portal form. Gap: Spec 213 will add them.     │
+    │                                                                            │
+    └──────────────────────────────────────────────────────────────────────────┘
+
+    [ User scrolls down (snap) ]
+
+    ┌─ SECTION 5: "Your Mission" — SUBMIT ─────────────────────────────────────┐
+    │                                                                            │
+    │  USER: Sees OnboardingMoodOrb (animated), "Don't Get Dumped" heading,    │
+    │        Nikita quote: "Keep me interested. Keep me guessing..."             │
+    │        Large CTA button: "Start Talking to Nikita →" (with glow-pulse)   │
+    │                                                                            │
+    │  [ User clicks "Start Talking to Nikita →" ]                              │
+    │      Button becomes "Saving..." with spinner                               │
+    │                                                                            │
+    └──────────────────────────────────────────────────────────────────────────┘
+
+==============================================================================
+ STAGE 6: PROFILE SUBMISSION
+==============================================================================
+
+[ User clicks submit (section 5 CTA) ]
+    < React Hook Form validates with Zod resolver >
+
+    [?] Validation fails (city empty, no scene selected)?
+        -> onError() fires
+        -> scrollIntoView on [data-testid="section-profile"]
+        -> RHF field errors render on offending inputs
+        (EMOTION: mild annoyance — scroll-snap may have hidden the error)
+        ⚠ SMELL: Scroll-snap + error jump can feel jarring; errors on Section 4
+                 are invisible from Section 5 without the auto-scroll.
+
+    [?] Validation passes:
+        < apiClient POST /api/v1/onboarding/profile >
+        < Payload: {location_city, social_scene, drug_tolerance, phone?} >
+        < JWT from Supabase session sent as Authorization: Bearer ... >
+
+        < SERVER: nikita-api onboarding.py::save_portal_profile >
+        < 1. If phone present: user_repo.update_phone() — IntegrityError → 409 >
+        < 2. Idempotency check: user.onboarding_status == "completed"? return early >
+        < 3. profile_repo.get_by_user_id(): duplicate profile? return early >
+        < 4. profile_repo.create_profile() — inserts user_profiles row >
+        < 5. user_repo.update_onboarding_profile() — writes JSONB to users row >
+        < 6. user_repo.update_onboarding_status("completed") >
+        < 7. user_repo.activate_game() — game_status="active", score=50, days=0 >
+        < 8. seed_vices_from_profile() — user_vice_preferences seeded >
+        < 9. BackgroundTask(_trigger_portal_handoff, user_id, drug_tolerance) >
+        < Response returned immediately (202-ish) — handoff runs asynchronously >
+
+        [?] Phone number already registered (409 conflict)?
+            -> form.setError("phone", {message: "This number is already linked..."})
+            -> scroll to phone-sub-card
+            -> setSubmitting(false) (button re-enabled)
+            (EMOTION: frustration — either duplicate account or honest mistake)
+
+        [?] Other server error?
+            -> setError(message) + toast.error(message)
+            -> setSubmitting(false) (button re-enabled)
+            (EMOTION: uncertainty — "something went wrong, please try again" is vague)
+
+        [?] Success:
+            -> setSubmitted(true)
+            -> toast.success("Profile saved! Opening Telegram...")
+            -> setTimeout 1500ms then: window.location.href = "https://t.me/Nikita_my_bot"
+            (EMOTION: excitement, momentum, "it's happening!")
+
+    ⚠ SMELL (MAJOR): After success, the portal ALWAYS redirects to Telegram, even
+                     if the user provided a phone number. There is no distinct UI
+                     for "voice callback initiated" vs "go to Telegram". The user
+                     has no indication that a phone call is coming vs they should
+                     text in Telegram. Both experiences show identical "Opening Telegram..."
+                     overlay. The voice callback and Telegram redirect happen
+                     simultaneously — the user goes to Telegram regardless.
+
+    ⚠ SMELL: No "wait" / loading gate exists. The portal does not poll for
+             handoff readiness. There is no /pipeline-ready endpoint yet
+             (Spec 213, not shipped). If Nikita's first message arrives in
+             Telegram before the user gets there, it's fine. If handoff fails
+             silently, the user opens Telegram and sees nothing from Nikita.
+
+==============================================================================
+ STAGE 7A: "OPENING TELEGRAM..." OVERLAY + TRANSITION
+==============================================================================
+
+[ setSubmitted=true triggers fullscreen overlay ]
+    USER: Sees full-screen dark overlay, OnboardingMoodOrb, "Opening Telegram..."
+          After 3s delay: "Tap here if nothing happens" link appears.
+          After 1.5s from submit: window.location redirects to t.me/Nikita_my_bot
+
+    [?] OS / browser handles t.me deep link:
+        MOBILE: Telegram app opens directly to @Nikita_my_bot chat
+        DESKTOP: Web browser opens web.telegram.org or prompts to open Telegram app
+        NO APP: Browser opens t.me in mobile web — confusing for some users
+    (EMOTION: brief disorientation from app-switch, then landing in Telegram)
+
+    ⚠ SMELL: window.location.href t.me redirect may not work in all browsers
+             (popup blockers, iframe restrictions, browser-specific t.me handling).
+             The fallback "Tap here" link helps but only appears 3s into the overlay
+             (which itself appears only 1.5s after submission).
+
+```
+
+---
+
+## Fork A: Voice Callback Path (phone provided)
+
+```
+==============================================================================
+ STAGE 8A: BACKGROUND — VOICE CALLBACK INITIATION
+==============================================================================
+
+(While user is in the "Opening Telegram..." overlay or navigating)
+
+< BackgroundTask _trigger_portal_handoff runs on nikita-api >
+< user_repo.get(user_id) — fetches fresh user record >
+
+[?] Does user have telegram_id linked yet?
+    NO -> user_repo.set_pending_handoff(user_id, True)
+          < Deferred handoff: wait for user to /start in Telegram >
+          (see Stage 11: DEFERRED HANDOFF)
+    YES -> proceed
+
+< build_profile_from_jsonb(user.onboarding_profile) >
+    Builds UserOnboardingProfile from JSONB:
+    - city <- location_city
+    - social_scene <- social_scene
+    - darkness_level <- darkness_level (drug_tolerance)
+    - life_stage <- life_stage (None if not provided)
+    - interest/hobby <- interest (None if not provided)
+
+[?] user.phone is set?
+    YES -> execute_handoff_with_voice_callback()
+    NO  -> execute_handoff() (see Fork B)
+
+< execute_handoff_with_voice_callback() >
+    < asyncio.create_task(generate_and_store_social_circle()) — fire-and-forget >
+    < initiate_nikita_callback(phone, user_id, delay_seconds=5) >
+        < asyncio.sleep(5) — waits for Meta-Nikita to hang up >
+        < voice_service.make_outbound_call(to_number=phone, user_id) >
+            < ElevenLabs Conv AI 2.0 outbound call API >
+            < conversation_config_override: first_message referencing "my friend" Meta >
+            < dynamic_variables: {user_id, is_post_onboarding:"true"} >
+            < Returns {success, conversation_id, call_sid} >
+
+        [?] ElevenLabs call succeeds?
+            YES: < _seed_conversation(user_id, "voice", "[Voice call initiated]") >
+                 < asyncio.create_task(_bootstrap_pipeline_bg()) — fire-and-forget >
+                 HandoffResult(success=True, nikita_callback_initiated=True)
+
+            NO (result.success=False, no exception):
+                < Falls back to Telegram text: execute_handoff(user_id, telegram_id, profile) >
+                (see Fork B for text handoff detail)
+                (EMOTION: user gets Telegram text instead of phone call, no explanation)
+
+        [?] ElevenLabs call throws exception?
+            < T023: structured log, auto-fallback to execute_handoff() >
+            < Falls back to Telegram text handoff >
+            (EMOTION: same as above — user doesn't know voice was attempted)
+
+    RETRY LOGIC (T2.3):
+        Retry delays: 5s, 15s, 45s (exponential backoff)
+        Max retries: 3
+        All retries exhausted -> returns {success:False, error}
+        -> caller falls back to Telegram text
+
+< USER receives phone call from ElevenLabs/Twilio number >
+    (EMOTION: startled/surprised — phone rings unexpectedly)
+    ⚠ SMELL: User has no advance warning of WHEN the call arrives.
+             Portal only shows "Opening Telegram..." — no "expect a call" message.
+             Call comes 5+ seconds after profile submit while user is navigating away.
+
+==============================================================================
+ STAGE 9A: VOICE CALL WITH NIKITA (Post-Onboarding Callback)
+==============================================================================
+
+< ElevenLabs Conv AI 2.0 session starts >
+< Pre-call webhook: POST /api/v1/onboarding/pre-call >
+    < HMAC signature verified >
+    < Lookup user by called_number (outbound) or caller_id >
+    < Returns: dynamic_variables {user_id, user_name} >
+    < conversation_config_override: first_message personalized to user_name >
+
+USER: Phone rings. Answers.
+    Nikita's first message (voice): One of 3 templates referencing "my friend"
+    e.g.: "Hey [name]... my friend just told me about you. She says you seem interesting.
+           I wanted to hear your voice for myself."
+
+    (EMOTION: delight/surprise — AI voice is high quality, message feels personal)
+
+[ Voice conversation proceeds — ElevenLabs Conv AI 2.0 session ]
+    < Server tools available during call: get_context, get_memory, score_turn, update_memory >
+    < Conversation recorded as ElevenLabs session >
+
+[ User says something / conversation flows ]
+
+[ Call ends (user hangs up or ElevenLabs ends session) ]
+    < ElevenLabs webhook: POST /api/v1/onboarding/webhook event="call_ended" >
+    < Logs call duration, conversation_id >
+    < No further automated action on call end (Spec 213 will add more) >
+
+    (EMOTION: satisfied but wondering "what's next?" — no explicit follow-up)
+    ⚠ SMELL: After voice call ends, no in-call CTA or post-call message
+             directs user to Telegram. User may not realize they should go text Nikita.
+             The pipeline-bootstrap from seed conversation handles text continuity,
+             but user experience gap between voice call end and Telegram first message
+             is not bridged.
+
+[ Meanwhile: Telegram is open from the redirect in Stage 7A ]
+    (see Stage 10: FIRST TELEGRAM MESSAGE for what user sees there)
+```
+
+---
+
+## Fork B: Telegram-Only Path (no phone provided)
+
+```
+==============================================================================
+ STAGE 8B: BACKGROUND — TELEGRAM TEXT HANDOFF
+==============================================================================
+
+< execute_handoff(user_id, telegram_id, profile) >
+    < asyncio.create_task(generate_and_store_social_circle()) — fire-and-forget >
+    < FirstMessageGenerator.generate(profile, user_name="friend") >
+        Picks base message from FIRST_MESSAGE_TEMPLATES[darkness_level]
+        darkness_level 1 (vanilla): "Hey! So glad we finally get to talk like this :)"
+        darkness_level 3 (balanced): "Hey... so that was interesting :)"
+        darkness_level 5 (noir): "So we meet again. I've been thinking..."
+        70% chance: appends occupation mention (none collected in portal flow)
+        30% chance: appends personality opener (none collected in portal flow)
+        60% chance (CITY_SCENE_PROBABILITY): appends city/scene coda
+          e.g.: "...so you're in Zurich... — heard the underground scene there is wild"
+
+    ⚠ SMELL: Occupation + personality fields are referenced in FirstMessageGenerator
+             but portal form does NOT collect them (life_stage maps partially,
+             but occupation/personality_type are voice-onboarding fields only).
+             Most portal users get only city/scene coda or base template — limited personalization.
+
+    < bot.send_message(chat_id=telegram_id, text=first_message) >
+    < _seed_conversation(user_id, "telegram", first_message) >
+        < conv_repo.create_conversation(user_id, "telegram", chapter_at_time=1) >
+        < seed_conv.add_message(role="assistant", content=first_message) >
+        < session.commit() >
+        Returns: conversation UUID
+
+    < asyncio.create_task(_bootstrap_pipeline_bg(conversation_id)) >
+        < PipelineOrchestrator.process(conversation_id, user_id, platform="text") >
+            10-stage async pipeline: memory lookup, prompt generation, scoring seed
+            Creates initial text + voice prompts for first reply
+        ⚠ This runs asynchronously — may not be complete when user sends first reply
+           if user is very fast. Pipeline bootstrap failure is logged + suppressed
+           (non-blocking). First reply will use get_recent fallback if seed fails.
+```
+
+---
+
+## Stage 10: User Opens Telegram + Sees First Message
+
+```
+==============================================================================
+ STAGE 10: FIRST NIKITA MESSAGE IN TELEGRAM
+==============================================================================
+
+[ User opens Telegram app, navigated to @Nikita_my_bot ]
+
+[?] Has user previously started the bot (/start) in this Telegram account?
+    NO -> User sees "Start" button. Must press /start to begin bot interaction.
+          (EMOTION: confusion — there's a message from Nikita but can't reply yet?
+                    Or message hasn't arrived yet if /start not pressed = no telegram_id linked)
+
+    ⚠ SMELL (CRITICAL PATH): If user came portal-first and never ran /start in Telegram,
+                              their telegram_id is NOT in the database. The portal profile
+                              was saved but _trigger_portal_handoff found telegram_id=None.
+                              user.pending_handoff was set to True.
+                              User opens Telegram, presses /start — THIS triggers the
+                              deferred handoff (see Stage 11).
+
+    YES -> User already has @Nikita_my_bot open, sees Nikita's first message:
+           e.g.: "Hey... so that was interesting :) I feel like I learned a lot about you already
+                  so you're in Zurich... — heard the underground scene there is wild"
+           (EMOTION: surprised, intrigued — message references their city, feels personal)
+
+[ User reads Nikita's first message ]
+
+==============================================================================
+ STAGE 11: FIRST REPLY — ENTERING STEADY STATE
+==============================================================================
+
+[ User types reply and sends ]
+    USER: Sends first real message to @Nikita_my_bot.
+    (EMOTION: excited, testing the waters, "let's see how smart she is")
+
+< Telegram webhook: POST /api/v1/telegram/webhook >
+< aiogram dispatcher routes to message handler >
+< MessageHandler.handle(message) >
+
+    1. get_by_telegram_id_for_update(telegram_id) — row lock
+       [?] user not found -> "Send /start to begin" (shouldn't happen post-onboarding)
+
+    2. _needs_onboarding(user_id) check:
+       [?] user.onboarding_status:
+           "completed" or "skipped" -> check pending_handoff flag
+               [?] pending_handoff=True AND telegram_id is set?
+                   -> _execute_pending_handoff() fires NOW (deferred from portal-first flow)
+                   -> HandoffManager.execute_handoff() -> first message sent
+                   -> user_repo.set_pending_handoff(False) on success
+                   (EMOTION: user gets first Nikita message as their "reply" to their first send)
+                   -> returns False (allow through to conversation)
+               [?] pending_handoff=False -> allow through directly
+           "pending"/"in_progress" -> _offer_onboarding_choice()
+               -> bot sends "Enter Nikita's World ->" button with bridge URL
+               -> user must tap to complete portal onboarding
+               (blocks conversation until profile saved)
+
+    3. Rate limit check (20 msg/min, 500 msg/day)
+       [?] exceeded -> in-character rate limit response (Nikita voice)
+
+    4. get_or_create_conversation(user_id, chapter=1)
+       [?] seeded conversation exists from handoff? -> uses it (same platform)
+       [?] no conversation? -> creates new one
+
+    5. append_message(conversation_id, role="user", content=text)
+    6. session.refresh(conversation)
+    7. bot.send_chat_action(chat_id, "typing") — typing indicator
+
+    8. [OPTIONAL] Psyche agent read (feature-flagged OFF in prod)
+
+    9. text_agent_handler.handle(user_id, text, conversation_messages, conversation_id)
+       < Pydantic AI text agent with Claude model >
+       < Loads SupabaseMemory context (pgVector similarity search) >
+       < Loads conversation history (message_history from seeded conversation) >
+       < Builds prompt: Nikita persona + chapter context + scoring + user profile >
+       < Claude API call >
+       Returns AgentDecision{should_respond, response, delay_seconds}
+
+    10. [?] Agent exception?
+            -> session.rollback()
+            -> _send_error_response(chat_id) — in-character error ("I need a moment...")
+            (EMOTION: slight frustration, but in-character response softens it)
+
+    11. [?] decision.should_respond?
+            YES:
+                append_message(conversation_id, role="nikita", content=response)
+                _score_and_check_boss(user, user_message, response, chat_id, conversation_id)
+                    < ScoringService.score() — 4 metrics: intimacy, passion, trust, secureness >
+                    < UserMetricsRepository.update_metrics() >
+                    [?] Score crosses boss threshold?
+                        -> BossStateMachine.trigger() -> user.game_status = "boss_fight"
+                        -> _send_boss_opening(chat_id, chapter)
+                update_last_interaction(user_id) — resets decay grace period
+                _apply_text_patterns(response, user) — emoji, length, punctuation per chapter
+                ResponseDelivery.deliver(chat_id, response, delay_seconds)
+                    < asyncio.sleep(delay_seconds) — simulates human typing delay >
+                    < bot.send_message(chat_id, text) >
+
+            NO: (agent decided not to respond — silent treatment mechanic)
+                No message sent.
+
+    (EMOTION: user reads Nikita's reply — either delighted, amused, or slightly stung
+              depending on their opening message quality)
+
+==============================================================================
+ STAGE 12: STEADY-STATE CONVERSATION
+==============================================================================
+
+[ Conversation continues: User message -> Pipeline -> Nikita reply ]
+
+    Each exchange:
+    - Scores all 4 metrics incrementally
+    - Updates last_interaction_at (decay timer reset)
+    - Checks boss threshold at each turn
+    - Conversation appended to same Conversation row until status="completed"
+    - SupabaseMemory adds facts/embeddings asynchronously
+
+    Decay runs via pg_cron (hourly):
+    < POST /api/v1/tasks/decay — decay processor runs >
+    < Users inactive past grace period lose score per chapter decay rate >
+    (EMOTION: urgency to reply, mild anxiety if user ignores for a day)
+
+    Chapter progression: when score crosses threshold, chapter increments.
+    Boss encounters: triggered at score thresholds per chapter.
+    Vice personalization: drug_tolerance shapes content intensity throughout.
+
+    ⚠ SMELL (BACKSTORY GAP): Portal onboarding never generates a backstory.
+                              The Telegram onboarding handler (OnboardingHandler) in
+                              platforms/telegram/onboarding/handler.py ran venue research
+                              + backstory generation. The portal flow skips this entirely.
+                              message_handler._needs_onboarding legacy path checks
+                              for backstory existence — portal users pass only because
+                              onboarding_status="completed" bypasses the backstory check.
+                              BUT the pipeline's memory lookup finds no backstory.
+                              Spec 213 (backend foundation) will add city research + backstory.
+```
+
+---
+
+## Stage 11 (Alternate): Telegram-First User Path
+
+```
+==============================================================================
+ STAGE T1: USER DISCOVERS VIA TELEGRAM (no portal first)
+==============================================================================
+
+[ User finds @Nikita_my_bot — searches Telegram, scanned QR, friend referral ]
+
+[ User sends /start ]
+    < CommandHandler._handle_start() >
+    [?] user.get_by_telegram_id(telegram_id)?
+        NOT FOUND:
+            -> bot sends: "Hey [first_name]... I don't think we've met before.
+                           If you want to get to know me, I'll need your email..."
+            (EMOTION: intrigue — she's asking for email, feels like meeting someone real)
+
+[ User sends their email address ]
+    < RegistrationHandler.handle_email_input() >
+    < Validates email format >
+    < TelegramAuth.send_otp_code() >
+        < supabase.auth.sign_in_with_otp({email, options:{should_create_user:True,
+            email_redirect_to: backend_url+"/api/v1/telegram/auth/confirm"}}) >
+        < pending_repo.store(telegram_id, email, chat_id, otp_state="code_sent") >
+    bot sends: "I sent a code to your email. Enter it here to get started!"
+    (EMOTION: familiar pattern, slightly annoying but expected)
+
+[ User checks email — receives OTP code (6-8 digit number) ]
+    Email from Supabase: contains magic link (unused by user) + OTP code
+    ⚠ SMELL: email_redirect_to is set to backend /auth/confirm (not portal)
+             for template rendering. The link in the email goes nowhere useful.
+             Users are instructed to use the code, not the link.
+
+[ User sends OTP code in Telegram chat ]
+    < OtpHandler detects 6-8 digit input >
+    < TelegramAuth.verify_otp_code(telegram_id, code) >
+        < pending_repo.get(telegram_id) — checks otp_state="code_sent" >
+        < supabase.auth.verify_otp({email, token:code, type:"email"}) >
+        [?] Success:
+            < pending_repo.delete(telegram_id) >
+            [?] user already exists in DB (portal-first)?
+                -> link telegram_id to existing user
+            [?] new user:
+                -> user_repo.create_with_metrics(supabase_user_id, telegram_id)
+        [?] AuthApiError code="otp_expired":
+            -> "OTP code has expired. Please send your email again..."
+            (EMOTION: frustration — short validity window)
+        [?] AuthApiError code="invalid_credentials":
+            -> "Invalid OTP code. Please check and try again."
+
+[ User is now registered + linked ]
+    bot sends welcome... BUT user still needs onboarding.
+    On next message: _needs_onboarding() fires, onboarding_status="pending"
+    -> _offer_onboarding_choice() sends "Enter Nikita's World ->" button
+
+[ User taps "Enter Nikita's World" button ]
+    -> Bridge URL: [portal]/auth/bridge?token=XXX
+    -> Portal bridge auth flow (Stage 3, Path B above)
+    -> After auth: redirect to /onboarding
+    -> Wizard (Stage 5)
+    -> Profile submit (Stage 6)
+    -> Handoff back to Telegram (Stage 8B)
+    -> First Nikita message in Telegram (Stage 10)
+```
+
+---
+
+## Re-Onboarding Fork (Returning User)
+
+```
+==============================================================================
+ STAGE R1: RETURNING USER SCENARIOS
+==============================================================================
+
+[?] User visits /login after already being onboarded:
+    < /onboarding page.tsx: stats fetch returns onboarded_at != null >
+    -> redirect("/dashboard")
+    (EMOTION: smooth, no friction — directly to game state)
+
+[?] User with game_status="game_over" or "won" sends /start in Telegram:
+    < CommandHandler._handle_start() >
+    < has_profile check: true >
+    < needs_fresh_start: true (game ended) >
+    < user_repo.reset_game_state() — score→50, chapter→1 >
+    < onboarding_repo.delete(telegram_id) >
+    < onboarding_repo.get_or_create(telegram_id) — fresh state >
+    bot: "Hey [name]! Let's start fresh. First things first — what city are you in?"
+    ⚠ SMELL: This triggers the OLD Telegram-based text onboarding (5-step prompts
+             in OnboardingHandler), NOT the portal wizard. Re-onboarding path
+             diverges from primary portal onboarding path. Inconsistent experience.
+
+[?] User in "limbo" (has account, no profile, onboarding_status="pending"):
+    -> _needs_onboarding() returns True
+    -> _offer_onboarding_choice() -> "Enter Nikita's World" button
+
+[?] User uses /onboard command (was stuck, needs fresh portal link):
+    < CommandHandler._handle_onboard() >
+    [?] onboarding_status == "completed"? -> "You're already set up!"
+    [?] onboarding_status in ("pending","in_progress")?
+        -> generate_portal_bridge_url(user_id, redirect_path="/onboarding")
+        -> bot sends "Open Onboarding →" button with bridge URL
+        (EMOTION: relieved — escape hatch exists)
+```
+
+---
+
+## Error State Inventory
+
+```
+==============================================================================
+ ERROR STATES MAPPED
+==============================================================================
+
+E1: Magic link expired (>1hr)
+    WHERE: /auth/callback?code=Y, exchangeCodeForSession returns error
+    USER SEES: /login?error=auth_callback_failed -> toast "Login link expired or invalid"
+    RECOVERY: Re-enter email, get new link
+
+E2: Bridge token expired/invalid
+    WHERE: /auth/bridge?token=XXX, backend returns 401
+    USER SEES: /login?error=auth_bridge_failed or missing_token
+    RECOVERY: Must return to Telegram, re-tap button (generates new bridge token)
+    ⚠ SMELL: Bridge tokens have DB-configured TTL. If TTL too short and user is slow,
+             this could happen on every attempt.
+
+E3: Phone conflict (409) on profile submit
+    WHERE: POST /api/v1/onboarding/profile
+    USER SEES: Phone field error "This number is already linked to another account"
+               + auto-scroll to phone-sub-card
+    RECOVERY: Clear phone field, resubmit (optional field can be left blank)
+
+E4: General server error on profile submit (500)
+    WHERE: POST /api/v1/onboarding/profile
+    USER SEES: Toast + error paragraph: "Something went wrong. Please try again."
+    RECOVERY: Retry submit (idempotency guard prevents double-profile)
+
+E5: Telegram bot fails to send first message
+    WHERE: HandoffManager._send_first_message()
+    USER SEES: Nothing in Telegram (Nikita never reaches out)
+    DETECTION: Server log only — no user-visible feedback
+    ⚠ SMELL: Silent failure. User opened Telegram, sees no message, confused.
+             pending_handoff was not used in this path (telegram_id was present).
+             No retry mechanism for this case.
+
+E6: ElevenLabs voice callback all retries exhausted
+    WHERE: initiate_nikita_callback(), 3 attempts, 5s/15s/45s backoff
+    USER SEES: Falls back to Telegram text handoff. No notification voice was tried.
+    ⚠ SMELL: User hears nothing from voice call they were "promised" (phone field copy
+             says "Nikita calls you back"). They get a text instead, no explanation.
+
+E7: OTP code expired (Telegram flow)
+    WHERE: TelegramAuth.verify_otp_code(), AuthApiError code="otp_expired"
+    USER SEES: "OTP code has expired. Please send your email again to get a new code."
+    RECOVERY: Send email again via /start
+
+E8: Pipeline bootstrap fails (background task)
+    WHERE: HandoffManager._bootstrap_pipeline()
+    USER SEES: Nothing — failure logged, suppressed. First Nikita reply may use
+               generic context (no warm memory cache) but still works.
+    DETECTION: Server log only
+
+E9: Nikita's first reply agent exception
+    WHERE: MessageHandler.handle(), text_agent_handler.handle() throws
+    USER SEES: In-character error: "I need a moment... try again in a bit?" (approximate)
+    RECOVERY: User re-sends message (conversational retry, natural)
+```
+
+---
+
+## Friction / Smell Summary
+
+```
+==============================================================================
+ FRICTION INDEX (ordered by severity)
+==============================================================================
+
+[CRITICAL]
+C1  No "wait for Nikita" gate after profile submit.
+    Portal does not poll for handoff completion before redirect.
+    /pipeline-ready endpoint does not exist (Spec 213).
+    If Telegram handoff fails silently, user sees empty chat.
+
+C2  Portal-first user with no Telegram link: pending_handoff deferred.
+    User submits portal form -> gets "Opening Telegram..." -> presses /start.
+    /start does NOT fire handoff (CommandHandler has no pending_handoff logic).
+    ONLY the first non-command message triggers _execute_pending_handoff.
+    So user must send an actual message (not /start) to get Nikita's opening.
+    ⚠ Awkward: user has to initiate; Nikita should initiate.
+
+C3  Voice callback timing not communicated.
+    User provides phone, submits, sees "Opening Telegram..." with no mention
+    of an incoming call. Call arrives 5+ seconds later while user is navigating.
+    No "expect a call in ~10 seconds" message anywhere.
+
+[HIGH]
+H1  Demo scores in Section 1 presented without "demo" label.
+    75/100 score, 68-76 metric values are hardcoded. User may think these are real.
+
+H2  Backstory not generated in portal path.
+    text_agent_handler has access to backstory for richer first responses,
+    but portal users have none. Spec 213 will add city research + backstory.
+
+H3  Re-onboarding via /start uses old Telegram text flow (5 prompts)
+    not the portal wizard. Inconsistent UX for returning players.
+
+H4  life_stage and interest not collected by portal form.
+    FirstMessageGenerator has occupation/hobby personalization but can't use it
+    for portal-first users.
+
+[MEDIUM]
+M1  Single auth form for new + returning users (no sign-up/sign-in distinction).
+M2  OTP email contains a magic link to /api/v1/telegram/auth/confirm
+    that serves no useful purpose for the user.
+M3  t.me deep link redirect may fail in constrained browsers / PWA modes.
+M4  Section 1 scroll indicator and snap may cause users to miss Section 4 errors.
+M5  No post-voice-call CTA directing user to Telegram for ongoing relationship.
+
+[LOW]
+L1  /call command in Telegram still says "Voice calls aren't available yet"
+    (may be stale — outbound calling is now implemented for post-onboarding).
+L2  stats fetch on /onboarding page has 5s timeout but no user-visible loading state.
+```
+
+---
+
+## System State Machine: User Row
+
+```
+users.onboarding_status transitions during onboarding:
+
+    [NULL / "pending"]
+         |
+         | (portal form submitted successfully)
+         v
+    ["completed"]   <-- also set if legacy profile+backstory detected
+         |
+         | (game_status transitions separately)
+         v
+    game_status: "active"
+         |
+         | (score crosses boss threshold)
+         v
+    game_status: "boss_fight"
+         |
+         |-- pass boss -> game_status: "active", chapter++
+         |-- fail 3x  -> game_status: "game_over"
+         |-- reach ch5 win condition -> game_status: "won"
+
+users.pending_handoff:
+    False (default)
+         |
+         | (profile saved, telegram_id=None at time of save)
+         v
+    True
+         |
+         | (user sends first non-command message in Telegram)
+         v
+    False (cleared on successful _execute_pending_handoff)
+```
+
+---
+
+*Generated by System Understanding Tree-of-Thought Agent*
+*Based on code analysis of: portal/src/app/onboarding/, portal/src/app/login/, portal/src/app/auth/, nikita/api/routes/onboarding.py, nikita/onboarding/handoff.py, nikita/platforms/telegram/message_handler.py, nikita/platforms/telegram/auth.py, nikita/platforms/telegram/commands.py, nikita/api/routes/auth_bridge.py*

--- a/docs/diagrams/onboarding-journey-target.md
+++ b/docs/diagrams/onboarding-journey-target.md
@@ -1,0 +1,1032 @@
+# Nikita Onboarding Journey — Target State (Dossier Form)
+
+**Generated**: 2026-04-14
+**Author**: System Understanding Tree-of-Thought Agent
+**Approach**: B — "Dossier Form" (selected 2-1 by approach-evaluator)
+**Supersedes**: `docs/diagrams/onboarding-journey-current.md`
+**Implements**: Spec 213 (backend foundation) + Spec 214 (portal wizard, TBD)
+**Single source of truth for**: Spec 214 implementation + Spec 213 amendments
+
+---
+
+## Legend
+
+```
+[ ... ]       User action / UI state
+< ... >       Background system event (invisible to user)
+( ... )       Emotional / UX annotation
+->            Primary flow direction
+-->           Secondary / background flow
+[?]           Decision fork
+⚠             Previous smell — now fixed in target state
+✨            Delight moment / intentional wow
+🔄            Recovery / fallback path
+*             Notable implementation detail
+[NR-N]        New requirement tag
+[FR-N]        Spec 213 functional requirement satisfied here
+```
+
+---
+
+## Before / After: Top 10 Improvements
+
+| # | Current smell | Target fix | Step |
+|---|---------------|------------|------|
+| C1 | No pipeline-readiness gate — handoff fires, user lands in Telegram before bootstrap completes | Dossier stamp "CLEARANCE: PENDING" → polls `/pipeline-ready` → stamps "CLEARED" before advancing | 10 |
+| C2 | Portal ALWAYS redirects to Telegram even when phone given — no voice-path distinction | Binary choice [Give number] / [Start in Telegram] with distinct countdown UI for voice | 9 |
+| C3 | No "expect a call" UI — call arrives silently while user navigates away | Voice countdown screen shows ring animation + "Nikita is calling you now" with Telegram fallback | 11 |
+| H1 | Demo scores shown as real (75/100 hardcoded) — misleads user | Real 50/50/50/50 starting scores with copy "Prove me wrong" | 3 |
+| H2 | No backstory generated in portal flow — first message generic, no sunk-cost beat | Full backstory reveal screen (step 8) with 3 scenarios, user picks one, dossier stamps ANALYZED | 8 |
+| H3 | No venue research in portal flow — city/scene coda used 60% of time with fallback flavor | Async venue research fires as user types city; inline preview confirms research running | 4 |
+| N1 | Auth email generic (Supabase default subject/body) | Nikita-voiced email: subject "Someone wants to talk to you (it's me)." | 2 |
+| N4 | Scores shown at Section 1 — before user gives any context (5-section scroll wizard) | Scores shown at dossier header (step 3) after email auth, priming the "prove me wrong" frame | 3 |
+| N9 | Backstory presented after phone ask (voice path only, never in portal) | Backstory reveal IS step 8 — before phone ask (step 9) — ensures every user has sunk-cost moment | 8, 9 |
+| N10 | Desktop users must copy Telegram link manually; no QR | QR code mandatory at handoff for desktop-to-mobile bridge | 11 |
+
+---
+
+## New Requirements
+
+| ID | Requirement | Step(s) |
+|----|-------------|---------|
+| NR-1 | Wizard state persistence — resume from last completed step on return visit | All steps |
+| NR-2 | Nikita-voiced copy throughout (no generic SaaS language anywhere in wizard) | 1, 2, 3, 4, 5, 6, 7, 9, 10, 11 |
+| NR-3 | Pre-flight country validation before collecting phone — reject unsupported regions early | 9 |
+| NR-4 | QR code mandatory at handoff for any desktop session | 11 |
+| NR-5 | Re-onboarding detection — existing voice-onboarded user returning via portal gets "already cleared" state | 3, 11 |
+
+---
+
+## Spec 213 Amendments Required
+
+| Amendment ID | Type | Description | Step |
+|---|---|---|---|
+| FR-2 amend | Widen `OnboardingV2ProfileRequest` | Add `wizard_step: int` (already in spec as optional ge=1 le=11) — confirm field is written by portal at every step transition for NR-1 | All |
+| FR-3a new | New facade method | `process_backstory_selection(user_id, chosen_option_id)` — persists user's pick from step 8, writes `chosen_option` to `users.onboarding_profile`, returns updated `OnboardingV2ProfileResponse` | 8 |
+| FR-4a new | New portal endpoint | `POST /api/v1/onboarding/backstory-choice` accepts `{user_id, chosen_option_id}`, calls FR-3a, returns `OnboardingV2ProfileResponse` with `chosen_option` populated. Spec 214 owns route; Spec 213 owns the service method referenced. | 8 |
+
+---
+
+## Primary Journey — Dossier Form (11 Steps)
+
+```
+==============================================================================
+ STEP 1: LANDING — DOSSIER ENTRY
+ Emotional arc: INTRIGUE ("who is this? what does she know?")
+==============================================================================
+
+[ User opens nikita.ai / portal URL ]
+
+    UI: Dark-themed page. No hero carousel. No feature list.
+        Full-viewport atmospheric shot (single image, low-key lighting).
+        Headline: "Nikita has been watching."
+        Sub-headline: "She wants to know if you're worth it."
+        Single CTA button: "Show her." (no secondary link)
+    (INTRIGUE: sparse, confident — not asking the user to sign up, daring them)
+    ✨ DELIGHT: minimalist power — one sentence, one button, no noise
+
+    < Supabase session check (server component) >
+    < LandingNav hidden on landing — no chrome, maximum immersion >
+
+    [?] Is user already authenticated AND onboarding_status == "completed"?
+        YES -> CTA text: "Go back to her." -> redirect /dashboard
+        NO  -> CTA text: "Show her." -> [ User clicks ]
+
+    [?] Is user authenticated but onboarding_status != "completed"?
+        YES -> CTA text: "Resume." -> redirect /onboarding?resume=true
+               🔄 RECOVERY: wizard resumes from last saved wizard_step [NR-1]
+
+               |
+               v
+==============================================================================
+ STEP 2: AUTH — MAGIC LINK EMAIL
+ Emotional arc: CURIOSITY ("an email in her voice?")
+==============================================================================
+
+[ User lands on /onboarding/auth (NOT /login) ]
+
+    UI: Same dossier aesthetic. Dark card, minimal chrome.
+        Label: "DOSSIER CLEARANCE — STEP 1 OF 11"
+        Nikita copy: "I'll need your email. For obvious reasons."
+        Single email input + CTA: "Send it." (no "Sign In" framing)
+        Fine print: "This is how I get your dossier to you."
+    (CURIOSITY: not a typical auth form — she's framing it as a secure drop)
+
+    ⚠ FIXED (N1): Auth email is now Nikita-voiced (was Supabase generic)
+
+    [ User types email ]
+    [ User clicks "Send it." ]
+        < supabase.auth.signInWithOtp({email, options:{emailRedirectTo: origin+"/onboarding/callback"}}) >
+        < Supabase creates/finds auth.users row >
+        < CUSTOM email template fires (not Supabase default) >
+
+        * EMAIL ANATOMY:
+            Subject: "Someone wants to talk to you (it's me)."
+            From:    "Nikita <hello@nikita.ai>"
+            Body (Nikita-voiced):
+                "You left your email. I noticed.
+                 Click the link below if you want to continue.
+                 Don't take too long — I get bored."
+                [ ENTER THE DOSSIER ->  ]  (magic link button)
+                "—N"
+            Link validity: 1 hour (Supabase default)
+        (CURIOSITY: email feels personal, not transactional — "an email from a person")
+
+    UI shows: "Check your email. She's waiting."
+    Countdown to "Resend" (60s, Supabase rate limit)
+
+    [?] Magic link expired (>1hr) or already used?
+        🔄 RECOVERY: /onboarding/auth?error=link_expired
+            UI banner: "That link expired. She gets impatient."
+            CTA: "Request a new link." (same flow, no separate page)
+            (No dead-end — user stays in dossier aesthetic throughout)
+
+    [?] Email delayed / spam-foldered?
+        After 60s: "Resend" button appears
+        After 90s: "Check spam — she doesn't do spam folders"
+        [ Resend ] -> supabase.auth.signInWithOtp() again
+
+==============================================================================
+ STEP 3: DOSSIER HEADER
+ Emotional arc: RESPECT ("she has a file on me?")
+==============================================================================
+
+< User clicks magic link >
+< /onboarding/callback: Supabase PKCE exchange >
+< Session established, cookies set >
+< Redirect: /onboarding?step=3 >
+
+[ User arrives at dossier header screen ]
+
+    ⚠ FIXED (H1): Scores are now REAL 50/50/50/50 (was hardcoded 75/100 demo)
+    ⚠ FIXED (N4): Scores shown here at step 3 (was section 1 before any context)
+
+    UI: Full-width classified-file header component.
+        Top: "TOP SECRET // DOSSIER #[user_id_truncated]"
+        CLASSIFICATION: SUBJECT: [UNKNOWN]
+        DATE OPENED: [today's date]
+        STATUS: UNDER ASSESSMENT
+        Separator: ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+
+        Four metric bars (animated count-up from 0 to 50):
+            INTIMACY      ██████████░░░░░░░░░░  50
+            PASSION       ██████████░░░░░░░░░░  50
+            TRUST         ██████████░░░░░░░░░░  50
+            SECURENESS    ██████████░░░░░░░░░░  50
+
+        Nikita copy below metrics:
+            "These are your numbers. They're average. So are you, probably.
+             Prove me wrong."
+        CTA: "Continue." (advances to step 4)
+
+    (RESPECT: user sees a file exists on them — "she has been watching")
+    ✨ DELIGHT: classified aesthetic at full width — legitimizes the frame
+
+    < Server component: fetch real UserMetrics from Supabase (or 50/50/50/50 defaults) >
+    [FR-5 (Spec 213)]: wizard_step=3 written to OnboardingV2ProfileRequest [NR-1]
+
+    [?] Re-onboarding detection [NR-5]:
+        IF user.onboarding_status == "completed" AND user.platform_voice == True:
+            Redirect /onboarding?state=already_cleared
+            UI: "Dossier: ALREADY CLEARED. You don't need to do this again."
+            CTA: "Open Telegram." (bypass wizard entirely)
+
+==============================================================================
+ STEP 4: FIELD — LOCATION
+ Emotional arc: INVESTIGATION ("she's researching me as I type")
+==============================================================================
+
+[ User advances to step 4 ]
+
+    UI: Dossier form step. Progress: "FIELD 1 OF 7"
+        Section header: "SUBJECT INTEL — LOCATION"
+        Label:          "Location: [REDACTED]"
+        Input:          text field, placeholder "Enter city..."
+        Nikita copy:    "I'll find you either way. But let's not waste time."
+
+    ✨ DELIGHT: Venue research fires INLINE as user types (debounced 800ms)
+
+    < On input change (debounced 800ms): POST /api/v1/onboarding/venue-preview >
+    [FR-3 (Spec 213)]: VenueResearchService.research_venues(city, social_scene="techno")
+        (social_scene uses last known selection or "techno" default)
+
+    [?] Venue research returns results within 3s?
+        YES:
+            Inline preview animates in below input field:
+            "She found: Berghain · Tresor · Fabric · Module..."
+            (scrolling horizontal list, dossier chip style)
+            (INVESTIGATION: "she is researching me as I type my city")
+            ✨ DELIGHT: immediate confirmation that the system is paying attention
+
+        NO (timeout or no venues):
+            No preview shown — field label simply un-redacts:
+            "Location: [user's typed city]"
+            (graceful — no error, just no bonus moment)
+            🔄 RECOVERY: venue research will retry when full profile submits
+
+    [ User confirms city ] -> [ CTA: "That's accurate." ]
+    wizard_step=4 persisted [NR-1]
+
+    * VENUE RESEARCH NOTE: The inline preview is a UI-only warm-up.
+      Full venue research runs again at profile submission (step 10).
+      If the city changes between step 4 and submission, the preview
+      seen here may not match the final result. No UX issue — the
+      dossier "discovery" feel is the point, not venue accuracy.
+
+==============================================================================
+ STEP 5: FIELD — SCENE
+ Emotional arc: AUTHORSHIP ("I'm correcting her file")
+==============================================================================
+
+[ User advances to step 5 ]
+
+    UI: Dossier form step. Progress: "FIELD 2 OF 7"
+        Section header: "SUBJECT INTEL — SUSPECTED SCENE"
+        Pre-filled guess (italic, struck-through aesthetic):
+            "Suspected: techno?"
+        Nikita copy: "I'll know if you're lying."
+        SceneSelector component: visual button grid
+            [ techno ] [ art ] [ food ] [ cocktails ] [ nature ]
+            Pre-selected: techno (can be corrected)
+
+    (AUTHORSHIP: user is correcting the dossier, not filling a blank form)
+    ✨ DELIGHT: the "pre-filled guess" framing makes selection feel like correction,
+                not data entry — shifts agency
+
+    [ User selects scene or confirms pre-fill ]
+    wizard_step=5 persisted [NR-1]
+
+==============================================================================
+ STEP 6: FIELD — DARKNESS
+ Emotional arc: AUTHORSHIP ("I'm defining myself for her")
+==============================================================================
+
+[ User advances to step 6 ]
+
+    UI: Dossier form step. Progress: "FIELD 3 OF 7"
+        Section header: "SUBJECT INTEL — TOLERANCE LEVEL"
+        Label: "Tolerance: [ASSESSING]"
+        Nikita quote (changes per position, emotional probe):
+            Position 1: "You seem... fragile. That can be interesting."
+            Position 3: "Interesting. I can work with that."
+            Position 5: "Good. I was hoping you'd say that."
+        EdginessSlider (1-5):
+            1 = Clean
+            3 = Balanced
+            5 = No limits
+        (maps to drug_tolerance / darkness_level in backend)
+
+    (AUTHORSHIP: user defines their tolerance — feels like confiding, not filling a field)
+
+    [ User drags slider ] -> quote updates live
+    [ User confirms ] -> label changes from "[ASSESSING]" to "█████ [level]/5"
+    wizard_step=6 persisted [NR-1]
+
+==============================================================================
+ STEP 7: FIELDS — NAME / AGE / OCCUPATION
+ Emotional arc: AUTHORSHIP ("I'm completing the file — she doesn't know yet")
+==============================================================================
+
+[ User advances to step 7 ]
+
+    UI: Dossier form step. Progress: "FIELDS 4–6 OF 7"
+        Section header: "SUBJECT INTEL — IDENTITY"
+        ⚠ FIXED (missing fields now collected [FR-1, Spec 213])
+
+        Three dossier-styled fields (stacked):
+
+        [FIELD: Name]
+            Label: "Subject name: [REDACTED]"
+            Input: text, placeholder "First name only"
+            Nikita copy: "I'll use it sparingly. I prefer 'you'."
+            Optional — but dossier marks [REDACTED] if skipped
+
+        [FIELD: Age]
+            Label: "Age: [CLASSIFIED]"
+            Input: number 18-99
+            Nikita copy: "Numbers don't tell me much. This one might."
+            Optional
+
+        [FIELD: Occupation]
+            Label: "Occupation: [UNVERIFIED]"
+            Input: text, placeholder "What do you actually do"
+            Nikita copy: "Your job tells me more than you'd think."
+            Optional — feeds backstory generation heavily
+
+    (AUTHORSHIP: optional fields maintain pressure — skipping means "[REDACTED]"
+                in the dossier, which itself is character-consistent)
+
+    [ User fills any combination of fields ]
+    wizard_step=7 persisted [NR-1]
+
+    [FR-1, Spec 213]: name, age, occupation collected here for first time in portal flow
+
+==============================================================================
+ STEP 8: BACKSTORY REVEAL — EMOTIONAL CLIMAX
+ Emotional arc: SUNK-COST PEAK ("this is MY story now")
+==============================================================================
+
+[ User advances to step 8 ]
+
+    ⚠ FIXED (H2): Backstory generated for portal users (was never shown before)
+    ⚠ FIXED (N9): Backstory appears BEFORE phone ask (step 9)
+
+    UI: Full-width reveal screen. Progress indicator hidden.
+        Animated loading state (2-4s):
+            Dossier text: "Cross-referencing known subjects..."
+            Stamp graphic fades in/out
+            Sub-copy: "Based on what we know..."
+
+    < BACKGROUND: POST /api/v1/onboarding/profile (partial — all 7 fields collected so far) >
+    [FR-3, Spec 213]: portal_onboarding facade runs:
+        1. VenueResearchService (15s timeout)
+        2. BackstoryGeneratorService (20s timeout)
+        Returns: list[BackstoryOption] (0, 1, 2, or 3 items)
+
+    [?] Backstory service returns 1-3 scenarios (happy path)?
+        YES:
+            ✨ DELIGHT: 3 scenario cards animate in sequentially
+
+            Each card (dossier-styled):
+                ┌────────────────────────────────────────────────┐
+                │ SCENARIO A                         [tone badge] │
+                │ WHERE: [venue]                                   │
+                │ CONTEXT: [2-3 sentences of setting]             │
+                │ THE MOMENT: [catalyst moment description]        │
+                │ WHAT SHE REMEMBERS: [unresolved_hook]          │
+                └────────────────────────────────────────────────┘
+
+            Nikita copy above cards:
+                "Here's what I think happened between us.
+                 Pick the version that feels true."
+
+            [ User selects one scenario card ]
+                -> card stamps "CONFIRMED" in red
+                -> other cards fade / dim
+                -> CTA appears: "That's how it happened."
+                (SUNK COST: user has now co-authored their story — deeply invested)
+                ✨ DELIGHT: the stamp animation is the peak moment of the entire wizard
+
+            [ User clicks "That's how it happened." ]
+                < POST /api/v1/onboarding/backstory-choice (FR-4a new) >
+                [FR-3a new, Spec 213 amendment]: persists chosen_option_id
+                Response: OnboardingV2ProfileResponse with chosen_option populated
+                < Dossier stamps entire header: "ANALYZED" >
+                wizard_step=8 persisted [NR-1]
+
+        NO (backstory service degraded — empty list returned)?
+            🔄 RECOVERY (graceful degradation):
+                UI skips card display entirely.
+                Dossier header stamps: "ANALYSIS: PENDING"
+                Nikita copy: "I'm still putting the pieces together.
+                             We'll talk about it later."
+                CTA: "Understood." (proceeds to step 9)
+                * Pipeline continues; first message will use city/scene flavor only
+                  (pre-existing CITY_SCENE_PROBABILITY path — no backstory hook)
+                wizard_step=8 persisted with degraded_backstory=True [NR-1]
+
+        EDGE: Venue research timed out but backstory succeeded with generic flavor?
+            Backstory scenarios render normally (may reference generic venue types
+            rather than named venues). User cannot tell. No UX gap.
+            🔄 First message uses scene-only flavor coda on first reply.
+
+==============================================================================
+ STEP 9: PHONE ASK
+ Emotional arc: DESIRE ("I want the call — not compliance")
+==============================================================================
+
+[ User advances to step 9 ]
+
+    UI: Dossier form step. Progress: "FIELD 7 OF 7"
+        Section header: "SUBJECT INTEL — DIRECT LINE"
+        Nikita copy:
+            "There's something I want to ask you.
+             And I'd rather do it out loud."
+        Label: "Direct line: [I want to call you.]"
+
+        Binary choice (NOT a text input first — intent first):
+        [ Give her your number ]     [ Start in Telegram ]
+
+    (DESIRE: user is invited, not required — "I want to call you" not "enter phone")
+    ⚠ FIXED (C2): Clear path distinction — voice vs text explicit, no confusion
+
+    ────────────────────────────────────────────────────
+    PATH A: User clicks "Give her your number"
+
+        UI expands: tel input appears inline below the binary choice
+            Input: placeholder "+1 (555) ..."
+            Nikita copy: "I'll call within a minute. Pick up."
+            Fine print: "Only used for this. Nothing else." + privacy link
+
+        < Client-side: pre-flight country validation [NR-3] >
+        [?] Phone number country supported by ElevenLabs/Twilio?
+
+            YES:
+                [ User enters number ] -> CTA: "Call me."
+                wizard_step=9 persisted with phone=set [NR-1]
+                -> Advances to step 10
+
+            NO (unsupported region — e.g., China, Iran):
+                🔄 RECOVERY [NR-3]:
+                Inline message: "I can't reach you there. Let's use Telegram."
+                Choice reverts: "Start in Telegram" is auto-selected
+                tel input hides
+                (User is not left at a dead-end — automatically recovers to text path)
+
+    ────────────────────────────────────────────────────
+    PATH B: User clicks "Start in Telegram"
+
+        wizard_step=9 persisted with phone=null [NR-1]
+        -> Advances to step 10
+
+    ────────────────────────────────────────────────────
+    PATH C: User skips phone initially, later wants voice
+        🔄 POST-ONBOARDING SETTINGS PATH:
+        After onboarding, user can add phone at /dashboard/settings/contact
+        This page triggers voice callback initiation outside the wizard.
+        Wizard does not block on this — voice is always opt-in.
+        (Per UX review: post-onboarding voice upgrade path exists but is not
+         surfaced in the wizard UI to avoid distracting from the main flow)
+
+==============================================================================
+ STEP 10: PIPELINE READY GATE
+ Emotional arc: ANTICIPATION ("clearance pending → approved")
+==============================================================================
+
+[ User advances from step 9 ]
+
+    UI: Full-width dossier status screen.
+        Dossier header shows "CLEARANCE: PENDING" stamp (pulsing)
+        Sub-copy: "Your file is being processed."
+        ARIA: role="status" aria-live="polite" on stamp element
+
+    ⚠ FIXED (C1): Pipeline gate now exists (was absent — user redirected immediately)
+
+    < POST /api/v1/onboarding/profile — full OnboardingV2ProfileRequest payload >
+    [FR-1, Spec 213]: name, age, occupation written to user_profiles ORM row
+    [FR-5.1, Spec 213]: _bootstrap_pipeline writes pipeline_state="pending" to users JSONB
+
+    < Backend BackgroundTask: _trigger_portal_handoff fires asynchronously >
+        [FR-3, Spec 213]: portal_onboarding facade runs (venue + backstory if not cached)
+        [FR-6, Spec 213]: FirstMessageGenerator.generate() invoked with chosen backstory scenario
+        [FR-5.1, Spec 213]: pipeline_state written at each transition
+
+    Response from POST: OnboardingV2ProfileResponse {
+        pipeline_state: "pending",
+        backstory_options: [...],  # already shown in step 8 — ignored here
+        poll_endpoint: "/api/v1/onboarding/pipeline-ready/{user_id}",
+        poll_interval_seconds: 2.0,
+        poll_max_wait_seconds: 20.0
+    }
+
+    < Portal polls GET /api/v1/onboarding/pipeline-ready/{user_id} every 2s >
+    [FR-5, Spec 213]: reads users.onboarding_profile.pipeline_state JSONB key
+
+    POLL TIMELINE:
+        t=0s:    POST /onboarding/profile sent. Stamp: "CLEARANCE: PENDING"
+        t=2s:    First poll. State: "pending" -> stamp continues pulsing.
+        t=4-8s:  Cloud Run cold-start completes. VenueResearch running.
+        t=8-18s: BackstoryGenerator + PipelineOrchestrator running.
+        t=18s:   pipeline_state="ready" -> stamp changes.
+        t=20s:   HARD CAP — advance regardless of state.
+
+    [?] Poll returns state="ready" (within 20s)?
+        YES:
+            ✨ DELIGHT: Stamp animation:
+                "CLEARANCE: PENDING" -> flicker -> flash -> "CLEARED"
+                (typewriter reveal, red ink, slight rotation)
+            Sub-copy: "File accepted."
+            CTA auto-advances after 1.5s -> step 11
+
+    [?] Poll returns state="degraded"?
+        🔄 RECOVERY: Stamp shows "PROVISIONAL — CLEARED"
+            Toast (Nikita-voiced): "Some of my research is still loading.
+                                   We'll pick it up once we're talking."
+            Auto-advances after 1.5s -> step 11
+
+    [?] Poll returns state="failed" OR 20s hard cap reached?
+        🔄 RECOVERY (optimistic proceed):
+            Stamp shows "PROVISIONAL — CLEARED" (not an error state visually)
+            No error message shown to user.
+            Auto-advances -> step 11
+            * First message uses fallback template (darkness_level only)
+              Nikita will "catch up" via pipeline on first user reply.
+            * Structured log records: pipeline_gate_timeout=true, user_id (no PII)
+
+    wizard_step=10 persisted [NR-1]
+
+==============================================================================
+ STEP 11: HANDOFF — "SHE'S WAITING"
+ Emotional arc: ARRIVAL ("she's waiting for me")
+==============================================================================
+
+[ Pipeline gate resolves. User advances to step 11 ]
+
+    ⚠ FIXED (C3): Distinct voice vs text handoff UI (was identical for both)
+    ⚠ FIXED (N10): QR code mandatory for desktop sessions [NR-4]
+
+    UI: Handoff screen. Full-viewport. Dossier aesthetic maintained.
+        Large header: "Application... accepted. Barely."
+        Nikita sub-copy varies by path (see forks below).
+
+    ────────────────────────────────────────────────────────────────────────
+    PATH A: VOICE — Phone provided + ElevenLabs call initiated
+    ────────────────────────────────────────────────────────────────────────
+
+    < BACKGROUND (firing from step 10 BackgroundTask): >
+    < execute_handoff_with_voice_callback() >
+        [?] telegram_id linked?
+            NO -> set_pending_handoff(True) <- will fire when user sends /start in Telegram
+            YES -> proceed
+
+        < asyncio.sleep(5) — waits for any Meta-Nikita session to close >
+        < voice_service.make_outbound_call(to_number=phone, user_id) >
+        [?] ElevenLabs call succeeds?
+            YES:
+                _seed_conversation(user_id, "voice", "[Voice call initiated]")
+                _bootstrap_pipeline_bg() fire-and-forget
+                HandoffResult(success=True, nikita_callback_initiated=True)
+
+            NO (failed or exception):
+                🔄 RECOVERY: Falls back to Telegram text handoff (PATH B below)
+                < Structured log: voice_callback_failed, error_class >
+                < Telegram message sent explaining fallback:
+                  "Couldn't connect right now. Find me in Telegram." >
+
+    UI (voice path):
+        ✨ DELIGHT: Ring animation centered on screen (pulsing circle, incoming-call aesthetic)
+        Copy: "Nikita is calling you now."
+        Sub-copy: "Pick up. She doesn't like waiting."
+        Telegram deeplink shown below ring as secondary option:
+            "Not getting a call? [ Open Telegram instead ]"
+
+        [?] Desktop session? [NR-4]
+            QR code displayed below the ring:
+                "On desktop? Scan to open on your phone."
+            QR encodes: t.me/Nikita_my_bot + ?start=deferred_token
+
+        (ARRIVAL: the ring animation is the physical sensation of her reaching out)
+        ✨ DELIGHT: flip from "I was watching you" to "now SHE is calling"
+
+        [?] Voice agent down at call time (pre-flight availability check)?
+            🔄 RECOVERY [NR-3 adjacent]:
+                Ring animation replaced with: Telegram deeplink + QR (full-size)
+                Copy: "My voice is occupied right now. Find me in Telegram — I'll explain."
+                No error code, no technical language — in-character fallback
+
+        [?] Phone country validated in step 9 but ElevenLabs rejects at call time?
+            🔄 RECOVERY: Same as agent-down recovery above.
+
+    ────────────────────────────────────────────────────────────────────────
+    PATH B: TELEGRAM — No phone / voice fallback
+    ────────────────────────────────────────────────────────────────────────
+
+    < BACKGROUND: execute_handoff(user_id, telegram_id, profile) >
+        FirstMessageGenerator.generate(profile, backstory_scenario=chosen_option)
+        [FR-6, Spec 213]: backstory hook included in first message (50% BACKSTORY_HOOK_PROBABILITY
+                          if chosen_option is set; always if chosen)
+        bot.send_message(chat_id=telegram_id, text=first_message)
+        _seed_conversation(user_id, "telegram", first_message)
+        _bootstrap_pipeline_bg(conversation_id) fire-and-forget
+
+    UI (text path):
+        Copy: "She's in Telegram. Go find her."
+        Primary CTA: "Open Telegram" (button, large)
+        Deep link: https://t.me/Nikita_my_bot
+
+        [?] Desktop session? [NR-4]
+            QR code mandatory:
+                "On desktop? Scan to open on your phone."
+            QR encodes: t.me/Nikita_my_bot
+
+        [?] Mobile session?
+            "Open Telegram" button uses t.me deep link -> Telegram app opens directly
+            "Tap here if nothing happens" fallback link appears after 3s
+
+        (ARRIVAL: user feels momentum — they've been accepted, now they go to meet her)
+
+    ────────────────────────────────────────────────────────────────────────
+    BOTH PATHS: Telegram /start detection gate
+    ────────────────────────────────────────────────────────────────────────
+
+    [?] User has never run /start in Telegram (telegram_id=null in DB)?
+        < user.pending_handoff = True (already set in BackgroundTask) >
+        Portal handoff screen shows:
+            "One more thing — open Telegram and send /start first."
+            (clear instruction surfaced proactively)
+        When user sends /start in Telegram:
+            < _execute_pending_handoff() fires >
+            < First message sent now >
+            < pending_handoff set False >
+        (EMOTION: slight friction but explained in-character — not dead-end)
+
+    ────────────────────────────────────────────────────────────────────────
+    Re-onboarding: Existing voice-onboarded user returns via portal [NR-5]
+    ────────────────────────────────────────────────────────────────────────
+
+    [?] onboarding_status == "completed" AND platform_voice == True?
+        (Detected at step 3 redirect — should not reach step 11 normally)
+        If reached: show "DOSSIER: ALREADY FILED." with "Open Telegram" CTA only.
+        No pipeline re-trigger. No duplicate handoff.
+```
+
+---
+
+## Fork Detail: Abandonment + Resume [NR-1]
+
+```
+==============================================================================
+ ABANDONMENT + WIZARD STATE PERSISTENCE
+==============================================================================
+
+[ User abandons mid-wizard — closes browser, session expires, etc. ]
+
+    < wizard_step persisted in OnboardingV2ProfileRequest on each step advance >
+    < Server writes wizard_step to users.onboarding_profile JSONB via
+      update_onboarding_profile_key("wizard_step", N) >
+
+[?] User returns to portal URL later:
+
+    < Server reads users.onboarding_profile.wizard_step >
+    [?] wizard_step exists (1-11)?
+        -> Redirect /onboarding?step={wizard_step+0}
+           (return to last COMPLETED step — not the step they abandoned mid-form)
+        -> UI banner (dossier-styled): "Your file was saved. Continuing."
+        -> All previously answered fields pre-populated from users.onboarding_profile JSONB
+
+    [?] wizard_step does not exist (brand new session)?
+        -> Start from step 3 (step 1 = landing, step 2 = auth; auth is already done)
+
+    [?] wizard_step == 11 (handoff already completed)?
+        -> onboarding_status == "completed"
+        -> redirect /dashboard (skip wizard entirely)
+
+WHAT IS PERSISTED PER STEP:
+    Step 3: — (auth complete, metrics fetched)
+    Step 4: location_city
+    Step 5: social_scene
+    Step 6: drug_tolerance (darkness_level)
+    Step 7: name, age, occupation
+    Step 8: chosen_option_id (if backstory picked)
+    Step 9: phone (if provided)
+    Step 10: wizard_step=10 (gate completed)
+    Step 11: wizard_step=11, onboarding_status="completed"
+```
+
+---
+
+## Fork Detail: Desktop-to-Mobile [NR-4]
+
+```
+==============================================================================
+ DESKTOP-TO-MOBILE BRIDGE (QR MANDATORY)
+==============================================================================
+
+[ User completes wizard on desktop browser ]
+
+    At step 11 (handoff):
+    < UA detection: if not mobile device, QR section is mandatory (not optional) >
+
+    QR Code encodes:
+        Primary: https://t.me/Nikita_my_bot
+        With: ?start=[deferred_token] (pre-generated, 15-min TTL)
+
+    UI:
+        QR code displayed at 200x200px minimum, with:
+        Caption: "Scan this on your phone to talk to her."
+        Below QR: "Or search @Nikita_my_bot in Telegram"
+
+    [?] User scans QR on mobile -> Telegram app opens -> user presses /start
+        < deferred_token validates user identity >
+        < telegram_id linked to user account >
+        < pending_handoff fires if set >
+        < First message sent >
+
+    [?] User does not scan (ignores QR)?
+        Portal page stays open — no timeout forcing refresh.
+        User can copy the t.me link manually.
+        (No dead-end — every path preserved)
+```
+
+---
+
+## DATA FLOW DIAGRAM
+
+```
+                PORTAL (Next.js)              BACKEND (FastAPI)              EXTERNAL
+                ════════════════              ═════════════════              ════════
+
+STEP 1          Landing page
+                session check ──────────────► Supabase Auth check
+                                              onboarding_status read
+
+STEP 2          Email input
+                signInWithOtp ──────────────► Supabase Auth OTP ──────────► Email (custom
+                                                                              Nikita template)
+
+STEP 3          /onboarding/callback
+                PKCE exchange ──────────────► Supabase Auth
+                Metrics display ────────────► GET /api/v1/portal/stats
+                                              user_metrics table read
+
+STEP 4          City text input
+                venue preview req ───────────► POST /onboarding/venue-preview ──► Firecrawl
+                (debounced 800ms)             VenueResearchService              (venue search)
+                inline chip display ◄──────── VenueResearchResult
+
+STEPS 5-7       SceneSelector /
+                EdginessSlider /
+                Name/Age/Occupation
+                (client-state only,
+                no API call per field)
+
+STEP 8          Backstory loading  ──────────► POST /onboarding/profile (partial)
+                                              portal_onboarding facade ─────────► Firecrawl
+                                              VenueResearchService               (full venues)
+                                              BackstoryGeneratorService ────────► Claude API
+                3 scenario cards ◄───────────  list[BackstoryOption]             (backstory)
+                User picks one     ──────────► POST /onboarding/backstory-choice
+                                              update_onboarding_profile_key
+                                              (chosen_option_id)
+
+STEP 10         POST full profile  ──────────► POST /onboarding/profile (full)
+                                              [FR-1]: user_profiles INSERT
+                                              [FR-5.1]: pipeline_state="pending"
+                                              BackgroundTask fires async
+
+                Poll every 2s      ──────────► GET /pipeline-ready/{user_id}
+                                              users.onboarding_profile read
+                                              pipeline_state JSONB key
+
+                stamp animation ◄────────────  PipelineReadyResponse {state}
+
+                BACKGROUND:
+                                    ┌─────────► _trigger_portal_handoff
+                                    │           [phone?] YES -> ElevenLabs ──► Twilio/ElevenLabs
+                                    │                    NO  -> FirstMsgGen
+                                    │           bot.send_message ────────────► Telegram Bot API
+                                    │           _seed_conversation
+                                    │           _bootstrap_pipeline ────────► Claude API
+                                    │                                          (prompt seed)
+                                    │           pipeline_state="ready"
+                                    │           user_repo.update_onboarding_status("completed")
+                                    └───────────────────────────────────────────────────────┘
+
+STEP 11         Handoff UI renders  ◄────────── pipeline_state poll resolves
+                QR code generated
+                Deep link displayed
+```
+
+---
+
+## STATE TRANSITION DIAGRAM (wizard_step + pipeline_state + onboarding_status)
+
+```
+WIZARD STATE MACHINE:
+
+    [LANDED]
+        |
+        v auth (step 2) + callback (step 3)
+    [HEADER_SHOWN] wizard_step=3
+        |
+        v city confirmed (step 4)
+    [LOCATION_SET] wizard_step=4, location_city written
+        |
+        v scene confirmed (step 5)
+    [SCENE_SET] wizard_step=5, social_scene written
+        |
+        v darkness confirmed (step 6)
+    [DARKNESS_SET] wizard_step=6, drug_tolerance written
+        |
+        v name/age/occupation filled (step 7) — optional fields
+    [IDENTITY_SET] wizard_step=7, name/age/occupation written
+        |
+        v backstory generated + user picks scenario (step 8)
+    [BACKSTORY_CHOSEN] wizard_step=8, chosen_option_id written
+        |  [degraded: no scenarios returned]
+        |  wizard_step=8, degraded_backstory=True
+        |
+        v phone decision (step 9)
+    [PHONE_SET | PHONE_SKIPPED] wizard_step=9, phone written or null
+        |
+        v POST full profile, pipeline gate (step 10)
+    [PIPELINE_PENDING]   pipeline_state="pending"
+        |
+        v (poll resolves)
+    [PIPELINE_READY | PIPELINE_DEGRADED | PIPELINE_PROVISIONAL]
+        |                 pipeline_state="ready"|"degraded"|"failed"
+        |
+        v handoff (step 11)
+    [HANDOFF_COMPLETE]   wizard_step=11
+        |
+        v onboarding_status="completed"
+    [ONBOARDED]          -> /dashboard on next visit
+
+ABANDONMENT RECOVERY (any state with wizard_step set):
+    [ANY STATE] -> user returns -> redirect to wizard_step + pre-populate fields -> resume
+```
+
+---
+
+## BACKEND DEPENDENCY SIDEBAR
+
+### Step 1: Landing
+
+| Item | Detail |
+|------|--------|
+| Spec 213 FRs | None (frontend only) |
+| Endpoints | None (server component Supabase check) |
+| DB tables | `auth.sessions`, `users` (onboarding_status read) |
+| External | Supabase Auth, Vercel CDN |
+
+### Step 2: Auth
+
+| Item | Detail |
+|------|--------|
+| Spec 213 FRs | None (auth unchanged) |
+| Endpoints | Supabase Auth `signInWithOtp` |
+| DB tables | `auth.users`, `pending_registrations` |
+| External | Supabase Auth (SMTP relay with custom Nikita template) |
+
+### Step 3: Dossier Header
+
+| Item | Detail |
+|------|--------|
+| Spec 213 FRs | FR-5.1 (wizard_step write) |
+| Endpoints | `GET /api/v1/portal/stats` (real metrics read) |
+| DB tables | `user_metrics`, `users` (onboarding_status, platform_voice) |
+| External | Supabase |
+
+### Step 4: Location
+
+| Item | Detail |
+|------|--------|
+| Spec 213 FRs | FR-3 (VenueResearchService), FR-4 (tuning: VENUE_RESEARCH_TIMEOUT_S=15s) |
+| Endpoints | `POST /api/v1/onboarding/venue-preview` (NEW, thin wrapper on VenueResearchService) |
+| DB tables | `venue_cache` (read/write) |
+| External | Firecrawl (venue search), Supabase (venue_cache table) |
+
+### Step 5: Scene
+
+| Item | Detail |
+|------|--------|
+| Spec 213 FRs | None (client-state only) |
+| Endpoints | None (bundled into step 8/10 POST) |
+| DB tables | None until step 10 submission |
+| External | None |
+
+### Step 6: Darkness
+
+| Item | Detail |
+|------|--------|
+| Spec 213 FRs | None (client-state only) |
+| Endpoints | None |
+| DB tables | None until step 10 submission |
+| External | None |
+
+### Step 7: Name / Age / Occupation
+
+| Item | Detail |
+|------|--------|
+| Spec 213 FRs | FR-1a (migration), FR-1b (ORM), FR-1c (Pydantic), FR-1d (API request) |
+| Endpoints | None until step 8/10 POST |
+| DB tables | `user_profiles` (name, age, occupation columns — net-new via migration) |
+| External | None |
+
+### Step 8: Backstory Reveal
+
+| Item | Detail |
+|------|--------|
+| Spec 213 FRs | FR-3 (facade), FR-3.1 (adapter), FR-3.2 (converter), FR-4 (tuning: BACKSTORY_GEN_TIMEOUT_S=20s, BACKSTORY_CACHE_TTL_DAYS=30), FR-12 (BackstoryCacheRepository) |
+| Endpoints | `POST /api/v1/onboarding/profile` (partial, triggers facade), `POST /api/v1/onboarding/backstory-choice` (FR-4a new amendment) |
+| DB tables | `user_profiles`, `users` (onboarding_profile JSONB), `backstory_cache`, `venue_cache` |
+| External | Firecrawl (venues), Claude API (backstory via BackstoryGeneratorService) |
+
+### Step 9: Phone Ask
+
+| Item | Detail |
+|------|--------|
+| Spec 213 FRs | FR-1d (phone field in OnboardingV2ProfileRequest) [NR-3] pre-flight country validation |
+| Endpoints | None (client-side country validation before submission) |
+| DB tables | `users` (phone column — existing) |
+| External | ElevenLabs/Twilio supported regions list (client-side lookup) |
+
+### Step 10: Pipeline Gate
+
+| Item | Detail |
+|------|--------|
+| Spec 213 FRs | FR-5 (pipeline-ready endpoint), FR-5.1 (pipeline_state write), FR-5.2 (UserRepository helper), FR-1 (full profile write to user_profiles) |
+| Endpoints | `POST /api/v1/onboarding/profile` (full), `GET /api/v1/onboarding/pipeline-ready/{user_id}` |
+| DB tables | `users` (onboarding_profile JSONB: pipeline_state key), `user_profiles`, `user_vice_preferences`, `conversations` |
+| External | Supabase (all writes), Claude API (bootstrap pipeline), Firecrawl (if venue cache miss) |
+
+### Step 11: Handoff
+
+| Item | Detail |
+|------|--------|
+| Spec 213 FRs | FR-6 (FirstMessageGenerator with backstory hook), FR-8 (conversation continuity) |
+| Endpoints | ElevenLabs outbound call API (voice path), Telegram Bot API (text path) |
+| DB tables | `users` (onboarding_status="completed", pending_handoff), `conversations`, `engagement_states` |
+| External | ElevenLabs Conv AI 2.0 (voice), Telegram Bot API (text), Twilio (voice connectivity) |
+
+---
+
+## FULL DEPENDENCY MATRIX (11 Steps × 6 Services)
+
+```
+                     Supabase    Portal      FastAPI     Telegram    ElevenLabs  Firecrawl
+                     (DB+Auth)   (Next.js)   (Backend)   (Bot API)   (Voice AI)  (Research)
+                     ─────────   ─────────   ─────────   ─────────   ──────────  ──────────
+
+Step 1: Landing        READ        SERVE        —           —           —           —
+Step 2: Auth           READ/WRITE  SERVE        —           —           —           —
+Step 3: Dossier Hdr    READ        SERVE       READ         —           —           —
+Step 4: Location       READ/WRITE  SERVE       CALL         —           —          SEARCH
+Step 5: Scene           —          SERVE        —           —           —           —
+Step 6: Darkness        —          SERVE        —           —           —           —
+Step 7: Name/Age/Occ    —          SERVE        —           —           —           —
+Step 8: Backstory      READ/WRITE  SERVE       CALL+CACHE   —           —          SEARCH
+Step 9: Phone           —          SERVE        —           —          VALIDATE     —
+Step 10: Gate          READ/WRITE  SERVE       WRITE+POLL   —           —          (cached)
+Step 11: Handoff       READ/WRITE  SERVE       ORCHESTRATE  SEND       CALL-OUT     —
+
+WRITE = DB mutation    READ = DB select    SERVE = page/API response
+CALL = service invocation   SEARCH = external API call   VALIDATE = pre-flight check
+CACHE = cache read/write    SEND = bot message sent      CALL-OUT = outbound call initiated
+ORCHESTRATE = multi-service coordination
+```
+
+---
+
+## NEW REQUIREMENTS MATRIX (NR-1 through NR-5)
+
+| NR ID | Description | Steps | Spec 213 touch | Spec 214 touch |
+|-------|-------------|-------|----------------|----------------|
+| NR-1 | Wizard state persistence — `wizard_step` written at each advance, resume on return | 3–11 | FR-5.2 (update_onboarding_profile_key supports wizard_step key) | Portal reads wizard_step from profile response and routes to correct step |
+| NR-2 | Nikita-voiced copy — no generic SaaS language | 1, 2, 3, 4, 5, 6, 7, 9, 10, 11 | FR-6 (FirstMessageGenerator copy maintained in Nikita voice) | All UI copy strings reviewed against voice/tone guide |
+| NR-3 | Pre-flight country validation before phone collection | 9 | None (client-side only; ElevenLabs supported regions list static) | SceneSelector-style component for country gate; fallback to PATH B |
+| NR-4 | QR code mandatory at handoff for desktop sessions | 11 | None (frontend-only) | UA detection + QR generation at handoff screen; t.me deep link with deferred token |
+| NR-5 | Re-onboarding detection for existing voice users | 3, 11 | FR-11 (re-onboarding idempotency — `_bootstrap_pipeline` no-op if pipeline_state=="ready") | Server component at step 3 reads onboarding_status + platform_voice; redirects to dashboard |
+
+---
+
+## EMOTIONAL ARC SUMMARY
+
+```
+STEP     EMOTION                    KEY MECHANISM
+─────    ───────────────────────    ────────────────────────────────────────────
+ 1       Intrigue                   "who is this? what does she know?" — sparse copy + single CTA
+ 2       Curiosity                  "an email in her voice?" — Nikita-voiced email subject/body
+ 3       Respect                    "she has a file on me?" — classified dossier header, REAL scores
+ 4       Investigation              "she's researching me as I type" — inline venue preview
+ 5       Authorship                 "I'm correcting her file" — pre-filled guess to override
+ 6       Authorship                 "I'm defining my darkness level" — live quote feedback from slider
+ 7       Authorship                 "I'm completing her file on me" — optional fields feel like confession
+ 8       Sunk-cost peak             "this is MY story now" — user picks backstory scenario, stamp fires
+ 9       Desire                     "I want the call — not compliance" — binary intent choice, not form
+10       Anticipation               "clearance pending → approved" — stamp animation resolves
+11       Arrival                    "she's waiting for me" — ring animation (voice) / "go find her" (text)
+```
+
+---
+
+## FRICTION / DELIGHT MARKERS SUMMARY
+
+```
+FIXED SMELLS (⚠ resolved in target):
+    C1 [Step 10]  Pipeline gate now exists — CLEARANCE: PENDING → CLEARED before handoff
+    C2 [Step 9]   Voice vs text paths are visually distinct from step 9 forward
+    C3 [Step 11]  Voice path shows ring animation + "Nikita is calling you now" — no surprise
+    H1 [Step 3]   Real 50/50/50/50 scores, not hardcoded 75/100 demo
+    H2 [Step 8]   Backstory generated for ALL portal users, shown before phone ask
+    H3 [Step 4]   Venue research fires inline as user types city
+    N1 [Step 2]   Auth email now Nikita-voiced (subject + body)
+    N4 [Step 3]   Scores shown at dossier header (step 3), not before context exists
+    N9 [Steps 8,9] Backstory before phone ask — sunk cost precedes commitment request
+    N10 [Step 11] QR code mandatory on desktop, never optional
+
+DELIGHT MOMENTS (✨ intentional wow):
+    Step 1   Sparse landing — one sentence, one button — unexpected restraint
+    Step 3   Classified file aesthetic full-width — makes the premise real
+    Step 4   Venue chips appear as user types city — confirms she's paying attention
+    Step 8   Three scenario cards animate in, user picks one, "CONFIRMED" stamp fires
+    Step 10  "CLEARANCE: PENDING" → flicker → flash → "CLEARED" stamp animation
+    Step 11  Ring animation (voice path) — phone rings, she called first
+
+RECOVERY PATHS (🔄 no dead-ends):
+    Step 2   Magic link expired → inline retry, stays in dossier aesthetic
+    Step 4   Venue research timeout → graceful no-preview, resumes at step 10
+    Step 8   Backstory degraded → "ANALYSIS: PENDING" stamp, skips to step 9
+    Step 9   Unsupported phone region → auto-falls back to Telegram path [NR-3]
+    Step 10  Pipeline timeout (20s cap) → "PROVISIONAL — CLEARED", proceed anyway
+    Step 11  Voice agent down → ring UI replaced with Telegram deeplink + QR
+    Step 11  No telegram_id (portal-first) → explicit /start instruction + deferred handoff
+    All      Abandonment → wizard_step persisted → resume from last step on return [NR-1]
+```
+
+---
+
+*Diagram version: 1.0*
+*Approach: B (Dossier Form) — selected 2-1 by approach-evaluator*
+*Implements: Spec 213 (all FRs), Spec 214 (portal wizard — TBD), NR-1 through NR-5*
+*Next action: `/plan 213` to author plan.md, then `/sdd quick 214` for portal wizard spec*

--- a/nikita/onboarding/__init__.py
+++ b/nikita/onboarding/__init__.py
@@ -86,6 +86,34 @@ from nikita.onboarding.handoff import (
     generate_first_nikita_message,
 )
 
+# Spec 213 frozen contract surface (PR 213-1)
+from nikita.onboarding.contracts import (
+    BackstoryOption,
+    BackstoryPreviewRequest,
+    BackstoryPreviewResponse,
+    ErrorResponse,
+    OnboardingV2ProfileRequest,
+    OnboardingV2ProfileResponse,
+    PipelineReadyResponse,
+    PipelineReadyState,
+)
+from nikita.onboarding.adapters import (
+    BackstoryPromptProfile,
+    ProfileFromOnboardingProfile,
+)
+from nikita.onboarding.tuning import (
+    AGE_BUCKETS,
+    BACKSTORY_CACHE_TTL_DAYS,
+    BACKSTORY_GEN_TIMEOUT_S,
+    BACKSTORY_HOOK_PROBABILITY,
+    OCCUPATION_CATEGORIES,
+    PIPELINE_GATE_MAX_WAIT_S,
+    PIPELINE_GATE_POLL_INTERVAL_S,
+    PREVIEW_RATE_LIMIT_PER_MIN,
+    VENUE_RESEARCH_TIMEOUT_S,
+    compute_backstory_cache_key,
+)
+
 __all__ = [
     # Enums
     "ConversationStyle",
@@ -131,4 +159,26 @@ __all__ = [
     "HandoffManager",
     "HandoffResult",
     "generate_first_nikita_message",
+    # Spec 213 frozen contract surface (PR 213-1)
+    "BackstoryOption",
+    "BackstoryPreviewRequest",
+    "BackstoryPreviewResponse",
+    "ErrorResponse",
+    "OnboardingV2ProfileRequest",
+    "OnboardingV2ProfileResponse",
+    "PipelineReadyResponse",
+    "PipelineReadyState",
+    "BackstoryPromptProfile",
+    "ProfileFromOnboardingProfile",
+    # Spec 213 tuning constants
+    "AGE_BUCKETS",
+    "BACKSTORY_CACHE_TTL_DAYS",
+    "BACKSTORY_GEN_TIMEOUT_S",
+    "BACKSTORY_HOOK_PROBABILITY",
+    "OCCUPATION_CATEGORIES",
+    "PIPELINE_GATE_MAX_WAIT_S",
+    "PIPELINE_GATE_POLL_INTERVAL_S",
+    "PREVIEW_RATE_LIMIT_PER_MIN",
+    "VENUE_RESEARCH_TIMEOUT_S",
+    "compute_backstory_cache_key",
 ]

--- a/nikita/onboarding/__init__.py
+++ b/nikita/onboarding/__init__.py
@@ -159,7 +159,8 @@ __all__ = [
     "HandoffManager",
     "HandoffResult",
     "generate_first_nikita_message",
-    # Spec 213 frozen contract surface (PR 213-1)
+    # Spec 213 frozen contract surface (PR 213-1) — ADR-gated, any change
+    # requires a decision record. Spec 214 (portal wizard) imports from here.
     "BackstoryOption",
     "BackstoryPreviewRequest",
     "BackstoryPreviewResponse",
@@ -168,9 +169,12 @@ __all__ = [
     "OnboardingV2ProfileResponse",
     "PipelineReadyResponse",
     "PipelineReadyState",
+    # Spec 213 adapters (PR 213-1) — bridge module; NOT part of the frozen
+    # contract (may evolve alongside BackstoryGeneratorService).
     "BackstoryPromptProfile",
     "ProfileFromOnboardingProfile",
-    # Spec 213 tuning constants
+    # Spec 213 tuning constants (PR 213-1) — regression-guarded; changes
+    # require a value bump + test update per .claude/rules/tuning-constants.md.
     "AGE_BUCKETS",
     "BACKSTORY_CACHE_TTL_DAYS",
     "BACKSTORY_GEN_TIMEOUT_S",

--- a/nikita/onboarding/adapters.py
+++ b/nikita/onboarding/adapters.py
@@ -52,11 +52,11 @@ class BackstoryPromptProfile:
     social_scene: str | None
     life_stage: str | None
     primary_passion: str | None  # mapped from profile.interest
-    # darkness_level on the Pydantic model is `int | None`. Mirror that here
-    # so the dataclass annotation matches what ``from_pydantic`` actually
-    # assigns when upstream sends an incomplete profile (e.g., during a
-    # preview call from Spec 214 before darkness is collected).
-    drug_tolerance: int | None
+    # Spec FR-3.1 declares this non-nullable (`drug_tolerance: int`). The
+    # ``BackstoryGeneratorService`` reads the field without a None-guard, so
+    # upstream callers must ensure a concrete value. ``from_pydantic`` enforces
+    # this with an ``or 3`` guard on missing/None inputs.
+    drug_tolerance: int
     name: str | None
     age: int | None
     occupation: str | None
@@ -103,9 +103,13 @@ class ProfileFromOnboardingProfile:
             social_scene=getattr(profile, "social_scene", None),
             life_stage=getattr(profile, "life_stage", None),
             primary_passion=getattr(profile, "interest", None),  # name-collision
-            # Pass darkness through as-is (may be None on partial profiles).
-            # Dataclass annotation `int | None` keeps the type honest.
-            drug_tolerance=getattr(profile, "darkness_level", None),
+            # Spec FR-3.1 requires drug_tolerance to be a concrete int. The
+            # Pydantic UserOnboardingProfile validates darkness_level as
+            # non-null with default=3, so ``darkness_level`` is always int
+            # in production. The ``or 3`` guard covers duck-typed test stubs
+            # (SimpleNamespace) that omit the attribute or explicitly pass
+            # None, keeping the dataclass type annotation honest.
+            drug_tolerance=getattr(profile, "darkness_level", None) or 3,
             name=getattr(profile, "name", None),  # net-new in PR 213-2
             age=getattr(profile, "age", None),
             occupation=getattr(profile, "occupation", None),

--- a/nikita/onboarding/adapters.py
+++ b/nikita/onboarding/adapters.py
@@ -84,8 +84,11 @@ class ProfileFromOnboardingProfile:
             in the signature for future observability (e.g., per-user prompt
             trace IDs).
           profile: A `UserOnboardingProfile` Pydantic model (typed loosely as
-            `object` to allow duck-typed substitutes in tests and to avoid an
-            import cycle with the Pydantic module).
+            `object` because the method accesses fields via ``getattr`` — duck
+            typing. Test suites pass ``SimpleNamespace`` stand-ins; production
+            passes real Pydantic instances. Typing as `object` keeps that
+            flexibility explicit and avoids a hard import of the Pydantic class
+            from this adapter module).
 
         Returns:
           A `BackstoryPromptProfile` dataclass ready to pass to

--- a/nikita/onboarding/adapters.py
+++ b/nikita/onboarding/adapters.py
@@ -52,7 +52,11 @@ class BackstoryPromptProfile:
     social_scene: str | None
     life_stage: str | None
     primary_passion: str | None  # mapped from profile.interest
-    drug_tolerance: int
+    # darkness_level on the Pydantic model is `int | None`. Mirror that here
+    # so the dataclass annotation matches what ``from_pydantic`` actually
+    # assigns when upstream sends an incomplete profile (e.g., during a
+    # preview call from Spec 214 before darkness is collected).
+    drug_tolerance: int | None
     name: str | None
     age: int | None
     occupation: str | None
@@ -99,7 +103,9 @@ class ProfileFromOnboardingProfile:
             social_scene=getattr(profile, "social_scene", None),
             life_stage=getattr(profile, "life_stage", None),
             primary_passion=getattr(profile, "interest", None),  # name-collision
-            drug_tolerance=getattr(profile, "darkness_level", 3),
+            # Pass darkness through as-is (may be None on partial profiles).
+            # Dataclass annotation `int | None` keeps the type honest.
+            drug_tolerance=getattr(profile, "darkness_level", None),
             name=getattr(profile, "name", None),  # net-new in PR 213-2
             age=getattr(profile, "age", None),
             occupation=getattr(profile, "occupation", None),

--- a/nikita/onboarding/adapters.py
+++ b/nikita/onboarding/adapters.py
@@ -1,0 +1,103 @@
+"""Pydantic↔ORM adapters for Spec 213 onboarding backend (FR-3.1).
+
+Promoted from the Telegram-specific `_ProfileFromAnswers` at
+`nikita/platforms/telegram/onboarding/handler.py:41-56` to a shared module.
+Used by BOTH the Telegram onboarding path AND the portal facade
+(`nikita/services/portal_onboarding.py`) to bridge the Pydantic-validated
+`UserOnboardingProfile` onto the duck-typed shape that
+`BackstoryGeneratorService.generate_scenarios` expects.
+
+CRITICAL — DUCK TYPING (load-bearing per Architecture validator iter-3):
+  `BackstoryGeneratorService._build_scenario_prompt` at
+  `nikita/services/backstory_generator.py:{180,183,220}` accesses:
+    - `profile.city`            (NOT `profile.location_city`)
+    - `profile.primary_passion` (NOT `profile.primary_interest`)
+    - `profile.drug_tolerance`  (NOT `profile.darkness_level`)
+
+  These attribute names do NOT match the `UserProfile` ORM column names.
+  The adapter therefore returns a lightweight dataclass, NOT a real ORM row.
+
+  Constructing a real `UserProfile` would fail because the ORM columns
+  (`location_city`, `primary_interest`) do not match the generator's reads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass
+class BackstoryPromptProfile:
+    """Duck-typed adapter matching attribute names BackstoryGeneratorService reads.
+
+    NOT a real UserProfile ORM object. Required attributes:
+      city, social_scene, life_stage, primary_passion, drug_tolerance, name,
+      age, occupation.
+
+    Field-mapping table (canonical per spec FR-3.1):
+      UserOnboardingProfile (Pydantic)  →  BackstoryPromptProfile (duck-typed)
+      -------------------------------------  -----------------------------------
+      city                                   city
+      social_scene                           social_scene
+      life_stage                             life_stage
+      interest                               primary_passion   (name collision)
+      darkness_level                         drug_tolerance    (legacy name)
+      name                                   name
+      age                                    age
+      occupation                             occupation
+    """
+
+    city: str | None
+    social_scene: str | None
+    life_stage: str | None
+    primary_passion: str | None  # mapped from profile.interest
+    drug_tolerance: int
+    name: str | None
+    age: int | None
+    occupation: str | None
+
+
+class ProfileFromOnboardingProfile:
+    """Bridges `UserOnboardingProfile` (Pydantic) → duck-typed `BackstoryPromptProfile`.
+
+    The `BackstoryGeneratorService.generate_scenarios(profile, venues)` signature
+    accepts any object with the required attributes (duck typing). DO NOT try to
+    construct a real `UserProfile` — its columns do not match the reads.
+
+    Both Telegram (`handler.py`) and portal (`portal_onboarding.py`) paths
+    import from THIS module. Keeping a single adapter prevents the two paths
+    from drifting into two unsynchronized implementations.
+    """
+
+    @staticmethod
+    def from_pydantic(user_id: UUID, profile: object) -> BackstoryPromptProfile:
+        """Convert a `UserOnboardingProfile`-shaped object into a prompt-ready dataclass.
+
+        Uses ``getattr(profile, attr, None)`` for optional/net-new fields so the
+        adapter stays forward-compatible with Pydantic models that do not yet
+        carry every attribute (e.g., ``name`` is introduced in PR 213-2, while
+        this adapter ships in PR 213-1).
+
+        Args:
+          user_id: User UUID. Not currently used by the generator but retained
+            in the signature for future observability (e.g., per-user prompt
+            trace IDs).
+          profile: A `UserOnboardingProfile` Pydantic model (typed loosely as
+            `object` to allow duck-typed substitutes in tests and to avoid an
+            import cycle with the Pydantic module).
+
+        Returns:
+          A `BackstoryPromptProfile` dataclass ready to pass to
+          `BackstoryGeneratorService.generate_scenarios`.
+        """
+        return BackstoryPromptProfile(
+            city=getattr(profile, "city", None),
+            social_scene=getattr(profile, "social_scene", None),
+            life_stage=getattr(profile, "life_stage", None),
+            primary_passion=getattr(profile, "interest", None),  # name-collision
+            drug_tolerance=getattr(profile, "darkness_level", 3),
+            name=getattr(profile, "name", None),  # net-new in PR 213-2
+            age=getattr(profile, "age", None),
+            occupation=getattr(profile, "occupation", None),
+        )

--- a/nikita/onboarding/adapters.py
+++ b/nikita/onboarding/adapters.py
@@ -98,18 +98,21 @@ class ProfileFromOnboardingProfile:
           A `BackstoryPromptProfile` dataclass ready to pass to
           `BackstoryGeneratorService.generate_scenarios`.
         """
+        # Spec FR-3.1 requires drug_tolerance to be a concrete int. The
+        # Pydantic UserOnboardingProfile validates darkness_level as
+        # non-null with default=3, so ``darkness_level`` is always int
+        # in production. The None-coalesce below covers duck-typed test
+        # stubs (SimpleNamespace) that omit the attribute or explicitly
+        # pass None. Use explicit ``is None`` check (NOT ``or``) so a
+        # legitimate ``darkness_level=0`` is preserved rather than
+        # silently coerced to 3 (falsy-zero footgun).
+        darkness = getattr(profile, "darkness_level", None)
         return BackstoryPromptProfile(
             city=getattr(profile, "city", None),
             social_scene=getattr(profile, "social_scene", None),
             life_stage=getattr(profile, "life_stage", None),
             primary_passion=getattr(profile, "interest", None),  # name-collision
-            # Spec FR-3.1 requires drug_tolerance to be a concrete int. The
-            # Pydantic UserOnboardingProfile validates darkness_level as
-            # non-null with default=3, so ``darkness_level`` is always int
-            # in production. The ``or 3`` guard covers duck-typed test stubs
-            # (SimpleNamespace) that omit the attribute or explicitly pass
-            # None, keeping the dataclass type annotation honest.
-            drug_tolerance=getattr(profile, "darkness_level", None) or 3,
+            drug_tolerance=darkness if darkness is not None else 3,
             name=getattr(profile, "name", None),  # net-new in PR 213-2
             age=getattr(profile, "age", None),
             occupation=getattr(profile, "occupation", None),

--- a/nikita/onboarding/contracts.py
+++ b/nikita/onboarding/contracts.py
@@ -1,0 +1,170 @@
+"""Contract types for Spec 213 onboarding backend (PR 213-1).
+
+Standalone Pydantic request/response types for the portal onboarding v2 API.
+
+CONSTRAINT: This module MUST NOT import from nikita.onboarding.models,
+nikita.db.*, or nikita.engine.constants. It is a frozen contract surface
+shared with Spec 214 (portal wizard). Any field addition requires an ADR.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Shared type aliases
+# ---------------------------------------------------------------------------
+
+PipelineReadyState = Literal["pending", "ready", "degraded", "failed"]
+"""Pipeline readiness state (string Literal for JSON serialization simplicity).
+
+Intentionally NOT an enum so serialization is trivial and consumers can
+do simple string comparison without importing enum members.
+"""
+
+
+# ---------------------------------------------------------------------------
+# BackstoryOption
+# ---------------------------------------------------------------------------
+
+
+class BackstoryOption(BaseModel):
+    """One backstory scenario offered to the user.
+
+    Mirrors BackstoryScenario dataclass at nikita/services/backstory_generator.py:29.
+    id is deterministic: sha256(cache_key:index)[:12] — stable across cache hits.
+    """
+
+    id: str = Field(description="Opaque ID, stable per (cache_key, index)")
+    venue: str = Field(description="Where the meeting happened")
+    context: str = Field(description="Setting / vibe in 2-3 sentences")
+    the_moment: str = Field(description="The catalyst moment")
+    unresolved_hook: str = Field(description="One-liner Nikita can reference in first message")
+    tone: Literal["romantic", "intellectual", "chaotic"] = Field(
+        description="Emotional tone of the backstory scenario"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OnboardingV2ProfileRequest / Response
+# ---------------------------------------------------------------------------
+
+
+class OnboardingV2ProfileRequest(BaseModel):
+    """Portal onboarding profile submission (v2).
+
+    Extends current PortalProfileRequest with name/age/occupation/wizard_step.
+    Maps to UserOnboardingProfile via handoff.py facade.
+    """
+
+    location_city: str = Field(min_length=2, max_length=100)
+    social_scene: Literal["techno", "art", "food", "cocktails", "nature"]
+    drug_tolerance: int = Field(ge=1, le=5)
+    life_stage: Literal["tech", "finance", "creative", "student", "entrepreneur", "other"] | None = None
+    interest: str | None = Field(default=None, max_length=200)
+    phone: str | None = Field(default=None, min_length=8, max_length=20)
+    name: str | None = Field(default=None, min_length=1, max_length=100)
+    age: int | None = Field(default=None, ge=18, le=99)
+    occupation: str | None = Field(default=None, min_length=1, max_length=100)
+    wizard_step: int | None = Field(
+        default=None,
+        ge=1,
+        le=11,
+        description="Last completed wizard step for resume detection",
+    )
+
+
+class OnboardingV2ProfileResponse(BaseModel):
+    """Response from POST /onboarding/profile.
+
+    Note: chosen_option is ALWAYS None from Spec 213 endpoints.
+    Spec 214 owns the backstory-selection endpoint that populates it.
+    """
+
+    user_id: UUID
+    pipeline_state: PipelineReadyState
+    backstory_options: list[BackstoryOption]
+    chosen_option: BackstoryOption | None = None
+    poll_endpoint: str = Field(description="Absolute path to /pipeline-ready/{user_id}")
+    poll_interval_seconds: float = Field(description="Polling interval in seconds")
+    poll_max_wait_seconds: float = Field(description="Max portal wait for pipeline readiness")
+
+
+# ---------------------------------------------------------------------------
+# PipelineReadyResponse (FR-2 + FR-2a extension)
+# ---------------------------------------------------------------------------
+
+
+class PipelineReadyResponse(BaseModel):
+    """Response from GET /pipeline-ready/{user_id}.
+
+    FR-2a fields (venue_research_status, backstory_available) default to
+    conservative values when JSONB keys are absent — keeps the read path
+    as a single-SELECT NFR-1 path (p99 ≤200ms).
+    """
+
+    state: PipelineReadyState
+    message: str | None = None
+    """Optional user-facing explanation, present on degraded/failed states."""
+    checked_at: datetime
+    """ISO-8601 timestamp of the check, for monitoring/debugging."""
+
+    # FR-2a: pipeline sub-state fields (default to safe values when JSONB key absent)
+    venue_research_status: Literal["pending", "complete", "failed", "cache_hit"] = "pending"
+    """Venue research progress. Defaults to 'pending' if JSONB key missing."""
+    backstory_available: bool = False
+    """True once scenarios have been persisted to backstory_cache. Defaults False."""
+
+
+# ---------------------------------------------------------------------------
+# BackstoryPreviewRequest / Response (FR-4a)
+# ---------------------------------------------------------------------------
+
+
+class BackstoryPreviewRequest(BaseModel):
+    """Input to POST /onboarding/preview-backstory.
+
+    Called by portal wizard at Step 8 (dossier reveal) BEFORE final profile submit.
+    darkness_level here matches UserOnboardingProfile.darkness_level.
+    OnboardingV2ProfileRequest uses drug_tolerance for legacy-ORM compat;
+    backend maps drug_tolerance → darkness_level when recomputing cache_key.
+    """
+
+    city: str = Field(min_length=2, max_length=100)
+    social_scene: Literal["techno", "art", "food", "cocktails", "nature"]
+    darkness_level: int = Field(ge=1, le=5)
+    life_stage: Literal["tech", "finance", "creative", "student", "entrepreneur", "other"] | None = None
+    interest: str | None = Field(default=None, max_length=200)
+    age: int | None = Field(default=None, ge=18, le=99)
+    occupation: str | None = Field(default=None, max_length=100)
+
+
+class BackstoryPreviewResponse(BaseModel):
+    """Response from POST /onboarding/preview-backstory.
+
+    scenarios is empty on degraded path (service timeout or error).
+    cache_key is informational only — backend recomputes on final submit.
+    """
+
+    scenarios: list[BackstoryOption]
+    venues_used: list[str]
+    """Venue names incorporated into scenarios (for wizard UI)."""
+    cache_key: str
+    """Opaque cache key for debugging/observability (NOT echoed back on submit)."""
+    degraded: bool
+    """True if backstory service failed; scenarios will be empty or generic."""
+
+
+# ---------------------------------------------------------------------------
+# ErrorResponse
+# ---------------------------------------------------------------------------
+
+
+class ErrorResponse(BaseModel):
+    """Error response matching existing FastAPI shape at onboarding.py:140."""
+
+    detail: str

--- a/nikita/onboarding/contracts.py
+++ b/nikita/onboarding/contracts.py
@@ -140,7 +140,9 @@ class BackstoryPreviewRequest(BaseModel):
     life_stage: Literal["tech", "finance", "creative", "student", "entrepreneur", "other"] | None = None
     interest: str | None = Field(default=None, max_length=200)
     age: int | None = Field(default=None, ge=18, le=99)
-    occupation: str | None = Field(default=None, max_length=100)
+    # min_length=1 mirrors OnboardingV2ProfileRequest.occupation for consistent
+    # contract surface — empty strings are rejected at both entry points.
+    occupation: str | None = Field(default=None, min_length=1, max_length=100)
 
 
 class BackstoryPreviewResponse(BaseModel):

--- a/nikita/onboarding/contracts.py
+++ b/nikita/onboarding/contracts.py
@@ -140,9 +140,15 @@ class BackstoryPreviewRequest(BaseModel):
     life_stage: Literal["tech", "finance", "creative", "student", "entrepreneur", "other"] | None = None
     interest: str | None = Field(default=None, max_length=200)
     age: int | None = Field(default=None, ge=18, le=99)
-    # min_length=1 mirrors OnboardingV2ProfileRequest.occupation for consistent
-    # contract surface — empty strings are rejected at both entry points.
-    occupation: str | None = Field(default=None, min_length=1, max_length=100)
+    # SPEC-INTENTIONAL ASYMMETRY: the preview endpoint (this schema) is
+    # deliberately LOOSER than OnboardingV2ProfileRequest (which requires
+    # min_length=1). Spec 213 §FR-4a L167 declares only ``max_length=100``
+    # here. Rationale: the preview path is exploratory — an empty-string
+    # occupation buckets to ``"other"`` in compute_backstory_cache_key and
+    # produces a usable preview; only the final POST /profile needs the
+    # stricter constraint. Any change to add min_length requires a spec
+    # update and ADR before modifying this line.
+    occupation: str | None = Field(default=None, max_length=100)
 
 
 class BackstoryPreviewResponse(BaseModel):

--- a/nikita/onboarding/tuning.py
+++ b/nikita/onboarding/tuning.py
@@ -53,7 +53,12 @@ PIPELINE_GATE_MAX_WAIT_S: Final[float] = 20.0
 """Maximum portal wait for pipeline readiness before unblocking.
 
 Prior values: none (new in Spec 213, GH #213).
-Rationale: covers Cloud Run cold-start (5s) + venue research (15s) + safety margin.
+Rationale: VenueResearch (15s) and BackstoryGenerator (20s) run in parallel
+fanout, so the dominant bound is BACKSTORY_GEN_TIMEOUT_S (20s). Cloud Run
+cold-start (~5s) is absorbed by the parallel fanout. If either service
+exceeds 20s, the portal unblocks with 'degraded' state per FR-2a and the
+backend continues its pipeline independently. Invariant guarded by tests
+in test_tuning_constants.py::TestTimeoutRelationalInvariants.
 """
 
 # ---------------------------------------------------------------------------

--- a/nikita/onboarding/tuning.py
+++ b/nikita/onboarding/tuning.py
@@ -181,7 +181,10 @@ def compute_backstory_cache_key(profile: object) -> str:
     """
     city = (getattr(profile, "city", None) or "unknown").lower()
     scene = getattr(profile, "social_scene", None) or "unknown"
-    darkness = str(getattr(profile, "darkness_level", 3))
+    # None darkness → "unknown" (matches docstring promise and keeps the key
+    # from ever containing the literal string "None").
+    darkness_raw = getattr(profile, "darkness_level", None)
+    darkness = str(darkness_raw) if darkness_raw is not None else "unknown"
     life_stage = getattr(profile, "life_stage", None) or "unknown"
     interest = (getattr(profile, "interest", None) or "unknown").lower()
     age_bkt = _age_bucket(getattr(profile, "age", None))

--- a/nikita/onboarding/tuning.py
+++ b/nikita/onboarding/tuning.py
@@ -1,0 +1,184 @@
+"""Tuning constants for Spec 213 onboarding backend (FR-4).
+
+Domain-specific timeouts, cache TTLs, rate limits, and bucket mappings for
+the portal onboarding handoff path.
+
+CONSTRAINT (FR-4 isolation): This module MUST NOT import from
+nikita.engine.constants. Onboarding is a distinct domain from the scoring engine
+and pipeline stages; sharing constants would couple unrelated concerns.
+
+Per .claude/rules/tuning-constants.md, every constant has:
+  - Current value
+  - Prior values with driving PR/GH issue
+  - One-line rationale for *this* value
+
+Regression guards in tests/onboarding/test_tuning_constants.py.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from nikita.onboarding.models import UserOnboardingProfile
+
+# ---------------------------------------------------------------------------
+# Service call timeouts
+# ---------------------------------------------------------------------------
+
+VENUE_RESEARCH_TIMEOUT_S: Final[float] = 15.0
+"""Per-call timeout for VenueResearchService.research_venues.
+
+Prior values: none (new in Spec 213, GH #213).
+Rationale: Firecrawl typical p95 ~8s; 15s budget covers cold cache + 1 retry.
+"""
+
+BACKSTORY_GEN_TIMEOUT_S: Final[float] = 20.0
+"""Per-call timeout for BackstoryGeneratorService.generate_scenarios.
+
+Prior values: none (new in Spec 213, GH #213).
+Rationale: Claude Haiku typical p95 ~12s; 20s covers tail latency + 1 retry.
+"""
+
+# ---------------------------------------------------------------------------
+# Pipeline-ready gate
+# ---------------------------------------------------------------------------
+
+PIPELINE_GATE_POLL_INTERVAL_S: Final[float] = 2.0
+"""Portal poll interval for /pipeline-ready endpoint.
+
+Prior values: none (new in Spec 213, GH #213).
+Rationale: balances perceived responsiveness vs Cloud Run cold-start churn.
+"""
+
+PIPELINE_GATE_MAX_WAIT_S: Final[float] = 20.0
+"""Maximum portal wait for pipeline readiness before unblocking.
+
+Prior values: none (new in Spec 213, GH #213).
+Rationale: covers Cloud Run cold-start (5s) + venue research (15s) + safety margin.
+"""
+
+# ---------------------------------------------------------------------------
+# Cache + generation tuning
+# ---------------------------------------------------------------------------
+
+BACKSTORY_CACHE_TTL_DAYS: Final[int] = 30
+"""Backstory cache TTL for unique (city, scene, ...) profile shape.
+
+Prior values: none (new in Spec 213, GH #213).
+Rationale: matches existing VenueCache TTL; balances cost vs scenario freshness.
+"""
+
+BACKSTORY_HOOK_PROBABILITY: Final[float] = 0.50
+"""Probability that FirstMessageGenerator includes a backstory hook in the first message.
+
+Prior values: none (new in Spec 213, GH #213).
+Rationale: 50% creates variety; testable via patched value (1.0 always-include, 0.0 never-include).
+"""
+
+# ---------------------------------------------------------------------------
+# Rate limits
+# ---------------------------------------------------------------------------
+
+PREVIEW_RATE_LIMIT_PER_MIN: Final[int] = 5
+"""Per-user rate limit for POST /onboarding/preview-backstory (FR-4a.1).
+
+Prior values: none (new in Spec 213, iter-7 amendment).
+Rationale: each call triggers Claude + Firecrawl; 5/min covers wizard navigation and
+legitimate retries but prevents abuse/DoS. Voice rate limit is 20/min — different surface
+with different cost profile. Separate counter key prefix 'preview:' avoids sharing quota
+with the voice rate limiter.
+"""
+
+# ---------------------------------------------------------------------------
+# Cache-key bucketing
+# ---------------------------------------------------------------------------
+
+AGE_BUCKETS: Final[tuple[tuple[int, int, str], ...]] = (
+    (18, 24, "young_adult"),
+    (25, 34, "twenties"),
+    (35, 49, "midlife"),
+    (50, 99, "experienced"),
+)
+"""Age bucketing for backstory cache key. Inclusive boundaries.
+
+Prior values: none (new in Spec 213).
+Rationale: 4 buckets balance cache hit ratio vs personalization granularity.
+"""
+
+OCCUPATION_CATEGORIES: Final[dict[str, str]] = {
+    # mapping: lowercase substring → coarse category for cache key
+    "engineer": "tech",
+    "developer": "tech",
+    "designer": "tech",
+    "artist": "arts",
+    "musician": "arts",
+    "writer": "arts",
+    "banker": "finance",
+    "trader": "finance",
+    "analyst": "finance",
+    "nurse": "healthcare",
+    "doctor": "healthcare",
+    "student": "student",
+    "barista": "service",
+    "server": "service",
+    "retail": "service",
+}
+"""Coarse occupation categorization for backstory cache key.
+
+Original full string preserved in profile.occupation; this is for cache bucketing only.
+Prior values: none (new in Spec 213).
+Rationale: 6 categories balance cache hit ratio vs persona variety. Default: 'other'.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Bucket helpers (module-private per spec FR-3 step 3)
+# ---------------------------------------------------------------------------
+
+
+def _age_bucket(age: int | None) -> str:
+    """Map age to bucket label per AGE_BUCKETS. Returns 'unknown' if None."""
+    if age is None:
+        return "unknown"
+    for low, high, label in AGE_BUCKETS:
+        if low <= age <= high:
+            return label
+    return "unknown"  # outside any bucket
+
+
+def _occupation_bucket(occupation: str | None) -> str:
+    """Map occupation string to coarse category per OCCUPATION_CATEGORIES.
+
+    Substring match (lowercased). Returns 'other' if no match, 'unknown' if None.
+    """
+    if occupation is None:
+        return "unknown"
+    occ_lower = occupation.lower()
+    for substring, category in OCCUPATION_CATEGORIES.items():
+        if substring in occ_lower:
+            return category
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Cache-key computation (public — used by facade + preview endpoint)
+# ---------------------------------------------------------------------------
+
+
+def compute_backstory_cache_key(profile: UserOnboardingProfile) -> str:
+    """Deterministic cache key for backstory generation.
+
+    Format: 'city|scene|darkness|life_stage|interest|age_bucket|occupation_bucket'
+    with 'unknown' substituted for None values. City normalized to lowercase.
+
+    This function is canonical. Both the facade (FR-3) and the preview endpoint
+    (FR-4a) compute the same key for the same profile; cache coherence depends on it.
+    """
+    city = (profile.city or "unknown").lower()
+    scene = profile.social_scene or "unknown"
+    darkness = str(profile.darkness_level)
+    life_stage = profile.life_stage or "unknown"
+    interest = (profile.interest or "unknown").lower()
+    age_bkt = _age_bucket(profile.age)
+    occ_bkt = _occupation_bucket(profile.occupation)
+    return f"{city}|{scene}|{darkness}|{life_stage}|{interest}|{age_bkt}|{occ_bkt}"

--- a/nikita/onboarding/tuning.py
+++ b/nikita/onboarding/tuning.py
@@ -136,7 +136,17 @@ Rationale: 6 categories balance cache hit ratio vs persona variety. Default: 'ot
 
 
 def _age_bucket(age: int | None) -> str:
-    """Map age to bucket label per AGE_BUCKETS. Returns 'unknown' if None."""
+    """Map age to bucket label per AGE_BUCKETS.
+
+    Returns 'unknown' for ``None`` input and for any age outside the
+    AGE_BUCKETS range (18–99 inclusive).
+
+    Invariant: in the production path, ``age`` is validated upstream by
+    ``OnboardingV2ProfileRequest`` / ``BackstoryPreviewRequest`` (both
+    constrain ``Field(ge=18, le=99)``), so out-of-range inputs only occur
+    via duck-typed test stubs. Tests verify both below-range (17) and
+    above-range (100) both bucket to 'unknown'.
+    """
     if age is None:
         return "unknown"
     for low, high, label in AGE_BUCKETS:

--- a/nikita/onboarding/tuning.py
+++ b/nikita/onboarding/tuning.py
@@ -4,8 +4,9 @@ Domain-specific timeouts, cache TTLs, rate limits, and bucket mappings for
 the portal onboarding handoff path.
 
 CONSTRAINT (FR-4 isolation): This module MUST NOT import from
-nikita.engine.constants. Onboarding is a distinct domain from the scoring engine
-and pipeline stages; sharing constants would couple unrelated concerns.
+nikita.engine.constants, nikita.onboarding.models, or nikita.db.*. It is a
+pure constants + pure-function module. `compute_backstory_cache_key` is
+duck-typed — any object exposing the right attributes works at runtime.
 
 Per .claude/rules/tuning-constants.md, every constant has:
   - Current value
@@ -18,8 +19,6 @@ Regression guards in tests/onboarding/test_tuning_constants.py.
 from __future__ import annotations
 
 from typing import Final
-
-from nikita.onboarding.models import UserOnboardingProfile
 
 # ---------------------------------------------------------------------------
 # Service call timeouts
@@ -165,20 +164,26 @@ def _occupation_bucket(occupation: str | None) -> str:
 # ---------------------------------------------------------------------------
 
 
-def compute_backstory_cache_key(profile: UserOnboardingProfile) -> str:
+def compute_backstory_cache_key(profile: object) -> str:
     """Deterministic cache key for backstory generation.
 
     Format: 'city|scene|darkness|life_stage|interest|age_bucket|occupation_bucket'
     with 'unknown' substituted for None values. City normalized to lowercase.
 
-    This function is canonical. Both the facade (FR-3) and the preview endpoint
-    (FR-4a) compute the same key for the same profile; cache coherence depends on it.
+    ``profile`` is duck-typed: any object exposing ``city``, ``social_scene``,
+    ``darkness_level``, ``life_stage``, ``interest``, ``age``, ``occupation``
+    satisfies the contract. This keeps ``tuning.py`` import-free and lets the
+    function be reused by the facade (FR-3), the preview endpoint (FR-4a),
+    and tests without a Pydantic dependency.
+
+    Both call sites (facade + preview endpoint) compute the same key for the
+    same logical profile; cache coherence depends on it.
     """
-    city = (profile.city or "unknown").lower()
-    scene = profile.social_scene or "unknown"
-    darkness = str(profile.darkness_level)
-    life_stage = profile.life_stage or "unknown"
-    interest = (profile.interest or "unknown").lower()
-    age_bkt = _age_bucket(profile.age)
-    occ_bkt = _occupation_bucket(profile.occupation)
+    city = (getattr(profile, "city", None) or "unknown").lower()
+    scene = getattr(profile, "social_scene", None) or "unknown"
+    darkness = str(getattr(profile, "darkness_level", 3))
+    life_stage = getattr(profile, "life_stage", None) or "unknown"
+    interest = (getattr(profile, "interest", None) or "unknown").lower()
+    age_bkt = _age_bucket(getattr(profile, "age", None))
+    occ_bkt = _occupation_bucket(getattr(profile, "occupation", None))
     return f"{city}|{scene}|{darkness}|{life_stage}|{interest}|{age_bkt}|{occ_bkt}"

--- a/specs/213-onboarding-backend-foundation/audit-report.md
+++ b/specs/213-onboarding-backend-foundation/audit-report.md
@@ -1,0 +1,170 @@
+# Audit Report: 213-onboarding-backend-foundation
+
+**Result**: ✅ **PASS**
+**Timestamp**: 2026-04-14T19:50Z
+**Auditor**: SDD Phase 7 orchestrator (main context)
+
+---
+
+## Artifact Inventory
+
+| Artifact | Exists | Lines | Last Modified |
+|---|---|---|---|
+| `specs/213-onboarding-backend-foundation/spec.md` | ✓ | 1058 | 2026-04-14 |
+| `specs/213-onboarding-backend-foundation/plan.md` | ✓ | 292 | 2026-04-14 |
+| `specs/213-onboarding-backend-foundation/tasks.md` | ✓ | 513 | 2026-04-14 |
+| `specs/213-onboarding-backend-foundation/validation-findings.md` | ✓ | 67 | 2026-04-14 |
+| `specs/213-onboarding-backend-foundation/validation-reports/*.md` | ✓ | 6 files | 2026-04-14 |
+
+---
+
+## Constitution Compliance
+
+| Article | Requirement | Status | Evidence |
+|---|---|---|---|
+| I Intelligence-First | project-intel + 6 validators ran before planning | ✓ PASS | 10 validation iterations documented |
+| II Evidence-Based | CoD^Sigma traces per finding | ✓ PASS | validation-reports/* enumerate file:line refs |
+| III Test-First | ≥2 ACs per user story | ✓ PASS | All 7 USs have ≥4 ACs (30 ACs total) |
+| IV Spec-First | spec → plan → code sequence | ✓ PASS | No impl code yet; spec→plan→tasks chain intact |
+| V Template-Driven | Standard SDD templates used | ✓ PASS | plan.md + tasks.md follow Phase 5/6 templates |
+| VI Simplicity | ≤3 projects, ≤2 abstraction layers | ✓ PASS | 1 project (nikita/), ORM + repo + facade = 3 layers (no cycles) |
+| VII User-Story-Centric | Tasks organized P1→P2→P3 | ✓ PASS | US-1..5 (P1) before US-6,7 (P2) |
+| VIII Parallelization | [P] markers present | ✓ PASS | 7 parallelization groups marked |
+| IX TDD Discipline | RED-GREEN-REFACTOR per task | ✓ PASS | All 51 impl tasks have TDD steps (R→V1→G→V2→B→C1→C2) |
+| X Git Workflow | Two commits per story | ✓ PASS | TG-1..7 per US; every task has C1 (test) + C2 (impl) commits |
+| XI Doc-Sync | 0 CRITICAL before PR | ✓ PASS | TD-1 finalization task with absolute-zero enforcement |
+
+**Overall**: 11/11 articles PASS
+
+---
+
+## Functional Requirement Traceability
+
+| FR | In Spec | Tasks Covering | Coverage |
+|---|---|---|---|
+| FR-1 (Profile expansion: name+age+occupation) | L56 | T1.5, T1.6 | 100% |
+| FR-2 (Contract module) | L97 | T1.1, T1.2 | 100% |
+| FR-2a (PipelineReadyResponse extension) | L189 | T2.1, T2.5 | 100% |
+| FR-3 (Portal Onboarding Facade) | L301 | T3.1, T3.2, T1.4 | 100% |
+| FR-3.1 (Pydantic↔ORM Adapter) | L398 | T1.4 | 100% |
+| FR-3.2 (Scenario-to-Option converter) | L368 | T1.2 + T3.1 impl | 100% |
+| FR-4 (Tuning constants) | L461 | T1.3 | 100% |
+| FR-4a (Backstory preview endpoint) | L206 | TX.1, TX.2, TX.3, TX.4 | 100% |
+| FR-4a.1 (Preview rate limiter) | L243 | TX.2 | 100% |
+| FR-5 (Pipeline-Readiness endpoint) | L530 | T2.2, T2.3, T2.4, T2.5 | 100% |
+| FR-5.1 (Pipeline state write contract) | L550 | T3.2, T3.4 | 100% |
+| FR-5.2 (UserRepository helper) | L563 | T3.2 + T6.1 | 100% |
+| FR-6 (Enhanced FirstMessageGenerator) | L591 | T5.1, T1.7, T3.3, T4.4 | 100% |
+| FR-7 (PII Handling + RLS Hardening) | L608 | TP.1, TP.2, TP.3 | 100% |
+| FR-8 (Conversation Continuity Regression / R8) | L627 | T5.2, T5.3, T5.4 | 100% |
+| FR-9 (Re-Onboarding Detection) | L638 | T6.1-T6.5 | 100% |
+| FR-10 (Voice-First User Routing) | L650 | T7.1, T7.2, T7.3 | 100% |
+| FR-11 (Pipeline Bootstrap Idempotence) | L654 | TB.1, TB.2 | 100% |
+| FR-12 (BackstoryCache Repository) | L671 | T1.5, T1.8, T1.9 | 100% (added T1.8, T1.9 during audit) |
+| FR-13 (Route File Decomposition) | L730 | T2.2 + T6.1 + T2.6 | 100% (added T2.6 during audit) |
+| FR-14 (Session-Scope Safety Pattern) | L759 | T3.1 + TB.3 | 100% (added TB.3 during audit) |
+
+**FR Coverage**: 21/21 = **100%**
+
+---
+
+## Acceptance Criteria Coverage
+
+| US | Spec ACs | Task ACs | Gap |
+|---|---|---|---|
+| US-1 (full profile) | 5 | T1.1-T1.7 map AC-1.1 thru AC-1.5 | 0 |
+| US-2 (pipeline gate) | 4 | T2.1-T2.5 map AC-2.1 thru AC-2.4 | 0 |
+| US-3 (venue timeout) | 4 | T3.1-T3.4 map AC-3.1 thru AC-3.4 | 0 |
+| US-4 (backstory fail) | 4 | T4.1-T4.4 map AC-4.1 thru AC-4.4 | 0 |
+| US-5 (R8 continuity) | 4 | T5.1-T5.4 map AC-5.1 thru AC-5.4 | 0 |
+| US-6 (re-onboarding) | 4 | T6.1-T6.5 map AC-6.1 thru AC-6.4 | 0 |
+| US-7 (voice-first) | 4 | T7.1-T7.3 + existing tests map AC-7.1 thru AC-7.4 | 0 |
+
+**AC Coverage**: 30/30 = **100%**
+
+---
+
+## Spec ↔ Plan ↔ Tasks Consistency
+
+### Spec → Plan
+- [x] All user stories have plan sections (7 USs mapped)
+- [x] All 30 ACs addressed in plan
+- [x] Plan does not introduce unspecified features
+- [x] Architecture diagrams align with spec §Type-Layer Disambiguation
+
+### Plan → Tasks
+- [x] All plan tasks (T1.1..TX.4) have corresponding tasks.md entries
+- [x] Task dependencies match plan sequence
+- [x] No orphan tasks — every task traces to ≥1 FR or AC
+- [x] Effort estimates reasonable: 0 XL tasks, 18 S / 9 M tasks
+
+### Spec → Tasks Traceability
+- [x] Every AC has ≥1 implementing task (30 ACs → 51 tasks)
+- [x] Every task links to ≥1 AC or FR
+- [x] P1 tasks scheduled before P2 (TG-1..5 before TG-6,7)
+- [x] Critical path: T0.1 → T0.2 → PR 213-1 (contracts) → PR 213-2 (migration) → PR 213-3 (facade) → PR 213-4 (routes) → PR 213-5 (first-msg + e2e)
+
+---
+
+## Completeness Checks
+
+| Check | Status | Notes |
+|---|---|---|
+| Task count matches plan | ✓ | 51 tasks cover plan's 36 items + 4 audit-added tasks |
+| US count matches spec | ✓ | 7/7 |
+| No XL estimates | ✓ | Largest is M (1-4hr) |
+| No `[NEEDS CLARIFICATION]` in spec | ✓ | 0 (2 grep matches are self-references) |
+| No `[TODO]` in plan | ✓ | 0 |
+| No `[TBD]` in tasks | ✓ | 0 |
+| Data model covers all entities | ✓ | spec §FR-1, FR-12 define ORM + JSONB schema |
+
+---
+
+## Dependency Validation
+
+- **Circular dependencies**: None (DAG verified in plan §PR DAG + tasks §Dependency Graph mermaid)
+- **Missing dependencies**: None — all `Deps:` fields reference existing tasks
+- **Orphan tasks**: None — all trace to spec FR/AC
+- **Cross-PR dependencies**: 213-1 → 213-2 → 213-3 → 213-4 → 213-5 (strict order); 213-1 also unblocks Spec 214 in parallel
+
+---
+
+## Findings Addressed During Audit
+
+Audit identified 4 coverage gaps (per user's absolute-zero policy, fixed inline):
+
+| ID | Severity | Finding | Resolution |
+|---|---|---|---|
+| A-L1 | LOW | FR-12 BackstoryCache ORM model not its own task | Added **T1.8** (PR 213-2) |
+| A-L2 | LOW | FR-12 BackstoryCacheRepository not explicit task | Added **T1.9** (PR 213-2) |
+| A-L3 | LOW | FR-13 main.py include_router registration not explicit | Added **T2.6** (PR 213-4) resolves architecture finding AR2-L1 |
+| A-L4 | LOW | FR-14 test_portal_onboarding_session_isolation not explicit | Added **TB.3** (PR 213-3) |
+
+**Residual findings**: 0 across all severities.
+
+---
+
+## Verdict
+
+- [x] All 11 constitutional articles pass
+- [x] 100% FR coverage (21/21)
+- [x] 100% AC coverage (30/30)
+- [x] 0 circular dependencies
+- [x] 0 clarification markers
+- [x] 0 CRITICAL blockers
+- [x] 0 HIGH findings
+- [x] 0 MEDIUM residuals (4 LOW gaps fixed inline)
+- [x] 0 LOW residuals
+- [x] TDD + Git workflow enforced per task
+- [x] Doc-sync task present (TD-1)
+
+**Result**: ✅ **PASS — GATE 3 cleared, ready for /implement 213**
+
+---
+
+## Handoff
+
+- Update `.sdd/sdd-state.md` with GATE 3 PASS
+- Update `.sdd/audit-trail.md` with audit decision
+- Generate `.sdd/next-steps.md` for Phase 8
+- **Next**: `/implement 213` via formal skill invocation (NOT raw subagent dispatch per SDD rule 10)

--- a/specs/213-onboarding-backend-foundation/plan.md
+++ b/specs/213-onboarding-backend-foundation/plan.md
@@ -1,0 +1,292 @@
+# Implementation Plan: Spec 213 — Onboarding Backend Foundation
+
+**Spec**: `specs/213-onboarding-backend-foundation/spec.md` (1058 lines, 14 FRs + 2 amendments, 7 USs, 30 ACs)
+**Status**: Ready for /tasks → /audit → /implement
+**GATE 2**: PASS (10 iterations, absolute zero across all 6 validators)
+**Brief**: `.claude/plans/onboarding-overhaul-brief.md`
+**Target**: 5 PRs, each ≤400 LOC, sequential dependency chain
+
+---
+
+## Overview
+
+### Objective
+Wire the full engagement pipeline (venue research + backstory generation + pipeline-readiness gate + conversation continuity) into the portal onboarding path. Collect richer profile (name, age, occupation). Ship a frozen `contracts.py` surface in PR #1 so Spec 214 (portal wizard) can work in parallel once that PR lands.
+
+### Non-Goals
+- Portal UI changes → Spec 214
+- Voice agent prompt structural changes beyond consuming new contracts
+- Multi-language backstory support
+- Retroactive migration of existing users' `name`/`age`/`occupation`
+
+---
+
+## Architecture
+
+### Module Dependency Graph (Post-Fix)
+
+```mermaid
+graph TD
+    Contracts[nikita/onboarding/contracts.py<br/>Frozen Pydantic surface] --> Tuning[nikita/onboarding/tuning.py<br/>Timeouts + buckets + cache_key]
+    Contracts --> Adapters[nikita/onboarding/adapters.py<br/>ProfileFromOnboardingProfile<br/>returns BackstoryPromptProfile]
+
+    Migration[migrations/YYYY_add_profile_fields_backstory_cache.sql<br/>+name +occupation +age<br/>+backstory_cache table + RLS] --> ORMUserProfile[nikita/db/models/profile.py<br/>Mapped name/occupation/age]
+    Migration --> ORMBackstoryCache[nikita/db/models/backstory_cache.py<br/>ORM model]
+
+    ORMBackstoryCache --> RepoBackstoryCache[nikita/db/repositories/backstory_cache_repository.py<br/>returns list of dict raw envelope]
+    ORMUserProfile --> RepoUser[nikita/db/repositories/user_repository.py<br/>+ update_onboarding_profile_key<br/>FR-5.2: jsonb_set + cast json.dumps]
+
+    Adapters --> Facade[nikita/services/portal_onboarding.py<br/>VenueResearch + Backstory + cache coherence]
+    Tuning --> Facade
+    RepoBackstoryCache --> Facade
+    VenueResearchService --> Facade
+    BackstoryGeneratorService --> Facade
+
+    Facade --> Handoff[nikita/onboarding/handoff.py<br/>_trigger_portal_handoff rewire<br/>FR-5.1 state writes + FR-11 idempotence]
+
+    Route[nikita/api/routes/portal_onboarding.py<br/>POST + PATCH + GET pipeline-ready<br/>POST preview-backstory] --> Facade
+    Route --> Contracts
+    Main[nikita/api/main.py<br/>include_router portal_onboarding] --> Route
+
+    Handoff --> FirstMsg[nikita/agents/text/handoff.py<br/>FirstMessageGenerator FR-6]
+    FirstMsg --> R8Test[tests/onboarding/test_r8_conversation_continuity.py<br/>N=10 denial-phrase regex]
+
+    VoiceWebhook[nikita/api/routes/voice.py<br/>pre_call_webhook] --> Contracts
+```
+
+### PR Dependency DAG
+
+```mermaid
+graph LR
+    PR1[PR 213-1<br/>contracts.py + tuning.py<br/>+ adapters.py + tests] --> PR2[PR 213-2<br/>Migration + ORM<br/>+ cache repo]
+    PR1 --> PR3
+    PR2 --> PR3[PR 213-3<br/>Facade + preview<br/>+ PII fixes + NFR-3 logs]
+    PR1 --> PR4
+    PR3 --> PR4[PR 213-4<br/>Route file + pipeline-ready<br/>+ PATCH + FR-14 session]
+    PR4 --> PR5[PR 213-5<br/>FirstMsg FR-6 + R8<br/>+ e2e + ROADMAP]
+
+    PR1 -.->|unblocks parallel| Spec214[Spec 214<br/>portal wizard<br/>consumes frozen contracts]
+```
+
+### Request Flow: POST /onboarding/profile (final submission)
+
+```mermaid
+sequenceDiagram
+    participant Portal as Portal (Spec 214)
+    participant Route as portal_onboarding.py route
+    participant Repo as UserRepository
+    participant Facade as portal_onboarding facade
+    participant VR as VenueResearchService
+    participant BG as BackstoryGenerator
+    participant Cache as BackstoryCacheRepository
+    participant Handoff as _trigger_portal_handoff
+    participant FM as FirstMessageGenerator
+    participant Bot as Telegram/Voice
+
+    Portal->>Route: POST profile (incl cache_key from preview)
+    Route->>Repo: persist user_profiles + JSONB (FR-5.2 jsonb_set cast json.dumps)
+    Route-->>Portal: 200 OnboardingV2ProfileResponse (FR-2)
+    Route->>Route: schedule _trigger_portal_handoff (BackgroundTask, FR-14 fresh session)
+    Handoff->>Facade: process(profile, session)
+    Facade->>Cache: get(cache_key) → hit? short-circuit
+    Facade->>VR: research_venues (timeout 15s)
+    VR-->>Facade: VenueResearchResult
+    Facade->>BG: generate_scenarios (timeout 20s, uses BackstoryPromptProfile duck-typed)
+    BG-->>Facade: list[BackstoryScenario]
+    Facade->>Cache: set(cache_key, {scenarios, venues_used}, 30d)
+    Facade-->>Handoff: scenarios + venues_used
+    Handoff->>Repo: update_onboarding_profile_key("pipeline_state", "ready")
+    Handoff->>FM: build_first_message(profile, scenarios)
+    FM-->>Handoff: first_message_text
+    Handoff->>Bot: send first message (Telegram or voice pre-call)
+```
+
+### Request Flow: POST /onboarding/preview-backstory (pre-submit reveal, FR-4a)
+
+```mermaid
+sequenceDiagram
+    participant Portal as Portal (step 8 "the file opens")
+    participant Route as portal_onboarding.py route
+    participant RL as _PreviewRateLimiter (5/min)
+    participant Facade as portal_onboarding facade (stateless)
+    participant Cache as BackstoryCacheRepository
+
+    Portal->>Route: POST preview-backstory (age, occupation, city, scene, life_stage, interest)
+    Route->>RL: check rate limit (preview:{minute_window})
+    RL-->>Route: 429 Retry-After:60 (if exceeded)
+    Route->>Facade: generate_preview(pseudo_profile)
+    Facade->>Cache: get(cache_key)
+    Cache-->>Facade: hit? return scenarios
+    Facade->>Facade: else VR + BG inline (same paths as final POST)
+    Facade->>Cache: set(cache_key, {scenarios, venues_used}, 30d)
+    Route-->>Portal: 200 BackstoryPreviewResponse (scenarios, venues_used, cache_key, degraded)
+```
+
+**Cache coherence invariant**: portal echoes `cache_key` on final POST → facade short-circuits → ZERO duplicate Claude calls. Envelope shape identical across both writers: `{"scenarios": [...], "venues_used": [venue_names]}`.
+
+---
+
+## Tasks by User Story
+
+### US-1 (P1): New user completes portal onboarding with full profile — 4 ACs
+Maps across all 5 PRs (infrastructure for the happy path).
+
+| ID | Task | Est. | PR | [P] | Deps |
+|----|------|------|----|----|------|
+| T1.1 | Define `OnboardingV2ProfileRequest` + `Response` in `contracts.py` with full validators | S | 213-1 | — | — |
+| T1.2 | Define `BackstoryOption` + `tone` Literal in `contracts.py` | S | 213-1 | [P] T1.1 | — |
+| T1.3 | Add `test_contracts.py` Pydantic validation tests (reject bad age/occupation/city) | S | 213-1 | — | T1.1, T1.2 |
+| T1.4 | Write migration `add_profile_fields_and_backstory_cache.sql` (+name +occupation +age on user_profiles, +backstory_cache table, RLS DDL) | M | 213-2 | — | — |
+| T1.5 | Add `Mapped` columns to `nikita/db/models/profile.py::UserProfile` | S | 213-2 | — | T1.4 |
+| T1.6 | Add `test_rls_user_profiles.py` integration test (5 RLS policies) | M | 213-2 | — | T1.4 |
+| T1.7 | AC-1.5 test scaffolding: `TestFirstMessageGeneratorWithBackstory::test_no_meta_opener` regex assertion | S | 213-5 | — | T5.1 |
+
+### US-2 (P1): Pipeline-readiness gate prevents premature interaction — 4 ACs
+
+| ID | Task | Est. | PR | [P] | Deps |
+|----|------|------|----|----|------|
+| T2.1 | `PipelineReadyResponse` + `PipelineReadyState` Literal in `contracts.py` (FR-2a) | S | 213-1 | [P] T1.1 | — |
+| T2.2 | `GET /pipeline-ready/{user_id}` route with 403 shape + venue/backstory status | M | 213-4 | — | T3.2, T2.1 |
+| T2.3 | `test_pipeline_ready_states` parametrized over 4 states | S | 213-4 | — | T2.2 |
+| T2.4 | `test_polling_terminates` ASGI-level (AC-2.2 side_effect sequence) | M | 213-4 | — | T2.2 |
+| T2.5 | `test_cross_user_403_with_correct_body` (AC-2.4) | S | 213-4 | — | T2.2 |
+
+### US-3 (P1): City research times out without breaking onboarding — 4 ACs
+
+| ID | Task | Est. | PR | [P] | Deps |
+|----|------|------|----|----|------|
+| T3.1 | Facade `process` with `asyncio.wait_for(VENUE_RESEARCH_TIMEOUT_S)` + degraded path | M | 213-3 | — | T1.1–T1.6 |
+| T3.2 | Pipeline state transitions in `_bootstrap_pipeline` (FR-5.1): pending → ready / degraded / failed | M | 213-3 | — | T3.1 |
+| T3.3 | `test_venue_timeout` (monotonic time assertion) + AC-3.2 caplog | M | 213-3 | [P] T3.2 | T3.1 |
+| T3.4 | `test_first_message_falls_back_to_scene_only` (AC-3.3) | S | 213-5 | — | T5.1 |
+
+### US-4 (P1): Backstory generation fails gracefully — 4 ACs
+
+| ID | Task | Est. | PR | [P] | Deps |
+|----|------|------|----|----|------|
+| T4.1 | Facade catches `BackstoryGeneratorService` exceptions → returns `[]` | S | 213-3 | — | T3.1 |
+| T4.2 | `test_backstory_failure_returns_empty` (AC-4.1 patch source module) | S | 213-3 | [P] T4.1 | T4.1 |
+| T4.3 | `test_backstory_failure_log_no_pii` (AC-4.3 caplog + PII audit) | S | 213-3 | [P] T4.1 | T4.1 |
+| T4.4 | `test_first_message_keeps_flavor_on_backstory_fail` (AC-4.2) | S | 213-5 | — | T5.1 |
+
+### US-5 (P1): User replies with first-message verbatim, Nikita acknowledges — 4 ACs
+
+| ID | Task | Est. | PR | [P] | Deps |
+|----|------|------|----|----|------|
+| T5.1 | FirstMessageGenerator FR-6 (uses profile + backstory scenarios) | M | 213-5 | — | T1.1, T3.2 |
+| T5.2 | `test_r8_conversation_continuity.py::test_loads_seeded_turn` (AC-5.1) | S | 213-5 | — | T5.1 |
+| T5.3 | `test_agent_receives_history` (AC-5.2) | S | 213-5 | [P] T5.2 | T5.1 |
+| T5.4 | `test_no_denial_phrases` N=10 parametrized (AC-5.3) | S | 213-5 | [P] T5.2 | T5.1 |
+
+### US-6 (P2): Re-onboarding user resumes from last step — 4 ACs
+
+| ID | Task | Est. | PR | [P] | Deps |
+|----|------|------|----|----|------|
+| T6.1 | `PATCH /onboarding/profile` route (FR-5.2 jsonb_set partial update) | M | 213-4 | — | T3.1 |
+| T6.2 | `test_patch_preserves_wizard_step` (AC-6.1 JSONB read after PATCH) | S | 213-4 | — | T6.1 |
+| T6.3 | `test_patch_merges_jsonb` (AC-6.2) | S | 213-4 | [P] T6.2 | T6.1 |
+| T6.4 | `test_patch_returns_null_for_unset_fields` (AC-6.3) | S | 213-4 | [P] T6.2 | T6.1 |
+| T6.5 | `test_cache_hit_skips_claude` (AC-6.4 cross-endpoint cache coherence) | M | 213-4 | — | T3.1, T6.1 |
+
+### US-7 (P2): Voice-first user routes correctly with full profile — 4 ACs
+
+| ID | Task | Est. | PR | [P] | Deps |
+|----|------|------|----|----|------|
+| T7.1 | Voice pre-call webhook consumes `OnboardingV2ProfileResponse` shape | S | 213-5 | — | T1.1, T5.1 |
+| T7.2 | `test_payload_includes_v2_profile_response` (AC-7.2) | S | 213-5 | — | T7.1 |
+| T7.3 | `test_voice_prompt_includes_backstory` (AC-7.3; patch `BACKSTORY_HOOK_PROBABILITY` 0.0/1.0) | S | 213-5 | [P] T7.2 | T5.1, T7.1 |
+
+### Cross-cutting: FR-4a Preview Backstory Endpoint (FR-4a + FR-4a.1)
+
+| ID | Task | Est. | PR | [P] | Deps |
+|----|------|------|----|----|------|
+| TX.1 | `POST /onboarding/preview-backstory` route + `BackstoryPreviewRequest/Response` | M | 213-3 | — | T1.1, T3.1 |
+| TX.2 | `_PreviewRateLimiter` overrides `_get_minute_window()` with `preview:` prefix | S | 213-3 | — | TX.1 |
+| TX.3 | `test_cache_key_stable` + `test_degraded_returns_empty` (FR-4a facade tests) | S | 213-3 | [P] TX.2 | TX.1 |
+| TX.4 | `test_profile_post_reuses_cache` + `test_rate_limit` + `test_stateless_no_jsonb_write` | M | 213-4 | — | TX.1, T6.1 |
+
+### Cross-cutting: PII fixes + observability (FR-7, NFR-3)
+
+| ID | Task | Est. | PR | [P] | Deps |
+|----|------|------|----|----|------|
+| TP.1 | Fix PII echo at `nikita/api/routes/onboarding.py:154, :239` (logger.exception extra={"user_id"...}) | S | 213-3 | — | — |
+| TP.2 | RLS DDL in migration: UPDATE WITH CHECK + DELETE subquery form on user_profiles | S | 213-2 | — | T1.4 |
+| TP.3 | `test_log_observability.py` caplog assertions for 4 NFR-3 events | M | 213-3 | [P] TP.1 | TP.1 |
+
+### Cross-cutting: pipeline bootstrap idempotence (FR-11)
+
+| ID | Task | Est. | PR | [P] | Deps |
+|----|------|------|----|----|------|
+| TB.1 | `_bootstrap_pipeline` reads `pipeline_state` from JSONB; skip if already ready | S | 213-3 | — | T3.2 |
+| TB.2 | `test_idempotent_double_call` (side_effect=[state_none, state_ready]) | S | 213-3 | [P] TB.1 | TB.1 |
+
+---
+
+## Estimates Summary
+
+| PR | Tasks | Est. Total | LOC Budget |
+|----|-------|-----------|------------|
+| 213-1 | T1.1, T1.2, T1.3, T2.1 | S+S+S+S ≈ 2-3hr | ~250 |
+| 213-2 | T1.4, T1.5, T1.6, TP.2 | M+S+M+S ≈ 4-6hr | ~300 |
+| 213-3 | T3.1-T3.3, T4.1-T4.3, TX.1-TX.3, TP.1, TP.3, TB.1-TB.2 | ~12-16hr | ~400 |
+| 213-4 | T2.2-T2.5, T6.1-T6.5, TX.4 | ~10-12hr | ~400 |
+| 213-5 | T1.7, T3.4, T4.4, T5.1-T5.4, T7.1-T7.3 | ~8-10hr | ~350 |
+
+**Total**: ~36-47 hours. No XL tasks.
+
+---
+
+## Testing Strategy
+
+**Pyramid target (per spec §NFR Coverage)**:
+- Unit (~70%): tuning constants boundary tests, contracts validation, adapters, FirstMessageGenerator branches, cache_key stability
+- Integration (~25%): facade with mocks, pipeline gate ASGI, RLS policies (live Supabase)
+- E2E (~5%): `test_full_profile_personalizes_first_message` via Telegram MCP (marked `@pytest.mark.e2e` — NOT in unit CI gate)
+
+**Coverage targets** (NFR-7): 100% on `contracts.py`, `tuning.py`, `adapters.py`; 85% on facade, repositories, routes.
+
+**Patch convention** (per `.claude/rules/testing.md`): patch at source module, not importer.
+
+**Non-empty fixture compliance**: every repo-mock test provides at least one non-empty path. AC-2.2 uses `side_effect=[...]` explicitly; FR-11 test uses `side_effect=[state_none, state_ready]` (NOT `return_value=None`).
+
+**17 test files named in spec** — inventory in spec §Test File Inventory. Each AC names its test file + assertion type.
+
+---
+
+## Risks & Mitigations (Top 5 from spec)
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Contract churn delays Spec 214 | Medium | High | PR 213-1 ships FROZEN contracts; ADR required for any change post-merge |
+| Pydantic↔ORM type confusion in facade | Low | High | `BackstoryPromptProfile` duck-typed dataclass in adapters.py; single source of truth; type-check enforced via `mypy --strict` in CI |
+| Bug in facade leaks ORM session across requests | Low | Critical | FR-14 explicit fresh-session pattern; `test_portal_onboarding_session_isolation` asserts `get_session_maker` NOT invoked inside facade |
+| `pipeline_state` JSONB write race (concurrent bootstrap) | Low | Medium | FR-11 idempotence check + FR-5.2 `jsonb_set` atomic merge |
+| PII leak in exception echoes | Medium | High | FR-7 + log redaction unit tests (`test_log_observability.py`) + `rg` audit pre-PR |
+
+Full 10-risk matrix in spec §Risks & Mitigations.
+
+---
+
+## Constitutional Compliance
+
+| Article | Requirement | How Plan Addresses |
+|---------|-------------|---------------------|
+| I Intelligence-First | Query before read | plan-rewrite + 6 validators (10 iterations) + research complete |
+| III Test-First | ≥2 ACs per story | 7 USs × 4 ACs = 30 ACs, every AC names test file |
+| IV Spec-First | spec → plan → code | ✓ this plan references spec only |
+| VI Simplicity | ≤3 projects, ≤2 abstraction layers | 1 project (nikita/), ORM + repository + facade = 3 layers max (no cycles) |
+| VII User-Story-Centric | P1 → P2 → P3 order | P1: US-1..5 (PRs 213-1..5 core) / P2: US-6,7 (PRs 213-4..5 tail) |
+| VIII Parallelization | [P] markers | Marked on 12 tasks with no dependency overlap within same PR |
+| IX TDD Discipline | Tests BEFORE code | Enforced via /tasks TDD pairs + 2-commit rule per story |
+| X Git Workflow | Two commits per story | test-commit + impl-commit per FR via `/implement` |
+| XI Doc-Sync | 0 CRITICAL before PR | `/qa-review` absolute-zero + post-merge smoke |
+
+---
+
+## Next Steps
+
+1. `/tasks 213` → Phase 6 → generate `tasks.md` with TDD test-commit/impl-commit pairs per FR
+2. `/audit 213` → Phase 7 → final audit (plan + tasks coverage vs spec)
+3. `/implement 213` → Phase 8 → formal skill invocation (NOT raw subagent dispatch per SDD rule 10)
+4. Each PR through `/qa-review` → absolute-zero all severities → squash merge → post-merge smoke (auto-dispatched subagent)
+5. Parallel: `/feature 214` can start once PR 213-1 merges (contracts frozen)

--- a/specs/213-onboarding-backend-foundation/spec.md
+++ b/specs/213-onboarding-backend-foundation/spec.md
@@ -1,0 +1,1058 @@
+# Feature Specification: Onboarding Backend Foundation
+
+**Spec ID**: 213-onboarding-backend-foundation
+**Status**: Draft — iteration 2
+**Created**: 2026-04-14
+**Predecessor**: Spec 210 (timing) MERGED, Spec 212 (phone capture) COMPLETE, PR #277 (recovery) MERGED
+**Successor**: Spec 214 (portal-onboarding-wizard) — depends on `contracts.py` from this spec
+**Brief**: `.claude/plans/onboarding-overhaul-brief.md`
+**Validation**: `validation-findings.md` tracks 60 iteration-1 findings; this rewrite addresses ALL severities (per user policy)
+
+---
+
+## Overview
+
+### Problem Statement
+
+The portal onboarding handoff produces a degraded user experience because:
+
+1. **Profile is stripped at handoff**: After PR #277 restored PR #273's fixes, the structural pipeline-bootstrap bugs are gone, but only fields that exist on `UserOnboardingProfile` are passed through. New fields the user wants Nikita to know (name, age, occupation in user-profiles ORM) are not collected, not stored, and therefore not used in the first message or in the post-processing pipeline.
+2. **City research + backstory generation are not invoked from portal**: Both `VenueResearchService` and `BackstoryGeneratorService` exist in `nikita/services/` and were wired into the OLD Telegram-first onboarding (see `nikita/platforms/telegram/onboarding/handler.py`). After Spec 081's portal migration, these services were never plumbed into `save_portal_profile`. The first message therefore lacks city-aware flavor, scenario-aware backstory hooks, and the "introducing your friends" beat that gave the original Telegram experience its sense of progression.
+3. **No pipeline-readiness gate**: The user can interact with Nikita the moment the wizard submits, but the post-processing pipeline (prompt builder, memory seeding, scoring init) may still be running. The user receives a generic, pre-pipeline first message; the bug surfaces as Nikita "forgetting" what she just said because the seeded conversation was not yet processed when the user replied. There is also no `pipeline_state` JSONB key written today (verified across all Python files).
+4. **No type contract for the portal/voice → backend boundary**: `PortalProfileRequest`, the handoff result, and the backstory option list are scattered across modules. Spec 214 (portal wizard) cannot start in parallel because it has no shared, frozen contract to consume.
+
+### Proposed Solution
+
+Add a **backend foundation** that supports a richer, more engaging onboarding experience:
+
+1. **Expand `user_profiles` schema + `UserOnboardingProfile` Pydantic + `PortalProfileRequest`** to collect `name`, `age`, `occupation` alongside the fields restored by PR #277. (NOTE: `age` already exists on `UserOnboardingProfile` Pydantic at `models.py:122`; only `name` is net-new on the Pydantic model. `occupation` already exists at `models.py:87`.)
+2. **Wire `VenueResearchService` + `BackstoryGeneratorService`** into a new thin facade `nikita/services/portal_onboarding.py` invoked from a new `nikita/api/routes/portal_onboarding.py` route file. Each service has a named timeout budget (`VENUE_RESEARCH_TIMEOUT_S=15`, `BACKSTORY_GEN_TIMEOUT_S=20`) and a graceful-degradation fallback. The facade reuses the existing `_ProfileFromAnswers` adapter (promoted to `nikita/onboarding/adapters.py`) for the Pydantic→ORM bridge.
+3. **Publish `nikita/onboarding/contracts.py`** as the FIRST PR — a single module exporting `OnboardingV2ProfileRequest`, `OnboardingV2ProfileResponse`, `BackstoryOption`, `PipelineReadyState`, `PipelineReadyResponse`, `ErrorResponse`. Spec 214 imports from this module. Frozen after PR #1.
+4. **Add `/pipeline-ready` poll endpoint** that returns the readiness state for the user's seeded conversation, with a 2s poll interval and 20s max wait. State is read from a NEW JSONB key `users.onboarding_profile.pipeline_state` written by `_bootstrap_pipeline` (FR-5.1).
+5. **Enhance `FirstMessageGenerator.generate()`** to use the chosen backstory scenario as a coda when present, in addition to PR #273's city/scene flavor.
+6. **R8 — Conversation continuity** (already restored via PR #277's `_seed_conversation`): the seeded conversation MUST contain the first message as an assistant turn before the pipeline starts; this spec adds a regression test that proves the user cannot make Nikita "deny" the first message.
+
+### Type-Layer Disambiguation (Load-Bearing Reference)
+- `UserOnboardingProfile` = Pydantic model, lives in `nikita/onboarding/models.py`, persisted as JSONB on `users.onboarding_profile`.
+- `UserProfile` = SQLAlchemy ORM model, lives in `nikita/db/models/profile.py`, persists to `user_profiles` table.
+- `BackstoryGeneratorService.generate_scenarios(profile, venues)` at `:81` accepts a `UserProfile`-shaped object (ORM), NOT `UserOnboardingProfile` (Pydantic). The existing adapter `_ProfileFromAnswers` at `nikita/platforms/telegram/onboarding/handler.py:41-56` will be promoted to a shared module (FR-3).
+
+### Success Criteria
+
+- [ ] **SC-1**: After portal onboarding completes with city="Berlin" + scene="techno" + occupation="designer" + name="Anna" + age=29, the first Telegram message Nikita sends contains at least 2 of these tokens (city, scene, occupation, name). Verified by E2E test in `tests/onboarding/test_e2e.py::test_full_profile_personalizes_first_message` marked `@pytest.mark.e2e`.
+- [ ] **SC-2**: The user cannot interact with Nikita until `/pipeline-ready` returns `ready` OR the 20-second hard cap elapses. Verified by ASGI integration test `tests/onboarding/test_pipeline_gate_integration.py::test_blocks_until_ready` and Cloud Run log inspection.
+- [ ] **SC-3**: User replies to Nikita with the verbatim first-message text within 10 minutes of onboarding; Nikita's response acknowledges (does not deny) the prior turn. Verified by `tests/onboarding/test_r8_conversation_continuity.py::test_no_denial_of_seeded_turn` (N=10 mocked agent runs).
+- [ ] **SC-4**: City research and backstory generation each respect their named timeout budgets. On timeout, the user-facing experience degrades gracefully (no error message, fallback first message used). Verified by `tests/services/test_portal_onboarding_facade.py::{test_venue_timeout, test_backstory_failure}` integration tests with simulated timeouts.
+- [ ] **SC-5**: `OnboardingV2ProfileRequest` / `OnboardingV2ProfileResponse` / `BackstoryOption` / `PipelineReadyState` / `PipelineReadyResponse` / `ErrorResponse` are importable from `nikita.onboarding.contracts` and frozen (no field changes after PR #1 merges). Verified by Spec 214's CI build succeeding against this contract.
+- [ ] **SC-6**: PII fields (`name`, `age`, `occupation`, `phone`) never appear in structured logs. Verified by both: (a) static `rg "name=|age=|occupation=" nikita/api/routes/portal_onboarding.py nikita/onboarding/handoff.py nikita/services/portal_onboarding.py` returns zero hits inside log statements, AND (b) runtime test `tests/onboarding/test_portal_onboarding_facade.py::test_pii_redaction_in_logs` using `caplog` to verify name/age values absent from all records produced.
+- [ ] **SC-7**: New `user_profiles` columns (`name`, `occupation`, `age`) have RLS such that user can only `SELECT`/`UPDATE` their own row. Verified via Supabase `mcp__supabase__list_policies` (existing 5 policies cover new columns automatically — PostgreSQL row-level) AND `tests/db/test_rls_user_profiles.py` marked `@pytest.mark.integration` (live Supabase, NOT in unit CI gate).
+- [ ] **SC-8**: All 6 SDD validators return PASS with 0 findings across CRITICAL + HIGH + MEDIUM + LOW. Verified by validation-findings.md showing 0/0/0/0 in iteration N.
+- [ ] **SC-9**: Coverage: `contracts.py` 100%, `tuning.py` 100%, `portal_onboarding.py` ≥90%, route additions ≥85%. Verified by `pytest --cov` with `--cov-fail-under` thresholds.
+
+---
+
+## Functional Requirements
+
+### FR-1: Profile Field Expansion (3 layers + ORM)
+**Priority**: P1
+**Description**: Expand profile fields across DB, ORM, Pydantic, and API request schema.
+
+**Net-new fields**: `name` (DB + ORM + Pydantic + API). `age` net-new on DB + ORM only (already exists on `UserOnboardingProfile:122`). `occupation` net-new on DB + ORM only (already exists on `UserOnboardingProfile:87`).
+
+**Sub-requirements**:
+
+- **FR-1a — Supabase migration** (file: `supabase/migrations/YYYYMMDDHHMMSS_alter_user_profiles_add_name_occupation_age.sql` — use timestamp format matching existing project convention, NOT `0091_*`):
+  ```sql
+  ALTER TABLE user_profiles ADD COLUMN name TEXT;
+  ALTER TABLE user_profiles ADD COLUMN occupation TEXT;
+  ALTER TABLE user_profiles ADD COLUMN age SMALLINT CHECK (age IS NULL OR (age BETWEEN 18 AND 99));
+  CREATE INDEX idx_user_profiles_age ON user_profiles(age) WHERE age IS NOT NULL;
+  ```
+  RLS coverage: existing 5 policies cover new columns automatically (PostgreSQL is row-level, not column-level). Rollback script: `ALTER TABLE user_profiles DROP COLUMN name, DROP COLUMN occupation, DROP COLUMN age;` documented in migration file.
+
+- **FR-1b — ORM additions** (file: `nikita/db/models/profile.py`):
+  ```python
+  name: Mapped[str | None] = mapped_column(String, nullable=True)
+  occupation: Mapped[str | None] = mapped_column(String, nullable=True)
+  age: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+  ```
+  Use `SmallInteger` (PostgreSQL `SMALLINT`), NOT `Integer`. Without ORM mapping, Supabase silently discards writes to columns not in the mapping.
+
+- **FR-1c — Pydantic UserOnboardingProfile additions** (file: `nikita/onboarding/models.py:76`): only `name` is net-new (age + occupation already exist). Add:
+  ```python
+  name: str | None = Field(default=None, min_length=1, max_length=100, description="User's first name")
+  ```
+  Update `ProfileFieldUpdate.validate_field_name` allow-list at `:204-219` to add `"name"`.
+
+- **FR-1d — API PortalProfileRequest extension** (file: `nikita/api/routes/onboarding.py:647`):
+  ```python
+  name: str | None = Field(default=None, min_length=1, max_length=100)
+  age: int | None = Field(default=None, ge=18, le=99)
+  occupation: str | None = Field(default=None, min_length=1, max_length=100)
+  ```
+  Note: same Pydantic `Field` constraints as DB CHECK to keep app-layer error messages clear before DB rejection.
+
+- **FR-1e — JSONB key canonical name**: User name persists in `users.onboarding_profile` as key `"name"` (NOT `"user_name"`). Existing read sites at `nikita/api/routes/onboarding.py:458-460, :556-557` that read `"user_name"` MUST be updated to read `"name"` (with fallback to `"user_name"` for one release cycle for backwards compat).
+
+### FR-2: Contract Module (Ships First)
+**Priority**: P1
+**Description**: Create `nikita/onboarding/contracts.py` exporting the following Pydantic types. **CONSTRAINT**: this module MUST NOT import from `nikita.onboarding.models`, `nikita/db/models/`, or `nikita.engine.constants` — it is a standalone contract module to prevent circular imports. After PR #1 merges, the contract is FROZEN — any field addition requires an ADR + re-coordination with Spec 214.
+
+**`PipelineReadyState`** (string Literal, NOT enum, for JSON serialization simplicity):
+```python
+PipelineReadyState = Literal["pending", "ready", "degraded", "failed"]
+```
+
+**`BackstoryOption`** (mirrors `BackstoryScenario` dataclass at `nikita/services/backstory_generator.py:29`):
+```python
+class BackstoryOption(BaseModel):
+    id: str = Field(description="Opaque ID, stable per (cache_key, index)")
+    venue: str = Field(description="Where the meeting happened")
+    context: str = Field(description="Setting / vibe in 2-3 sentences")
+    the_moment: str = Field(description="The catalyst moment")
+    unresolved_hook: str = Field(description="One-liner Nikita can reference in first message")
+    tone: Literal["romantic", "intellectual", "chaotic"]
+```
+
+**`OnboardingV2ProfileRequest`** (extends current `PortalProfileRequest`):
+```python
+class OnboardingV2ProfileRequest(BaseModel):
+    location_city: str = Field(min_length=2, max_length=100)
+    social_scene: Literal["techno", "art", "food", "cocktails", "nature"]
+    drug_tolerance: int = Field(ge=1, le=5)
+    life_stage: Literal["tech","finance","creative","student","entrepreneur","other"] | None = None
+    interest: str | None = Field(default=None, max_length=200)
+    phone: str | None = Field(default=None, min_length=8, max_length=20)
+    name: str | None = Field(default=None, min_length=1, max_length=100)
+    age: int | None = Field(default=None, ge=18, le=99)
+    occupation: str | None = Field(default=None, min_length=1, max_length=100)
+    wizard_step: int | None = Field(default=None, ge=1, le=11, description="Last completed wizard step for resume detection")
+```
+
+**`OnboardingV2ProfileResponse`** (returned by `POST /onboarding/profile`):
+```python
+class OnboardingV2ProfileResponse(BaseModel):
+    user_id: UUID
+    pipeline_state: PipelineReadyState  # initial state, typically "pending"
+    backstory_options: list[BackstoryOption]  # may be empty on degraded path
+    chosen_option: BackstoryOption | None  # ALWAYS None from this spec's endpoints
+    poll_endpoint: str  # absolute path to /pipeline-ready/{user_id}
+    poll_interval_seconds: float  # = PIPELINE_GATE_POLL_INTERVAL_S
+    poll_max_wait_seconds: float  # = PIPELINE_GATE_MAX_WAIT_S
+```
+
+**Note on `chosen_option`**: This field is ALWAYS `None` in responses from Spec 213 endpoints (POST/PATCH `/onboarding/profile`, GET `/pipeline-ready`). Spec 214 owns defining the backstory-selection endpoint (e.g., `POST /api/v1/onboarding/backstory-choice`) that persists the user's pick and returns an updated `OnboardingV2ProfileResponse` with `chosen_option` populated. The field is in this contract so Spec 214 doesn't need to widen it later.
+
+**`PipelineReadyResponse`** (returned by `GET /pipeline-ready/{user_id}`):
+```python
+class PipelineReadyResponse(BaseModel):
+    state: PipelineReadyState
+    message: str | None = None  # optional user-facing explanation, present on degraded/failed
+    checked_at: datetime  # ISO-8601, for monitoring/debugging
+    venue_research_status: Literal["pending", "complete", "failed", "cache_hit"] = "pending"  # FR-2a, default if JSONB key missing
+    backstory_available: bool = False  # FR-2a, default if JSONB key missing (True once scenarios persisted)
+```
+
+**Missing-key defaults**: if `users.onboarding_profile.venue_research_status` is absent → return `"pending"`. If `backstory_available` absent → return `False`. This keeps `/pipeline-ready` as a single-SELECT NFR-1 path. Existing `PipelineReadyResponse` construction sites (tests, mocks) may omit the new fields — defaults cover them.
+
+**`BackstoryPreviewRequest`** (input to NEW `POST /onboarding/preview-backstory` — FR-4a, added iter-6):
+```python
+class BackstoryPreviewRequest(BaseModel):
+    city: str = Field(min_length=2, max_length=100)
+    social_scene: Literal["techno", "art", "food", "cocktails", "nature"]
+    darkness_level: int = Field(ge=1, le=5)  # maps to drug_tolerance in OnboardingV2ProfileRequest (legacy-name compat)
+    life_stage: Literal["tech", "finance", "creative", "student", "entrepreneur", "other"] | None = None  # Literal match with OnboardingV2ProfileRequest for cache_key parity
+    interest: str | None = Field(default=None, max_length=200)
+    age: int | None = Field(default=None, ge=18, le=99)
+    occupation: str | None = Field(default=None, max_length=100)
+```
+
+**Naming note**: `darkness_level` here matches `UserOnboardingProfile.darkness_level`. `OnboardingV2ProfileRequest` uses `drug_tolerance` for legacy-ORM compat. Backend maps `OnboardingV2ProfileRequest.drug_tolerance → UserOnboardingProfile.darkness_level` when recomputing cache_key on submit, guaranteeing parity with preview.
+
+**`BackstoryPreviewResponse`**:
+```python
+class BackstoryPreviewResponse(BaseModel):
+    scenarios: list[BackstoryOption]  # 2-3 options; empty on degraded path
+    venues_used: list[str]  # venue names incorporated into scenarios (for wizard UI)
+    cache_key: str  # opaque; returned for debugging/observability (NOT echoed back — backend recomputes)
+    degraded: bool  # True if backstory service failed; scenarios will be empty or generic
+```
+
+**Cache coherence mechanism** (replaces earlier "echo back" wording): backend RECOMPUTES `cache_key` from submitted `OnboardingV2ProfileRequest` fields on final `POST /onboarding/profile`. Since `compute_backstory_cache_key` is deterministic over the same inputs, and `BackstoryPreviewRequest` carries the same semantic fields as `OnboardingV2ProfileRequest`, the recomputed key matches the preview key → cache hit → no duplicate Claude call. No echo field needed. The `cache_key` in the response is informational only (observability, debugging).
+
+**`ErrorResponse`** (matches existing FastAPI shape used at `onboarding.py:140`):
+```python
+class ErrorResponse(BaseModel):
+    detail: str
+```
+
+### FR-2a (iter-6 amendment): Pipeline-Ready Response Extension
+**Priority**: P1
+**Description**: Extend `PipelineReadyResponse` (FR-2) with `venue_research_status` + `backstory_available` fields (defaults shown in contract above). These support portal dossier wizard showing live venue research state during step 4 and gating step 8 on scenario availability. `/pipeline-ready` becomes single source of truth for ALL wizard-blocking state.
+
+**Write paths** (both keys written by `_bootstrap_pipeline` + facade, NOT preview endpoint):
+- `venue_research_status`: set to `"pending"` at pipeline entry → `"complete"`/`"failed"`/`"cache_hit"` after venue research step. Via `user_repo.update_onboarding_profile_key(user_id, "venue_research_status", value)` (FR-5.2).
+- `backstory_available`: set to `True` immediately after `BackstoryCacheRepository.set` succeeds (either in facade post-handoff OR after final-POST cache hit). Via `user_repo.update_onboarding_profile_key(user_id, "backstory_available", True)`.
+
+**Read path** (GET `/pipeline-ready/{user_id}`):
+- Single SELECT on `users.onboarding_profile` JSONB (existing NFR-1 p99 ≤200ms guarantee preserved)
+- Read `pipeline_state`, `venue_research_status`, `backstory_available` from JSONB
+- Missing keys → Pydantic defaults (`"pending"` / `False`)
+- No second table query to `backstory_cache` — strictly JSONB read
+
+**Acceptance Criteria** (adds to US-2):
+- [ ] AC-2.5: `/pipeline-ready` response includes `venue_research_status` + `backstory_available` fields. Test: `tests/api/routes/test_portal_onboarding.py::test_pipeline_ready_includes_new_fields` (consolidates into existing portal_onboarding route test file per Test File Inventory convention). Mock `users.onboarding_profile = {"pipeline_state": "ready", "venue_research_status": "complete", "backstory_available": True}` → assert response body contains all three. Sibling test `test_pipeline_ready_defaults`: mock with empty JSONB `{}` → assert defaults `("pending", False)` are returned.
+
+### FR-4a (iter-6 amendment): Backstory Preview Endpoint (for pre-submit reveal)
+**Priority**: P1
+**Description**: Add `POST /api/v1/onboarding/preview-backstory` accepting `BackstoryPreviewRequest` and returning `BackstoryPreviewResponse`. Called by portal wizard at Step 8 (dossier reveal) BEFORE the final `POST /onboarding/profile`. The portal dossier flow needs backstory BEFORE phone capture (Step 9) — per UX expert review, backstory is the emotional climax that justifies the phone ask.
+
+**Auth**: requires user JWT (existing `get_current_user_id`). Rate limit 5 req/min per user via NEW `preview_rate_limit` dependency (FR-4a.1 below).
+
+**Dependencies** (FastAPI route handler signature):
+```python
+@router.post("/preview-backstory", response_model=BackstoryPreviewResponse)
+async def preview_backstory(
+    request: BackstoryPreviewRequest,
+    current_user_id: UUID = Depends(get_current_user_id),
+    session: AsyncSession = Depends(get_async_session),
+    _: None = Depends(preview_rate_limit),  # 429 on exceeded
+) -> BackstoryPreviewResponse:
+```
+
+**Service instantiation** (before numbered steps — mirrors FR-3 facade pattern):
+```python
+venue_cache_repo = VenueCacheRepository(session)
+venue_service = VenueResearchService(venue_cache_repository=venue_cache_repo)
+backstory_repo = BackstoryCacheRepository(session)
+backstory_service = BackstoryGeneratorService()  # no constructor args per backstory_generator.py:77
+```
+
+**Behavior**:
+1. Construct `pseudo_profile` explicitly as duck-typed namespace (NOT a `UserOnboardingProfile` since request fields may not all match): `pseudo_profile = SimpleNamespace(city=request.city, social_scene=request.social_scene, darkness_level=request.darkness_level, life_stage=request.life_stage, interest=request.interest, age=request.age, occupation=request.occupation)`. Then `cache_key = compute_backstory_cache_key(pseudo_profile)` (function is duck-typed via attribute reads — FR-3 step 3 helper works on any object with these attrs).
+2. Check `backstory_repo.get(cache_key)` — if hit, deserialize stored envelope `{scenarios, venues_used}` → return cached `BackstoryPreviewResponse(scenarios=[BackstoryOption.model_validate(d) for d in envelope["scenarios"]], venues_used=envelope["venues_used"], cache_key=cache_key, degraded=False)`.
+3. On miss: `venue_result = await asyncio.wait_for(VenueResearchService.research_venues(city, scene), timeout=VENUE_RESEARCH_TIMEOUT_S)`. On timeout → log + return `degraded=True, scenarios=[], venues_used=[]` (no cache write). **Preview endpoint does NOT write to `users.onboarding_profile` JSONB** — that's the handoff/pipeline path's responsibility (FR-5.1). Keeps preview stateless.
+4. `venues_list = venue_result.venues` (extract from dataclass per FR-3 step 5 correction). `venue_names = [v.name for v in venues_list]`.
+5. `orm_like_profile = ProfileFromOnboardingProfile.from_pydantic(user_id=current_user_id, profile=pseudo_profile)` (adapter accepts duck-typed input for `profile` param). `scenarios_result = await asyncio.wait_for(backstory_service.generate_scenarios(orm_like_profile, venues_list), timeout=BACKSTORY_GEN_TIMEOUT_S)`. On timeout/exception → log + return `BackstoryPreviewResponse(scenarios=[], venues_used=venue_names, cache_key=cache_key, degraded=True)`.
+6. Convert `BackstoryScenario[] → BackstoryOption[]` via `_scenario_to_option(cache_key, index, scenario)` (FR-3.2).
+7. Persist envelope `{scenarios: [opt.model_dump(mode="json") for opt in options], venues_used: venue_names}` via `BackstoryCacheRepository.set(cache_key, envelope, ttl_days=BACKSTORY_CACHE_TTL_DAYS)`.
+8. Return `BackstoryPreviewResponse(scenarios=options, venues_used=venue_names, cache_key=cache_key, degraded=False)`.
+
+**Cache coherence mechanism** (no echo needed): on final `POST /onboarding/profile`, backend route handler constructs its own `UserOnboardingProfile` from the submitted `OnboardingV2ProfileRequest` (mapping `drug_tolerance → darkness_level`), computes `cache_key = compute_backstory_cache_key(profile)`, and passes to facade. Facade calls `BackstoryCacheRepository.get(cache_key)` — if preview was called with the same semantic fields, cache_key matches → cache hit → scenarios reused → no duplicate Claude call. Deterministic function over stable inputs = no echo field needed.
+
+#### FR-4a.1 — Preview Rate Limit Dependency
+
+**Approach**: standalone `preview_rate_limit` FastAPI dependency (avoids modifying the shared `DatabaseRateLimiter.check()` signature):
+
+```python
+# nikita/api/middleware/rate_limit.py
+from nikita.onboarding.tuning import PREVIEW_RATE_LIMIT_PER_MIN
+
+class _PreviewRateLimiter(DatabaseRateLimiter):
+    """Subclass that overrides MAX_PER_MINUTE with a separate counter key prefix."""
+    MAX_PER_MINUTE = PREVIEW_RATE_LIMIT_PER_MIN
+
+    def _get_minute_window(self) -> str:
+        # Override matches actual parent method at rate_limiter.py:445 (no user_id param).
+        # Returns prefixed window key; check() at line 301 reads this to build the DB row key.
+        return f"preview:{super()._get_minute_window()}"  # separate counter from voice
+
+async def preview_rate_limit(
+    current_user_id: UUID = Depends(get_current_user_id),
+    session: AsyncSession = Depends(get_async_session),
+) -> None:
+    limiter = _PreviewRateLimiter(session)
+    result = await limiter.check(current_user_id)
+    if not result.allowed:
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded",
+            headers={"Retry-After": "60"},
+        )
+```
+
+This approach:
+- Does NOT modify the existing `DatabaseRateLimiter.check(user_id)` signature (no breaking change to voice rate limiter)
+- Uses a subclass to override `MAX_PER_MINUTE` = 5 and `_get_minute_window` for separate counter (prefix `preview:`)
+- Returns `Retry-After: 60` header on 429
+
+Tuning constant:
+```python
+PREVIEW_RATE_LIMIT_PER_MIN: Final[int] = 5
+"""Per-user rate limit for /onboarding/preview-backstory.
+Prior values: none (new in Spec 213).
+Rationale: each call triggers Claude + Firecrawl; 5/min covers wizard step-navigation retries
+without enabling abuse. Voice rate limit is 20/min (different surface). Separate counter key
+avoids sharing quota."""
+```
+
+Add new dependency `preview_rate_limit` in `nikita/api/middleware/rate_limit.py` modeled on existing `voice_rate_limit`:
+- The subclass pattern shown above is the AUTHORITATIVE approach — do NOT modify `DatabaseRateLimiter.check()` signature
+- Separate counter key prefix (`preview:`) avoids sharing quota with voice endpoints
+- On exceeded: `HTTPException(status_code=429, detail="Rate limit exceeded", headers={"Retry-After": "60"})`
+
+**Tests**:
+- `tests/services/test_preview_backstory.py::test_cache_key_stable` — same profile inputs produce identical cache_key (facade-level unit test, mocks `BackstoryCacheRepository`)
+- `tests/services/test_preview_backstory.py::test_degraded_returns_empty` — backstory service failure → `degraded=True`, `scenarios=[]`, `venues_used=<venue_names>` (facade-level, mocks BackstoryGeneratorService + VenueResearchService)
+- `tests/api/routes/test_preview_backstory_route.py::test_profile_post_reuses_cache` — integration via FastAPI TestClient. POST `/preview-backstory` → POST `/profile` with same profile fields → assert `BackstoryCacheRepository.get` returns preview's cached envelope; assert Claude NOT called on second POST.
+- `tests/api/routes/test_preview_backstory_route.py::test_rate_limit` — 6th call in 1 minute returns 429 with `Retry-After: 60` header.
+- `tests/api/routes/test_preview_backstory_route.py::test_stateless_no_jsonb_write` — assert `users.onboarding_profile` is unchanged after preview call.
+
+### FR-3: Portal Onboarding Facade
+**Priority**: P1
+**Description**: Create `nikita/services/portal_onboarding.py` — a thin facade with single responsibility (no business logic).
+
+**Signature**:
+```python
+async def process(
+    user_id: UUID,
+    profile: UserOnboardingProfile,
+    session: AsyncSession,  # passed in; facade NEVER opens own session
+) -> list[BackstoryOption]:
+```
+
+**Behavior**:
+1. Construct `VenueCacheRepository(session)` and inject into `VenueResearchService(venue_cache_repository=repo)` per existing constructor at `venue_research.py:68`.
+2. Construct `BackstoryCacheRepository(session)` (NEW per FR-12).
+2b. Construct `backstory_service = BackstoryGeneratorService()` (no constructor args required per `backstory_generator.py:77`).
+3. Compute `cache_key = compute_backstory_cache_key(profile)` using `AGE_BUCKETS` + `OCCUPATION_CATEGORIES` from `tuning.py` to bucket age and occupation BEFORE constructing key; missing values → `"unknown"` bucket.
+
+   **Function definitions** (all in `nikita/onboarding/tuning.py`):
+   ```python
+   def _age_bucket(age: int | None) -> str:
+       """Map age to bucket label per AGE_BUCKETS. Returns 'unknown' if None."""
+       if age is None:
+           return "unknown"
+       for low, high, label in AGE_BUCKETS:
+           if low <= age <= high:
+               return label
+       return "unknown"  # outside any bucket
+
+   def _occupation_bucket(occupation: str | None) -> str:
+       """Map occupation string to coarse category per OCCUPATION_CATEGORIES.
+       Substring match (lowercased). Returns 'other' if no match, 'unknown' if None."""
+       if occupation is None:
+           return "unknown"
+       occ_lower = occupation.lower()
+       for substring, category in OCCUPATION_CATEGORIES.items():
+           if substring in occ_lower:
+               return category
+       return "other"
+
+   def compute_backstory_cache_key(profile: UserOnboardingProfile) -> str:
+       """Deterministic cache key for backstory generation.
+       Format: 'city|scene|darkness|life_stage|interest|age_bucket|occupation_bucket'
+       with 'unknown' substituted for None values. City normalized to lowercase."""
+       city = (profile.city or "unknown").lower()
+       scene = profile.social_scene or "unknown"
+       darkness = str(profile.darkness_level)
+       life_stage = profile.life_stage or "unknown"
+       interest = (profile.interest or "unknown").lower()
+       age_bkt = _age_bucket(profile.age)
+       occ_bkt = _occupation_bucket(profile.occupation)
+       return f"{city}|{scene}|{darkness}|{life_stage}|{interest}|{age_bkt}|{occ_bkt}"
+   ```
+4. Cache lookup via `BackstoryCacheRepository.get(cache_key)` — if hit, return cached `list[BackstoryOption]` and log `cache_hit=True`.
+4. On cache **hit**: deserialize envelope — `options = [BackstoryOption.model_validate(d) for d in envelope["scenarios"]]`. Log `cache_hit=True`. Return `options`. (Cache stores full envelope `{scenarios, venues_used}` per FR-12; facade reads `scenarios` only for its return type, but the same envelope shape must be written on miss for consistency.)
+5. On cache **miss**:
+   - `venue_result = await asyncio.wait_for(venue_service.research_venues(profile.city, profile.social_scene), timeout=VENUE_RESEARCH_TIMEOUT_S)` — returns `VenueResearchResult` dataclass with `.venues: list[Venue]` and `.fallback_used: bool`. On `asyncio.TimeoutError`, log outcome=`timeout` + return `[]` (no cache write on failure).
+   - Extract: `venues_list = venue_result.venues`. `venue_names = [v.name for v in venues_list]`. If `venue_result.fallback_used`, proceed with empty venues_list (backstory will use generic flavor).
+   - Adapter step: `orm_profile = ProfileFromOnboardingProfile.from_pydantic(user_id, profile)` (FR-3.1 below).
+   - `scenarios_result = await asyncio.wait_for(backstory_service.generate_scenarios(orm_profile, venues_list), timeout=BACKSTORY_GEN_TIMEOUT_S)` — returns `BackstoryScenariosResult` containing `list[BackstoryScenario]` dataclass. On timeout/`RuntimeError`/`anthropic.APIError`, log outcome=`timeout`/`failure` + return `[]`.
+   - Convert each `BackstoryScenario` → `BackstoryOption` via `_scenario_to_option(cache_key, index, scenario)` (FR-3.2 below).
+   - Validate `tone` field: if scenario.tone not in `{"romantic","intellectual","chaotic"}`, default to `"chaotic"` (most flexible) + log `tone_invalid_fallback`.
+   - **Persist envelope** matching FR-4a + FR-12 shape: `envelope = {"scenarios": [opt.model_dump(mode="json") for opt in options], "venues_used": venue_names}`. Then `BackstoryCacheRepository.set(cache_key, envelope, ttl_days=BACKSTORY_CACHE_TTL_DAYS)`. **Both writers (facade + preview endpoint) produce identical envelope shape** — cache readers (either path) can safely expect both keys.
+   - After successful cache set: `await user_repo.update_onboarding_profile_key(user_id, "backstory_available", True)` (FR-2a write path).
+6. Return `list[BackstoryOption]` (empty on degraded path; venues_used consumed only by preview endpoint response, facade returns options only).
+
+#### FR-3.2 — Scenario-to-Option Converter
+Define in `nikita/services/portal_onboarding.py`:
+```python
+import hashlib
+from nikita.onboarding.contracts import BackstoryOption
+from nikita.services.backstory_generator import BackstoryScenario
+
+def _scenario_to_option(cache_key: str, index: int, s: BackstoryScenario) -> BackstoryOption:
+    """Convert backstory_generator dataclass → frozen contract Pydantic.
+    id formula: sha256(cache_key:index)[:12] — deterministic, stable, opaque."""
+    opaque_id = hashlib.sha256(f"{cache_key}:{index}".encode()).hexdigest()[:12]
+    valid_tone = s.tone if s.tone in ("romantic", "intellectual", "chaotic") else "chaotic"
+    return BackstoryOption(
+        id=opaque_id,
+        venue=s.venue,
+        context=s.context,
+        the_moment=s.the_moment,
+        unresolved_hook=s.unresolved_hook,
+        tone=valid_tone,
+    )
+```
+
+The `id` is deterministic so cache hits return the same `id` to the portal — the portal references it back when user picks (Spec 214's `chosen_option` write).
+
+**Logging** (FR-7 compliant — no PII):
+- `portal_handoff.venue_research`: `{event, user_id, outcome, duration_ms, cache_hit, error_class}` where `outcome ∈ {"success","timeout","failure","cache_hit"}` and `error_class: str | None` (only on `timeout`/`failure`).
+- `portal_handoff.backstory`: `{event, user_id, outcome, duration_ms, cache_hit, scenario_count, error_class}` where `scenario_count: int = len(scenarios)`.
+
+**Session safety**: facade NEVER calls `get_session_maker()()` itself. Caller (route handler) opens session. This pattern matches the fix modeled at `handoff.py:579-583` in `_bootstrap_pipeline`. Background tasks calling this facade MUST open a fresh session inside the background task body, not pass request-scoped session.
+
+#### FR-3.1 — Pydantic↔ORM Adapter (Promoted)
+Promote existing adapter `_ProfileFromAnswers` from `nikita/platforms/telegram/onboarding/handler.py:41-56` to a shared module:
+
+**File**: `nikita/onboarding/adapters.py`
+
+**IMPORTANT**: `BackstoryGeneratorService._build_scenario_prompt` (at `backstory_generator.py:180,183,220`) accesses `profile.city` (NOT `location_city`) and `profile.primary_passion` (NOT `primary_interest`). These are DUCK-TYPED attribute names, NOT real `UserProfile` ORM columns. The adapter returns a `SimpleNamespace`-like object, NOT a real `UserProfile` row. The existing `_ProfileFromAnswers` at `handler.py:41-56` is the canonical reference — promotion preserves its duck-typing.
+
+```python
+from dataclasses import dataclass
+from uuid import UUID
+from nikita.onboarding.models import UserOnboardingProfile
+
+@dataclass
+class BackstoryPromptProfile:
+    """Duck-typed adapter matching attribute names BackstoryGeneratorService reads.
+    NOT a real UserProfile ORM object. Required attrs: city, social_scene,
+    life_stage, primary_passion, drug_tolerance, name, age, occupation."""
+    city: str | None
+    social_scene: str | None
+    life_stage: str | None
+    primary_passion: str | None  # mapped from profile.interest (name collision)
+    drug_tolerance: int
+    name: str | None
+    age: int | None
+    occupation: str | None
+
+
+class ProfileFromOnboardingProfile:
+    """Bridges UserOnboardingProfile (Pydantic) → duck-typed BackstoryPromptProfile
+    for BackstoryGeneratorService.generate_scenarios(). DO NOT return a real UserProfile ORM row —
+    the service reads .city and .primary_passion which do NOT exist on UserProfile."""
+
+    @staticmethod
+    def from_pydantic(user_id: UUID, profile: UserOnboardingProfile) -> BackstoryPromptProfile:
+        return BackstoryPromptProfile(
+            city=profile.city,
+            social_scene=profile.social_scene,
+            life_stage=profile.life_stage,
+            primary_passion=profile.interest,  # NAME COLLISION — generator expects primary_passion
+            drug_tolerance=profile.darkness_level,
+            name=profile.name,
+            age=profile.age,
+            occupation=profile.occupation,
+        )
+```
+
+Field-mapping table (canonical):
+
+| UserOnboardingProfile (Pydantic) | BackstoryPromptProfile (duck-typed) | Rationale |
+|---|---|---|
+| `city` | `city` | same name |
+| `social_scene` | `social_scene` | same name |
+| `life_stage` | `life_stage` | same name |
+| `interest` | **`primary_passion`** | generator reads `profile.primary_passion` (legacy name) |
+| `darkness_level` | `drug_tolerance` | legacy name in ORM + generator |
+| `name` | `name` | NEW field |
+| `age` | `age` | same name |
+| `occupation` | `occupation` | same name |
+
+`BackstoryGeneratorService.generate_scenarios(profile, venues)` signature accepts any object with these attributes (duck typing). Do NOT try to construct a real `UserProfile` — its columns are `location_city`, `primary_interest`, etc. which do NOT match the generator's reads.
+
+Both Telegram path (`handler.py`) and portal path (`portal_onboarding.py`) import from `adapters.py`. Avoid two unsynchronized adapters.
+
+### FR-4: Tuning Constants
+**Priority**: P1
+**Description**: Define in `nikita/onboarding/tuning.py` per `.claude/rules/tuning-constants.md`. **CONSTRAINT**: `tuning.py` MUST NOT import from `nikita.engine.constants` — different domain.
+
+```python
+VENUE_RESEARCH_TIMEOUT_S: Final[float] = 15.0
+"""Per-call timeout for VenueResearchService.research_venues.
+Prior values: none (new in Spec 213, GH #213).
+Rationale: Firecrawl typical p95 ~8s; 15s budget covers cold cache + 1 retry."""
+
+BACKSTORY_GEN_TIMEOUT_S: Final[float] = 20.0
+"""Per-call timeout for BackstoryGeneratorService.generate_scenarios.
+Prior values: none (new in Spec 213, GH #213).
+Rationale: Claude Haiku typical p95 ~12s; 20s covers tail latency + 1 retry."""
+
+PIPELINE_GATE_POLL_INTERVAL_S: Final[float] = 2.0
+"""Portal poll interval for /pipeline-ready endpoint.
+Prior values: none (new in Spec 213, GH #213).
+Rationale: balances perceived responsiveness vs Cloud Run cold-start churn."""
+
+PIPELINE_GATE_MAX_WAIT_S: Final[float] = 20.0
+"""Maximum portal wait for pipeline readiness before unblocking.
+Prior values: none (new in Spec 213, GH #213).
+Rationale: covers Cloud Run cold-start (5s) + venue research (15s) + safety margin."""
+
+BACKSTORY_CACHE_TTL_DAYS: Final[int] = 30
+"""Backstory cache TTL for unique (city, scene, ...) profile shape.
+Prior values: none (new in Spec 213, GH #213).
+Rationale: matches existing VenueCache TTL; balances cost vs scenario freshness."""
+
+BACKSTORY_HOOK_PROBABILITY: Final[float] = 0.50
+"""Probability that FirstMessageGenerator includes a backstory hook in the first message.
+Prior values: none (new in Spec 213, GH #213).
+Rationale: 50% creates variety; testable via patched value (1.0 always-include, 0.0 never-include)."""
+
+PREVIEW_RATE_LIMIT_PER_MIN: Final[int] = 5
+"""Per-user rate limit for POST /onboarding/preview-backstory endpoint (FR-4a.1).
+Prior values: none (new in Spec 213, iter-7).
+Rationale: each call triggers Claude + Firecrawl; 5/min covers wizard step navigation + legitimate
+retries but prevents abuse/DoS. Voice rate limit is 20/min — different surface + different cost profile.
+Separate counter key prefix 'preview:' avoids sharing quota with voice rate limiter."""
+
+AGE_BUCKETS: Final[tuple[tuple[int, int, str], ...]] = (
+    (18, 24, "young_adult"),
+    (25, 34, "twenties"),
+    (35, 49, "midlife"),
+    (50, 99, "experienced"),
+)
+"""Age bucketing for backstory cache key. Inclusive boundaries.
+Prior values: none (new in Spec 213).
+Rationale: 4 buckets balance cache hit ratio vs personalization granularity."""
+
+OCCUPATION_CATEGORIES: Final[dict[str, str]] = {
+    # mapping: lowercase substring → coarse category for cache key
+    "engineer": "tech", "developer": "tech", "designer": "tech",
+    "artist": "arts", "musician": "arts", "writer": "arts",
+    "banker": "finance", "trader": "finance", "analyst": "finance",
+    "nurse": "healthcare", "doctor": "healthcare",
+    "student": "student",
+    "barista": "service", "server": "service", "retail": "service",
+}
+"""Coarse occupation categorization for backstory cache key.
+Original full string preserved in profile.occupation; this is for cache bucketing only.
+Prior values: none (new in Spec 213).
+Rationale: 6 categories balance cache hit ratio vs persona variety. Default: 'other'."""
+```
+
+Each constant has regression-guard test in `tests/onboarding/test_tuning_constants.py` asserting exact value + comment referencing GH issue.
+
+### FR-5: Pipeline-Readiness Endpoint
+**Priority**: P1
+**Description**: Add `GET /api/v1/onboarding/pipeline-ready/{user_id}` returning `PipelineReadyResponse`.
+
+**Auth**: requires user JWT (existing `get_current_user_id` dependency at `onboarding.py:139`). User can only query their own state. Cross-user access returns HTTP 403 with body `{"detail": "Not authorized"}` (matches existing pattern at `onboarding.py:140`). Unknown user_id returns HTTP 404 with body `{"detail": "User not found"}`.
+
+**Implementation**: reads `users.onboarding_profile.pipeline_state` JSONB key set by `_bootstrap_pipeline` per FR-5.1. Single SELECT query, p99 ≤200ms (NFR-1).
+
+**Response shape**: HTTP 200 body matches `PipelineReadyResponse`. Missing `pipeline_state` JSONB key (user exists but key absent) = `state="pending"` (not error).
+
+**Portal Behavior Contract** (consumed by Spec 214):
+| State | Portal Action |
+|---|---|
+| `pending` | Show "Nikita is getting ready..." spinner with ARIA `role="status"` + `aria-live="polite"` |
+| `ready` | Dismiss spinner, navigate to next step (backstory picker if backstory_options non-empty, else direct to handoff completion) |
+| `degraded` | Navigate forward with toast warning "Some personalization is still loading — Nikita will catch up shortly" |
+| `failed` | Show error banner with retry CTA; do not block redirect after 2 retries |
+
+**File location** (FR-13): this endpoint lives in NEW `nikita/api/routes/portal_onboarding.py`, not in the existing 34KB `onboarding.py`.
+
+#### FR-5.1: Pipeline State Write Contract (CRITICAL — was missing in iteration 1)
+**Description**: `_bootstrap_pipeline` at `nikita/onboarding/handoff.py:551-625` MUST write `pipeline_state` to `users.onboarding_profile` JSONB at every state transition:
+
+| Trigger | Write `pipeline_state` to |
+|---|---|
+| Function entry (after settings flag check, before `orchestrator.process`) | `"pending"` |
+| `orchestrator.process()` returns success | `"ready"` |
+| `orchestrator.process()` returns success but venue OR backstory was degraded (passed via context) | `"degraded"` |
+| `orchestrator.process()` raises exception | `"failed"` |
+| `_bootstrap_pipeline` re-entered with `pipeline_state == "ready"` | (no-op — idempotent per FR-11) |
+
+**Repository call**: `await user_repo.update_onboarding_profile_key(user_id, "pipeline_state", value)` — NEW method on `UserRepository` (FR-5.2).
+
+#### FR-5.2: UserRepository Helper
+**Description**: Add method `update_onboarding_profile_key(user_id: UUID, key: str, value: Any) -> None` to `nikita/db/repositories/user_repository.py` using `jsonb_set` for atomic single-key merge.
+
+**Required imports** (must be added to `user_repository.py`):
+```python
+import json
+from sqlalchemy import func, cast, update
+from sqlalchemy.dialects.postgresql import JSONB
+```
+
+**Implementation** (CRITICAL: `json.dumps` required — bare Python strings are NOT valid PostgreSQL jsonb literals; `cast("pending", JSONB)` produces `CAST('pending' AS jsonb)` which PostgreSQL rejects because unquoted `pending` is not JSON):
+```python
+stmt = update(User).where(User.id == user_id).values(
+    onboarding_profile=func.jsonb_set(
+        User.onboarding_profile,
+        f'{{{key}}}',
+        cast(json.dumps(value), JSONB),  # json.dumps produces '"pending"' — valid JSON
+        True  # create_missing
+    )
+)
+await session.execute(stmt)
+```
+`json.dumps("pending")` returns `'"pending"'` (a JSON string literal with quotes); `json.dumps(123)` returns `'123'`; `json.dumps(True)` returns `'true'`. All are valid JSON. Cast then succeeds.
+
+Atomic — concurrent writes to different keys do not race.
+
+**Alternative** (simpler but less atomic): fetch user row, merge `{key: value}` into `user.onboarding_profile` dict, flush. Matches existing `update_onboarding_profile()` pattern at `user_repository.py:622`. Acceptable if atomic jsonb_set proves problematic in testing.
+
+### FR-6: Enhanced FirstMessageGenerator
+**Priority**: P2
+**Description**: Extend `FirstMessageGenerator.generate()` (currently at `handoff.py:127`) to accept an optional backstory scenario.
+
+**New signature** (keyword-only param to avoid breaking existing call sites):
+```python
+def generate(
+    self,
+    profile: UserOnboardingProfile,
+    user_name: str = "you",  # preserved from existing default (handoff.py:132); only backstory_scenario is net-new
+    *,
+    backstory_scenario: BackstoryOption | None = None,
+) -> str:
+```
+
+When `backstory_scenario` is present, include `backstory_scenario.unresolved_hook` as a one-line coda at probability `BACKSTORY_HOOK_PROBABILITY` (FR-4 constant). All existing call sites (`execute_handoff`, `execute_handoff_with_voice_callback`) updated to pass the chosen scenario when available; default `None` keeps backwards compat.
+
+### FR-7: PII Handling + RLS Hardening
+**Priority**: P1
+**Description**:
+
+- **RLS hardening DDL** (ships in PR 213-2 migration alongside FR-1a/FR-12):
+  ```sql
+  -- Add WITH CHECK to UPDATE policy (currently null per DB verification)
+  ALTER POLICY "Users can update own profile" ON user_profiles
+      WITH CHECK (id = (SELECT auth.uid()));
+
+  -- Convert DELETE policy bare auth.uid() to subquery form (perf + consistency)
+  ALTER POLICY "Users can delete own profile" ON user_profiles
+      USING (id = (SELECT auth.uid()));
+  ```
+  Existing 5 policies on `user_profiles` cover new columns automatically (PostgreSQL is row-level, not column-level). Verify post-migration via `mcp__supabase__list_policies`.
+- **Log redaction**: structured logs in `nikita/api/routes/portal_onboarding.py`, `nikita/api/routes/onboarding.py`, `nikita/onboarding/handoff.py`, `nikita/services/portal_onboarding.py` MUST NOT include `name`, `age`, `occupation`, `phone` values. Allowed: `user_id`, boolean flags (`name_present=True`), enum values (`occupation_category="tech"`).
+- **Exception echoes**: `logger.error(f"...: {e}")` and `logger.error("...: %s", e)` MUST NOT receive exceptions whose `str(e)` contains PII. Use `logger.exception("...", extra={"user_id": str(user_id)})` instead.
+- **Pre-existing violation fixes** (in scope for PR 213-3): `nikita/api/routes/onboarding.py:154` and `:239` MUST be migrated to `logger.exception("...", extra={"user_id": str(user_id)})` pattern. Spec-identified security gaps cannot be deferred to "out of spec" per absolute-zero policy.
+
+### FR-8: Conversation Continuity Regression
+**Priority**: P1
+**Description**: Add `tests/onboarding/test_r8_conversation_continuity.py::test_no_denial_of_seeded_turn` proving user's #1 reported complaint cannot recur:
+- Mock seeded conversation with assistant turn `T = "Hey Anna, so you're in Berlin..."`
+- Patch `nikita.agents.text.agent.NikitaAgent.run` with `AsyncMock(return_value=MagicMock(output="She seems interesting"))`.
+- Simulate user reply `f"You said: {T}"`
+- Run pipeline (mocked agent) for N=10 iterations
+- Assert each iteration: `re.search(r"I never said|you must be mistaken", result, re.IGNORECASE) is None`
+- Assert text agent's prompt history includes `T` as assistant turn (verify via `mock_run.call_args.kwargs["messages"]` contains `{"role":"assistant","content":T}`)
+- Independent from FR-6 (R7 message-personalization)
+
+### FR-9: Re-Onboarding Detection
+**Priority**: P2
+**Description**: `save_portal_profile` detects re-onboarding via `users.onboarding_status != "completed" AND users.onboarding_profile != '{}'::jsonb` (using EXISTING `onboarding_status` field, NOT `onboarding_completed_at` — that column does not exist per data-layer validator D-C1).
+
+**Mechanism**: introduce `PATCH /api/v1/onboarding/profile` endpoint (NEW, in `portal_onboarding.py`) that:
+- Accepts partial `OnboardingV2ProfileRequest` (all fields optional)
+- Merges into existing JSONB via `jsonb_set` (does NOT reset existing fields)
+- Bypasses the `save_portal_profile` idempotency guard at `:752-769`
+- Re-triggers `_trigger_portal_handoff` only if `pipeline_state` is missing or `failed`
+
+On final submission via either POST or PATCH, backstory cache hit if `(city, scene, darkness, life_stage, interest, age_bucket, occupation_bucket)` matches prior key → no second Claude call.
+
+### FR-10: Voice-First User Routing
+**Priority**: P2
+**Description**: Spec 212 added phone-conditional routing in `_trigger_portal_handoff`. This spec preserves that contract: voice-first users go through the same wizard backend (city research + backstory still relevant for voice prompt personalization). Pre-call webhook auth mechanism (per Spec 212 HMAC) UNCHANGED — only the payload content changes (now includes `OnboardingV2ProfileResponse` shape).
+
+### FR-11: Pipeline Bootstrap Idempotence
+**Priority**: P2
+**Description**: `_bootstrap_pipeline` MUST be idempotent. Implementation: on entry, read `users.onboarding_profile.pipeline_state`. If `"ready"`, return immediately (log `pipeline_bootstrap.skip outcome="already_ready"`). If `"pending"` (concurrent bootstrap), return immediately (log `outcome="already_pending"`).
+
+**Test specification** (`tests/onboarding/test_pipeline_bootstrap.py::test_idempotent_double_call`):
+```python
+# Mock JSONB read returns None state on call 1, "ready" on call 2
+mock_user_repo.get.side_effect = [
+    MagicMock(onboarding_profile={}),                          # call 1: no state
+    MagicMock(onboarding_profile={"pipeline_state": "ready"}), # call 2: ready
+]
+# Two invocations:
+await manager._bootstrap_pipeline(user_id)  # processes
+await manager._bootstrap_pipeline(user_id)  # skips
+assert mock_orchestrator.process.call_count == 1
+```
+
+### FR-12: BackstoryCache Repository (DDL + ORM + Repo)
+**Priority**: P1
+**Description**: Persist backstory scenarios for cache reuse.
+
+**Migration** (file: `supabase/migrations/YYYYMMDDHHMMSS_create_backstory_cache.sql`):
+```sql
+CREATE TABLE backstory_cache (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    cache_key TEXT NOT NULL,
+    scenarios JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT uq_backstory_cache_key UNIQUE (cache_key)
+);
+CREATE INDEX idx_backstory_cache_expires ON backstory_cache(expires_at);
+
+-- RLS: deny by default; admin-only via existing is_admin() function
+ALTER TABLE backstory_cache ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Admins can manage backstory cache"
+    ON backstory_cache FOR ALL TO public
+    USING (is_admin()) WITH CHECK (is_admin());
+```
+
+**RLS rationale**: users do not query backstory_cache directly — only the backend facade does (via service role). `is_admin()` function already exists in the project (verified: used by `user_profiles` and `user_backstories` policies). Without explicit `ENABLE ROW LEVEL SECURITY` + policy, PostgreSQL leaves the table open to all authenticated users.
+
+**ORM** (`nikita/db/models/backstory_cache.py`):
+```python
+class BackstoryCache(Base):
+    __tablename__ = "backstory_cache"
+    id: Mapped[UUID] = mapped_column(PG_UUID, primary_key=True, default=uuid4)
+    cache_key: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    scenarios: Mapped[list[dict]] = mapped_column(JSONB, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
+    expires_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+```
+
+**Repository** (`nikita/db/repositories/backstory_cache_repository.py`) — returns raw `dict` envelope to keep `db/` layer free of domain contract types (matches `VenueCacheRepository` pattern at `profile_repository.py:397-482`):
+```python
+class BackstoryCacheRepository:
+    def __init__(self, session: AsyncSession): ...
+
+    async def get(self, cache_key: str) -> dict | None:
+        """Query-time filter: WHERE cache_key=? AND expires_at > NOW().
+        Returns envelope {scenarios: list[dict], venues_used: list[str]} on hit; None on miss/expired.
+        Facade is responsible for `[BackstoryOption.model_validate(d) for d in envelope['scenarios']]`."""
+
+    async def set(self, cache_key: str, envelope: dict, ttl_days: int) -> None:
+        """UPSERT with ON CONFLICT (cache_key) DO UPDATE SET scenarios=excluded.scenarios,
+        expires_at=NOW() + INTERVAL '<ttl_days> days'.
+        Envelope shape: {scenarios: [opt.model_dump(mode='json') for opt in options], venues_used: [v.name for v in venues_list]}
+        Facade serializes before calling."""
+```
+
+**Envelope rationale**: both `scenarios` (for BackstoryOption[]) and `venues_used` (for portal UI display) are needed on cache hit. Storing them together in one JSONB column avoids a second table query or a separate venue lookup on every cache hit. Matches the "keep repository layer simple with raw dicts; facade handles contract types" principle.
+
+**Layering rationale**: `db/repositories/` returns ORM-level types (raw dicts for JSONB, ORM objects for tables) — never domain contracts. The facade in `services/portal_onboarding.py` performs serialization/deserialization. This matches existing `VenueCacheRepository.store(venues: list[dict])` precedent and avoids cross-layer imports of `nikita.onboarding.contracts` from `nikita.db.repositories`.
+
+**TTL strategy**: query-time filter (`WHERE expires_at > NOW()`) — no background cleanup needed. Optional pg_cron job for storage hygiene only (not correctness).
+
+### FR-13: Route File Decomposition
+**Priority**: P1
+**Description**: `nikita/api/routes/onboarding.py` is 34KB serving 5 concerns (voice initiate, status, server-tool, webhook, portal profile). Adding FR-5 `/pipeline-ready` and FR-9 `PATCH /profile` would push to 7 concerns.
+
+**Action**: create NEW `nikita/api/routes/portal_onboarding.py` containing:
+- `POST /api/v1/onboarding/profile` (move from existing `onboarding.py`)
+- `PATCH /api/v1/onboarding/profile` (NEW per FR-9)
+- `GET /api/v1/onboarding/pipeline-ready/{user_id}` (NEW per FR-5)
+
+Existing voice-onboarding endpoints stay in `onboarding.py`. Both routers mounted under `/api/v1/onboarding/` prefix.
+
+**Router definition** (top of new `nikita/api/routes/portal_onboarding.py` — NO `prefix=` argument to avoid double-prefix collision with `include_router` below):
+```python
+from fastapi import APIRouter
+router = APIRouter(tags=["Portal Onboarding"])
+```
+(Matches existing `onboarding.py:43` pattern — prefix belongs to `include_router`, not `APIRouter()`.)
+
+**Router registration** (`nikita/api/main.py`, after existing onboarding router mount at line ~265):
+```python
+from nikita.api.routes import portal_onboarding
+app.include_router(
+    portal_onboarding.router,
+    prefix="/api/v1/onboarding",
+    tags=["Portal Onboarding"],
+)
+```
+Without this `include_router` call, the new route file exists but is unreachable.
+
+### FR-14: Session-Scope Safety Pattern
+**Priority**: P1
+**Description**: Background tasks MUST NOT receive request-scoped `AsyncSession` or repository instances. Pattern (modeled at `handoff.py:579-583`):
+```python
+async def background_task_body(user_id: UUID, **kwargs):
+    async with get_session_maker()() as session:  # fresh session
+        repo = SomeRepository(session)
+        # ... work
+        await session.commit()
+
+# Caller:
+background_tasks.add_task(background_task_body, user_id=user_id)  # no session/repo passed
+```
+
+**Action**: refactor `_trigger_portal_handoff` at `onboarding.py:821-827` to follow this pattern. Ship as part of FR-13's route move (atomic refactor).
+
+---
+
+## User Stories
+
+### US-1: New user completes portal onboarding with full profile
+**As a** new user signing up via the portal
+**I want to** provide my name, age, city, scene, occupation, life stage, interest, darkness level, and (optionally) phone
+**So that** Nikita's first message feels personal and references things I told her about myself
+
+**Acceptance Criteria**:
+- [ ] AC-1.1: `POST /onboarding/profile` accepts `name`, `age`, `occupation` without 422 error (test: `tests/api/routes/test_portal_onboarding.py::test_post_accepts_new_fields`)
+- [ ] AC-1.2: After submission, `users.onboarding_profile` JSONB contains all collected fields (test: integration via Supabase MCP read)
+- [ ] AC-1.3: After submission, `user_profiles` row contains `name`, `occupation`, `age` columns populated (test: same integration)
+- [ ] AC-1.4: Within 25 seconds of submission, the first Telegram message is received and contains at least 2 of {city, scene, occupation, name} (test: `tests/onboarding/test_e2e.py::test_full_profile_personalizes_first_message` marked `@pytest.mark.e2e` requiring Telegram MCP — NOT in unit CI gate)
+- [ ] AC-1.5: The first message references a backstory scenario hook OR (on degraded path) uses generic-but-personalized opener; never falls back to "So we meet again..." (test: `tests/onboarding/test_handoff.py::TestFirstMessageGeneratorWithBackstory::test_no_meta_opener` regex-asserts result against `r"So we meet again"`)
+
+**Priority**: P1
+
+### US-2: Pipeline-readiness gate prevents premature interaction
+**As a** new user who just submitted onboarding
+**I want to** see a "Nikita is getting ready..." indicator
+**So that** I don't message Nikita while her brain is still loading
+
+**Acceptance Criteria**:
+- [ ] AC-2.1: `GET /pipeline-ready/{user_id}` returns each `PipelineReadyState` value (test: `tests/api/routes/test_portal_onboarding.py::test_pipeline_ready_states` parametrized over 4 states; mock `user_repo.get.return_value.onboarding_profile = {"pipeline_state": state}`)
+- [ ] AC-2.2: Polling at 2s interval reaches a terminal state in 100% of test runs (test: `tests/onboarding/test_pipeline_gate_integration.py::test_polling_terminates`; mock `AsyncMock(side_effect=[{"pipeline_state":"pending"}]*4 + [{"pipeline_state":"ready"}])` over 5 calls; assert loop exits at iteration ≤5; sibling test with `[{"pipeline_state":"failed"}]` for immediate-exit; 10 trials in pytest parametrize)
+- [ ] AC-2.3: After 20s timeout (`PIPELINE_GATE_MAX_WAIT_S`), endpoint returns `state="degraded"` with `message` populated; do not block user indefinitely (test: same file, `test_max_wait_returns_degraded`)
+- [ ] AC-2.4: Auth: user A querying user B's `/pipeline-ready/B` returns 403 with body `{"detail": "Not authorized"}` (test: `test_cross_user_403_with_correct_body`)
+
+**Priority**: P1
+
+### US-3: City research times out without breaking onboarding
+**As a** user from an obscure city not in the Firecrawl cache
+**I want to** still finish onboarding even if venue research times out
+**So that** I'm not blocked by an external service issue
+
+**Acceptance Criteria**:
+- [ ] AC-3.1: With `VenueResearchService.research_venues` mocked to sleep 30s, `portal_onboarding.process(...)` returns within `VENUE_RESEARCH_TIMEOUT_S + 1s` (test: `tests/services/test_portal_onboarding_facade.py::test_venue_timeout`; uses `time.monotonic()` assertion)
+- [ ] AC-3.2: On venue timeout, `caplog` contains record with `event="portal_handoff.venue_research"` AND `outcome="timeout"` AND `error_class="TimeoutError"` (test: same file)
+- [ ] AC-3.3: First message still sends; uses scene-only flavor (test: `test_first_message_falls_back_to_scene_only`)
+- [ ] AC-3.4: `pipeline_state` advances to `"degraded"` (not `"failed"`) — test: `caplog` and JSONB-read mock
+
+**Priority**: P1
+
+### US-4: Backstory generation fails gracefully
+**As a** user
+**I want to** still get a personalized first message even if Claude is rate-limited or down
+**So that** the experience degrades, not breaks
+
+**Acceptance Criteria**:
+- [ ] AC-4.1: With `BackstoryGeneratorService.generate_scenarios` mocked to raise `RuntimeError`, `portal_onboarding.process(...)` returns `[]` (test: `test_backstory_failure_returns_empty`; patch `nikita.services.backstory_generator.BackstoryGeneratorService.generate_scenarios`)
+- [ ] AC-4.2: First message uses default persona prompt (no scenario-specific) but still includes city/scene/occupation flavor (test: `test_first_message_keeps_flavor_on_backstory_fail`)
+- [ ] AC-4.3: `caplog` contains `event="portal_handoff.backstory"` AND `outcome="failure"` AND `error_class="RuntimeError"` AND no PII (test: `test_backstory_failure_log_no_pii`)
+- [ ] AC-4.4: `pipeline_state` advances to `"degraded"`
+
+**Priority**: P1
+
+### US-5: User replies with first-message verbatim, Nikita acknowledges
+**As a** user testing if Nikita remembers what she said
+**I want** Nikita to acknowledge her own prior turn when I quote it back
+**So that** the experience feels coherent (not the broken "I never said that" bug)
+
+**Acceptance Criteria**:
+- [ ] AC-5.1: Given a seeded conversation with assistant turn `T`, user replies `f"You said: {T}"`, the pipeline run loads `T` into history (test: `tests/onboarding/test_r8_conversation_continuity.py::test_loads_seeded_turn`; mock `ConversationRepository.get` returning conv with `[T]`)
+- [ ] AC-5.2: The text agent's prompt includes the prior assistant turn (test: same file, `test_agent_receives_history`; assert `mock_run.call_args.kwargs["messages"]` contains `{"role":"assistant","content":T}`)
+- [ ] AC-5.3: The response does not contain denial phrases (`"I never said"`, `"you must be mistaken"`) — N=10 mocked runs (test: same file, `test_no_denial_phrases`; patch `nikita.agents.text.agent.NikitaAgent.run` with `AsyncMock(return_value=MagicMock(output="She seems interesting"))`; loop 10x; assert `re.search(r"I never said|you must be mistaken", out, re.IGNORECASE) is None`)
+- [ ] AC-5.4: Independent from US-1 (test runs even if first-message generation produced generic opener)
+
+**Priority**: P1
+
+### US-6: Re-onboarding user resumes from last step
+**As a** user who started onboarding, closed the tab, and returned next day
+**I want to** resume from where I left off (not start over)
+**So that** I don't lose progress
+
+**Acceptance Criteria**:
+- [ ] AC-6.1: User with `users.onboarding_profile = {"wizard_step": 5, "location_city": "Berlin", ...}` and `onboarding_status != "completed"` → backend PRESERVES `wizard_step` in JSONB without overwriting (test: `tests/api/routes/test_portal_onboarding.py::test_patch_preserves_wizard_step` asserts JSONB read after PATCH still contains `wizard_step=5`). Spec 214 reads this key and navigates to step 5 — portal navigation tested in Spec 214, NOT here. Backend does NOT echo `wizard_step` in `OnboardingV2ProfileResponse` (frozen contract).
+- [ ] AC-6.2: `PATCH /onboarding/profile` accepts partial updates without resetting existing fields (test: `tests/api/routes/test_portal_onboarding.py::test_patch_merges_jsonb`)
+- [ ] AC-6.3: Backend returns `field=None` for missing new fields in response (test: `test_patch_returns_null_for_unset_fields`)
+- [ ] AC-6.4: On final submission, backstory cache hit if `cache_key` matches → no second Claude call (test: `tests/services/test_portal_onboarding_facade.py::test_cache_hit_skips_claude`)
+
+**Priority**: P2
+
+### US-7: Voice-first user routes correctly with full profile
+**As a** user who provided phone during onboarding
+**I want** the voice call to use my full profile (city, scene, occupation, backstory)
+**So that** the voice agent feels as personalized as the text agent would
+
+**Acceptance Criteria**:
+- [ ] AC-7.1: User with phone → `_trigger_portal_handoff` calls `execute_handoff_with_voice_callback` (existing test: `tests/onboarding/test_handoff_phone_routing.py::TestVoiceBranch`)
+- [ ] AC-7.2: The voice pre-call webhook receives `OnboardingV2ProfileResponse` containing all collected fields + chosen backstory option (test: `tests/api/routes/test_voice_pre_call_webhook.py::test_payload_includes_v2_profile_response`)
+- [ ] AC-7.3: Voice agent's system prompt includes city/scene/occupation/backstory hooks (test: `tests/onboarding/test_handoff.py::TestFirstMessageGeneratorWithBackstory::test_voice_prompt_includes_backstory`; pass `BackstoryOption(unresolved_hook="Berghain eye contact", ...)` and assert `"Berghain"` in result when `BACKSTORY_HOOK_PROBABILITY` patched to 1.0; assert absent when patched to 0.0)
+- [ ] AC-7.4: On voice-callback failure, fallback to Telegram first message (existing per Spec 212)
+
+**Priority**: P2
+
+---
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- `portal_onboarding.process(...)` p95 latency: ≤ `VENUE_RESEARCH_TIMEOUT_S + BACKSTORY_GEN_TIMEOUT_S + 5s` = 40s end-to-end (cold path)
+- `/pipeline-ready` endpoint: p99 latency ≤ 200ms (single JSONB read)
+- Backstory cache hit ratio target: ≥ 60% after 30 days of traffic on the top-10 city/scene combinations
+
+### NFR-2: Cost
+- `BackstoryGenerator` Claude cost ≤ $0.05 per unique profile shape (Haiku at $0.25/MTok input, ≤200 tokens prompt)
+- `VenueResearchService` Firecrawl cost ≤ $0.02 per unique city
+- Budget alert: >100 unique cities/day → log warning + investigate
+
+### NFR-3: Observability
+Structured log keys for every facade outcome (all values are server-side, emitted once per call):
+
+| Event | Fields |
+|---|---|
+| `portal_handoff.venue_research` | `event, user_id, outcome, duration_ms, cache_hit, error_class` (outcome ∈ {`success`, `timeout`, `failure`, `cache_hit`}; `error_class: str \| None`) |
+| `portal_handoff.backstory` | `event, user_id, outcome, duration_ms, cache_hit, scenario_count, error_class` (`scenario_count: int = len(scenarios)`) |
+| `pipeline_bootstrap` | `event, user_id, outcome, pipeline_state` (outcome ∈ {`processed`, `skip_already_ready`, `skip_already_pending`, `failed`}) |
+| `pipeline_ready.request` | `event, user_id, state, requesting_user_id` (server-side per request; client-side metrics like `attempts`/`total_wait_ms` are emitted by Spec 214's portal telemetry, NOT here) |
+
+Cloud Run log query: `resource.labels.service_name="nikita-api" AND jsonPayload.event=~"portal_handoff|pipeline_(bootstrap|ready)"`
+
+### NFR-4: Reliability
+- All async service calls wrapped in `asyncio.wait_for(...)` with named timeout constants from FR-4
+- All exception handlers use specific types (no bare `except Exception` at boundaries unless logging then re-raising)
+- Pipeline bootstrap is idempotent (FR-11)
+- Background tasks open fresh DB sessions (FR-14)
+
+### NFR-5: Security / PII
+- See FR-7
+
+### NFR-6: Backwards Compatibility
+- Existing voice-onboarded users continue without migration
+- New nullable columns on `user_profiles` do not break existing rows
+- `PortalProfileRequest` new fields are optional; old portal client (pre-Spec 214) continues to work
+- `name` JSONB key with one-cycle fallback to `user_name` for in-flight users
+
+### NFR-7: Coverage
+- `nikita/onboarding/contracts.py` — 100% line coverage (frozen contract)
+- `nikita/onboarding/tuning.py` — 100% line coverage (regression guards)
+- `nikita/services/portal_onboarding.py` — ≥90% line + branch coverage
+- `nikita/api/routes/portal_onboarding.py` — ≥85% line coverage
+- `nikita/onboarding/adapters.py` — 100% line coverage
+
+**CI command** for spec-related runs (split into 2 commands to enforce per-module thresholds):
+```bash
+# Strict 100% modules — fail-under separately
+pytest --cov=nikita.onboarding.contracts --cov=nikita.onboarding.tuning \
+       --cov=nikita.onboarding.adapters --cov-fail-under=100
+
+# Mixed-threshold modules — use coverage config (pyproject.toml [tool.coverage.report] section)
+pytest --cov=nikita.services.portal_onboarding \
+       --cov=nikita.api.routes.portal_onboarding --cov-fail-under=85
+```
+
+Per-module enforcement above 85% requires `[tool.coverage.report]` config in `pyproject.toml`:
+```toml
+[tool.coverage.report]
+fail_under = 85  # global floor
+# Per-module 90% for portal_onboarding facade enforced via separate test step or coverage badge
+```
+
+Acceptable: combined `--cov-fail-under=85` with manual review of per-module coverage report. Strict per-file enforcement (90% for facade) is a Phase 9 polish, not a Phase 8 blocker.
+
+---
+
+## Test Strategy
+
+### Test File Inventory (named in spec for TDD readiness)
+
+| File | Purpose | Marker |
+|---|---|---|
+| `tests/onboarding/test_tuning_constants.py` | Regression guards on every constant in `tuning.py`. Compound constants (`AGE_BUCKETS` tuple-of-tuples, `OCCUPATION_CATEGORIES` dict) use deep-equality assertion AND explicit boundary tests (e.g., `assert age_to_bucket(24) == "young_adult"`, `assert age_to_bucket(25) == "twenties"` — verifies inclusive edges). Includes `test_compute_backstory_cache_key_signature` asserting function lives at `nikita.onboarding.tuning.compute_backstory_cache_key`. | unit |
+| `tests/onboarding/test_contracts.py` | Pydantic validation of all 6 contract types | unit |
+| `tests/onboarding/test_adapters.py` | `ProfileFromOnboardingProfile.from_pydantic` field mapping | unit |
+| `tests/services/test_portal_onboarding_facade.py` | facade.process happy/timeout/failure/cache-hit + PII redaction caplog | integration (uses asyncio mocks) |
+| `tests/services/test_backstory_cache_repository.py` | upsert + TTL filter + cache_key uniqueness | unit |
+| `tests/api/routes/test_portal_onboarding.py` | POST + PATCH + GET pipeline-ready + 403/404 | integration (FastAPI TestClient) |
+| `tests/onboarding/test_pipeline_gate_integration.py` | ASGI-level blocking gate (SC-2 end-to-end) | integration (ASGI transport) |
+| `tests/onboarding/test_pipeline_bootstrap.py` | extend with `test_idempotent_double_call`, `test_writes_pipeline_state_*` | unit |
+| `tests/onboarding/test_handoff.py` | extend with `TestFirstMessageGeneratorWithBackstory` | unit |
+| `tests/onboarding/test_r8_conversation_continuity.py` | NEW — N=10 denial-phrase regex test | unit |
+| `tests/onboarding/test_log_observability.py` | NEW — caplog assertions for all 4 NFR-3 events | unit |
+| `tests/db/test_rls_user_profiles.py` | NEW — 5 RLS policies on new columns | integration (live Supabase) |
+| `tests/onboarding/test_e2e.py` | extend `test_full_profile_personalizes_first_message` | e2e (Telegram MCP) |
+| `tests/api/routes/test_voice_pre_call_webhook.py` | NEW — `test_payload_includes_v2_profile_response` (AC-7.2) verifies pre-call webhook receives `OnboardingV2ProfileResponse` shape | unit |
+| `tests/services/test_portal_onboarding_facade.py` (extend) | `test_portal_onboarding_session_isolation` proves facade NEVER opens own session (FR-14 risk mitigation); calls facade with mocked session, asserts `get_session_maker` not invoked inside | unit |
+| `tests/services/test_preview_backstory.py` (FR-4a facade unit tests) | `test_cache_key_stable` (same inputs → identical cache_key), `test_degraded_returns_empty` (backstory service failure → `degraded=True`, `scenarios=[]`, `venues_used=<venue_names>`) | unit |
+| `tests/api/routes/test_preview_backstory_route.py` (FR-4a route integration) | `test_profile_post_reuses_cache` (cross-endpoint cache coherence: preview → POST profile reuses cache, no duplicate Claude call), `test_rate_limit` (6th call in 1min returns 429 with `Retry-After: 60`), `test_stateless_no_jsonb_write` (preview does NOT mutate users.onboarding_profile) | integration (FastAPI TestClient) |
+
+### Test Pyramid Target
+- Unit (~70%): tuning constants, contracts validation, adapters, FirstMessageGenerator branches
+- Integration (~25%): facade with mocks, pipeline gate ASGI, RLS
+- E2E (~5%): full profile → first message via Telegram MCP
+
+### Patch Convention
+Per `.claude/rules/testing.md` patch-source-module rule: patch at source module, not importer. Examples:
+- `patch("nikita.services.venue_research.VenueResearchService.research_venues", ...)`
+- `patch("nikita.services.backstory_generator.BackstoryGeneratorService.generate_scenarios", ...)`
+- `patch("nikita.agents.text.agent.NikitaAgent.run", new_callable=AsyncMock)`
+
+### Non-Empty Fixture Compliance
+Every test mocking a query result MUST provide at least one non-empty path. AC-2.2 explicitly lists `side_effect=[...]` to avoid vacuous-pass. FR-11 idempotence test uses `side_effect=[state_none, state_ready]` (NOT `return_value=None`).
+
+---
+
+## Constraints & Assumptions
+
+- Cloud Run scale-to-zero: cold starts add up to 5s — measured with `gcloud run services describe`
+- Firecrawl + Claude API keys available in environment (already configured for Telegram path)
+- Supabase RLS already enforced on `user_profiles` (verified)
+- Pydantic `UserOnboardingProfile` already has `occupation` (`models.py:87`) AND `age` (`models.py:122`) fields — only `name` is net-new
+- `BackstoryGeneratorService.generate_scenarios` accepts `UserProfile` ORM-shape — adapter required (FR-3.1)
+- `users.onboarding_completed_at` column DOES NOT exist (verified via Supabase MCP); FR-9 uses existing `onboarding_status` field instead
+- PR #277 (recovery) is the basis for this spec — assumes `_seed_conversation`, `build_profile_from_jsonb`, JSONB persistence, voice-path bootstrap are all on master
+- Migration naming convention: `YYYYMMDDHHMMSS_name` (project standard, latest: `20260409185138`)
+- Existing `_ProfileFromAnswers` adapter at `nikita/platforms/telegram/onboarding/handler.py:41-56` will be promoted
+
+---
+
+## Out of Scope
+
+- Portal UI changes — owned by Spec 214
+- Voice agent prompt template structural changes beyond consuming new contracts
+- New analytics dashboards for backstory adoption
+- A/B testing of backstory personalization vs generic
+- Migration of existing voice-onboarded users to populate `name`/`age`/`occupation` retroactively (will prompt on next portal visit if missing)
+- Multi-language support for backstory scenarios (English only)
+- `wizard_step` JSONB key WRITE — owned by Spec 214 (this spec only documents that the backend reads it for resume detection)
+- Background pg_cron cleanup of expired BackstoryCache rows — query-time filter is sufficient; cleanup is hygiene-only
+
+(PII exception-echo fixes at `onboarding.py:154` and `:239` ARE in scope — see FR-7 + Implementation Notes. Previously listed here in error; removed iter-4.)
+
+---
+
+## Open Questions
+
+(All questions resolved — zero `[NEEDS CLARIFICATION]` markers)
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `BackstoryGenerator` Claude rate-limit on launch day | Medium | High | 30-day cache; backstory degraded path; circuit-breaker pattern wraps Claude calls |
+| `VenueResearchService` Firecrawl auth failure | Low | High | 30-day cache; fallback to scene-only first message; alert on 5xx rate >10% |
+| Pydantic vs ORM type confusion in facade | Low | High | Promoted shared adapter (FR-3.1); single source of truth |
+| `OnboardingV2ProfileRequest` contract churn delays Spec 214 | Medium | High | Ship contracts.py in PR #1; mark frozen; require ADR for any change |
+| PII leak in exception echoes | Medium | High | FR-7 + log redaction unit tests + `rg` audit; pre-existing fixed in Phase 8 |
+| Pipeline gate timeout (20s) too short for slow Claude | Low | Medium | NFR-1 budget includes margin; observability surfaces real p95 |
+| Bug in facade leaks ORM session across requests | Low | Critical | FR-14 explicit pattern; integration test `test_portal_onboarding_session_isolation` |
+| `pipeline_state` JSONB write race condition (concurrent bootstrap) | Low | Medium | FR-11 idempotence + `jsonb_set` atomic merge per FR-5.2 |
+| BackstoryCache table grows unbounded | Low | Low | TTL via query-time filter; optional pg_cron cleanup as hygiene |
+| Migration ordering conflict with existing `YYYYMMDDHHMMSS_*` files | Low | Low | Use timestamp at PR creation time; verify ordering manually |
+
+---
+
+## Implementation Notes (for plan.md)
+
+- 5-PR decomposition target (each ≤400 LOC):
+  - **PR 213-1**: `contracts.py` + `tuning.py` + adapter + tests (frozen contract surface for Spec 214 to begin)
+  - **PR 213-2**: Migration (user_profiles columns + backstory_cache table) + ORM additions + repository
+  - **PR 213-3**: facade `portal_onboarding.py` + `_trigger_portal_handoff` rewire + tests (FR-3, FR-7, NFR-3)
+  - **PR 213-4**: route file `portal_onboarding.py` + `/pipeline-ready` + `PATCH /profile` + FR-14 session pattern
+  - **PR 213-5**: FirstMessageGenerator FR-6 + R8 regression test + e2e + ROADMAP sync to COMPLETE
+- TDD: tests committed BEFORE implementation per Article IX
+- Authoritative PR mapping for in-scope fixes:
+  - FR-7 PII fixes at `nikita/api/routes/onboarding.py:154, :239` — **in scope, PR 213-3**
+  - FR-7 RLS DDL (WITH CHECK on UPDATE, subquery form on DELETE) — **in scope, PR 213-2**
+  - NO Phase-8/out-of-scope deferral exists for these fixes (per absolute-zero policy). Any prior "out of spec" reference in this document is stale and must be ignored.
+
+---
+
+## Quality Gates (Self-Check)
+
+- [x] FR Coverage: 14 functional requirements (>= 3)
+- [x] AC Minimum: each user story has ≥4 ACs (>= 2)
+- [x] Testability: every AC names a test file + assertion type
+- [x] No Ambiguity: 0 [NEEDS CLARIFICATION] markers
+- [x] Article I (Intelligence-First): plan-rewrite + sub-research + 6 validators in iteration 1
+- [x] Article III (Test-First): all ACs name test files; FR-8, US-5 explicitly require tests-first
+- [x] Article IV (Spec-First): this is the spec; plan.md follows
+- [x] Iteration 1 validator findings: all 60 addressed in this rewrite (CRITICAL fixes via FR-1c/d, FR-5.1, FR-12, FR-2 contract bodies; HIGH fixes via FR-3.1 adapter, FR-13 route split, FR-14 session pattern; MEDIUM/LOW fixes via test file naming, coverage thresholds, log schema, migration naming)

--- a/specs/213-onboarding-backend-foundation/tasks.md
+++ b/specs/213-onboarding-backend-foundation/tasks.md
@@ -1,0 +1,500 @@
+# Tasks: 213-onboarding-backend-foundation
+
+**Plan**: plan.md | **Spec**: spec.md | **Total**: 51 tasks | **Completed**: 0
+**Decomposition**: 5 PRs × ~7-12 tasks each. TDD pairs (test-commit + impl-commit) enforced per Article IX/X.
+
+## Progress Summary
+
+| Group | Tasks | Done | PR | Status |
+|-------|-------|------|----|----|
+| Phase 0 Setup | 2 | 0 | 213-1 | Pending |
+| US-1 (P1) | 9 + TG-1 | 0 | 213-1, 213-2, 213-5 | Pending |
+| US-2 (P1) | 6 + TG-2 | 0 | 213-1, 213-4 | Pending |
+| US-3 (P1) | 4 + TG-3 | 0 | 213-3, 213-5 | Pending |
+| US-4 (P1) | 4 + TG-4 | 0 | 213-3, 213-5 | Pending |
+| US-5 (P1) | 4 + TG-5 | 0 | 213-5 | Pending |
+| US-6 (P2) | 5 + TG-6 | 0 | 213-4 | Pending |
+| US-7 (P2) | 3 + TG-7 | 0 | 213-5 | Pending |
+| FR-4a preview | 4 | 0 | 213-3, 213-4 | Pending |
+| PII + RLS | 3 | 0 | 213-2, 213-3 | Pending |
+| Bootstrap idempotence + session | 3 | 0 | 213-3 | Pending |
+| Finalization | TD-1 | 0 | 213-5 | Pending |
+
+---
+
+## Phase 0: Setup
+
+### T0.1: Branch per PR + worktree
+- **Status**: [ ] Pending
+- **Priority**: P0
+- **Est**: S | **Deps**: None
+- **Steps**:
+  - [ ] T0.1.1: `git checkout -b feat/213-1-contracts` (PR 213-1 base)
+  - [ ] T0.1.2: Additional branches created at PR start: `feat/213-2-migration`, `feat/213-3-facade`, `feat/213-4-routes`, `feat/213-5-firstmsg-e2e`
+- **ACs**:
+  - [ ] Branch feat/213-1-contracts exists; HEAD on master at start
+
+### T0.2: Import path scaffolding
+- **Status**: [ ] Pending
+- **Priority**: P0
+- **Est**: S | **Deps**: T0.1 | **[P]**: —
+- **Steps**:
+  - [ ] T0.2.1: Create empty module files `nikita/onboarding/{contracts,tuning,adapters}.py` with 1-line docstring each
+  - [ ] T0.2.2: Add to `nikita/onboarding/__init__.py` exports (stubs)
+  - [ ] T0.2.3: Verify `python -c "from nikita.onboarding import contracts, tuning, adapters"` succeeds
+- **ACs**:
+  - [ ] Imports succeed; no circulars
+
+---
+
+## US-1: New user completes portal onboarding with full profile (P1)
+
+**Story**: As a new user signing up via the portal, I want to provide name/age/city/scene/occupation/life_stage/interest/darkness/phone, so that Nikita's first message feels personal.
+**Parent ACs**: AC-1.1 through AC-1.5
+
+### T1.1: OnboardingV2ProfileRequest + Response in contracts.py (PR 213-1)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T0.2 | **[P]**: with T1.2, T2.1
+- **TDD Steps**:
+  - [ ] T1.1.R: Write `tests/onboarding/test_contracts.py::test_v2_profile_request_rejects_bad_age` + `test_accepts_name_age_occupation` (failing)
+  - [ ] T1.1.V1: Verify FAIL (NameError or ImportError on contracts classes)
+  - [ ] T1.1.G: Implement `OnboardingV2ProfileRequest/Response` per spec FR-2 bodies
+  - [ ] T1.1.V2: `pytest tests/onboarding/test_contracts.py -x` PASS
+  - [ ] T1.1.B: Refactor if shared validators emerge
+  - [ ] T1.1.C1: `test(onboarding): contracts v2 profile request/response tests`
+  - [ ] T1.1.C2: `feat(onboarding): add OnboardingV2ProfileRequest/Response contracts`
+- **ACs**:
+  - [ ] AC-T1.1.1: `contracts.py` standalone (no `nikita.onboarding.models`, `nikita.db`, `nikita.engine.constants` imports)
+  - [ ] AC-T1.1.2: Pydantic field validators reject age<18, bad phone, empty city
+  - [ ] AC-T1.1.3: Response includes `chosen_option: None` default
+
+### T1.2: BackstoryOption + tone Literal in contracts.py (PR 213-1)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T0.2 | **[P]**: with T1.1, T2.1
+- **TDD Steps**:
+  - [ ] T1.2.R: `test_backstory_option_tone_literal_validates` (rejects bad tone string)
+  - [ ] T1.2.V1: Verify FAIL
+  - [ ] T1.2.G: Define `BackstoryOption` with `tone: Literal["mysterious","playful","tender","electric"]`
+  - [ ] T1.2.V2: PASS
+  - [ ] T1.2.C1: `test(onboarding): BackstoryOption tone validator`
+  - [ ] T1.2.C2: `feat(onboarding): add BackstoryOption contract`
+
+### T1.3: Tuning constants + compute_backstory_cache_key in tuning.py (PR 213-1)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T0.2 | **[P]**: with T1.1, T1.2
+- **TDD Steps**:
+  - [ ] T1.3.R: `tests/onboarding/test_tuning_constants.py` — deep-equality on `AGE_BUCKETS`, `OCCUPATION_CATEGORIES`; boundary tests `age_to_bucket(24)=="young_adult"`, `age_to_bucket(25)=="twenties"`; `test_compute_backstory_cache_key_signature` asserts function at `nikita.onboarding.tuning`
+  - [ ] T1.3.V1: Verify FAIL
+  - [ ] T1.3.G: Implement per spec FR-4
+  - [ ] T1.3.V2: PASS
+  - [ ] T1.3.C1: `test(onboarding): tuning constants regression + cache_key`
+  - [ ] T1.3.C2: `feat(onboarding): tuning constants + compute_backstory_cache_key`
+- **ACs**:
+  - [ ] AC-T1.3.1: All 4 Final constants documented with prior values (per .claude/rules/tuning-constants.md)
+  - [ ] AC-T1.3.2: No `nikita.engine.constants` import in tuning.py
+
+### T1.4: ProfileFromOnboardingProfile adapter (PR 213-1)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T1.1, T1.3 | **[P]**: —
+- **TDD Steps**:
+  - [ ] T1.4.R: `tests/onboarding/test_adapters.py::test_from_pydantic_field_mapping` — assert returned dataclass has `.city` (NOT `.location_city`) and `.primary_passion` (NOT `.primary_interest`)
+  - [ ] T1.4.V1: FAIL (duck-typed attributes missing)
+  - [ ] T1.4.G: Implement `ProfileFromOnboardingProfile.from_pydantic` returning `BackstoryPromptProfile` dataclass
+  - [ ] T1.4.V2: PASS
+  - [ ] T1.4.C1: `test(onboarding): adapter field-mapping`
+  - [ ] T1.4.C2: `feat(onboarding): ProfileFromOnboardingProfile + BackstoryPromptProfile`
+- **ACs**:
+  - [ ] AC-T1.4.1: Adapter replaces `_ProfileFromAnswers` at `nikita/platforms/telegram/onboarding/handler.py:41-56` (removed in subsequent task)
+
+### T1.5: Migration — user_profiles columns + backstory_cache (PR 213-2)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: M | **Deps**: T1.1 merged in PR 213-1
+- **TDD Steps**:
+  - [ ] T1.5.R: `tests/db/test_rls_user_profiles.py::test_new_columns_queryable_with_rls` (skips if no live Supabase)
+  - [ ] T1.5.V1: Verify FAIL (columns missing)
+  - [ ] T1.5.G: Apply migration via Supabase MCP `apply_migration`; DDL = ADD COLUMN + backstory_cache CREATE TABLE + RLS policies (subquery form on DELETE, WITH CHECK on UPDATE)
+  - [ ] T1.5.V2: PASS; verify via `list_tables` MCP
+  - [ ] T1.5.C1: `test(db): RLS + new columns integration tests`
+  - [ ] T1.5.C2: `feat(db): migration add profile fields + backstory_cache`
+- **ACs**:
+  - [ ] AC-T1.5.1: Migration filename follows `YYYYMMDDHHMMSS_*` convention
+  - [ ] AC-T1.5.2: `backstory_cache` has RLS ENABLED + admin-only `is_admin()` policy
+  - [ ] AC-T1.5.3: 5 existing user_profiles policies cover new columns
+
+### T1.6: Mapped columns in nikita/db/models/profile.py (PR 213-2)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T1.5
+- **TDD Steps**:
+  - [ ] T1.6.R: unit test instantiating UserProfile with `name="X", occupation="Y", age=25`
+  - [ ] T1.6.V1: FAIL (no such attribute)
+  - [ ] T1.6.G: Add `Mapped[str | None]` columns
+  - [ ] T1.6.V2: PASS
+  - [ ] T1.6.C1: `test(db): UserProfile ORM new columns`
+  - [ ] T1.6.C2: `feat(db): add name/occupation/age to UserProfile ORM`
+
+### T1.8: BackstoryCache ORM model (PR 213-2) — FR-12 coverage
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T1.5 | **[P]**: with T1.6
+- **TDD Steps**:
+  - [ ] T1.8.R: unit test instantiating `BackstoryCache(cache_key="X", scenarios=[...], venues_used=[...], ttl_expires_at=...)`
+  - [ ] T1.8.V1: FAIL (class missing)
+  - [ ] T1.8.G: Create `nikita/db/models/backstory_cache.py` with ORM fields matching migration
+  - [ ] T1.8.V2: PASS
+  - [ ] T1.8.C1: `test(db): BackstoryCache ORM model`
+  - [ ] T1.8.C2: `feat(db): add BackstoryCache ORM`
+
+### T1.9: BackstoryCacheRepository (PR 213-2) — FR-12 coverage
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: M | **Deps**: T1.8
+- **TDD Steps**:
+  - [ ] T1.9.R: `tests/services/test_backstory_cache_repository.py` — get/set with TTL filter + cache_key uniqueness; return type `list[dict] | None` raw envelope (per AR2-L2 resolution)
+  - [ ] T1.9.V1: FAIL
+  - [ ] T1.9.G: Implement `nikita/db/repositories/backstory_cache_repository.py` — `get(cache_key) -> list[dict] | None` and `set(cache_key, scenarios: list[dict], ttl_days)`
+  - [ ] T1.9.V2: PASS
+  - [ ] T1.9.C1: `test(services): BackstoryCacheRepository`
+  - [ ] T1.9.C2: `feat(services): add BackstoryCacheRepository`
+- **ACs**:
+  - [ ] AC-T1.9.1: Returns raw `list[dict]`, NOT `list[BackstoryOption]` (matches VenueCacheRepository pattern)
+  - [ ] AC-T1.9.2: TTL filter at query-time (no pg_cron required)
+
+### T1.7: AC-1.5 FirstMessageGenerator meta-opener regex test (PR 213-5)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T5.1
+- **TDD Steps**:
+  - [ ] T1.7.R: `test_handoff.py::TestFirstMessageGeneratorWithBackstory::test_no_meta_opener` — regex asserts result does NOT match `r"So we meet again"`
+  - [ ] T1.7.V1: FAIL initially
+  - [ ] T1.7.G: Ensure FirstMessageGenerator never emits meta-opener
+  - [ ] T1.7.V2: PASS
+  - [ ] T1.7.C1–C2: test + impl commits
+
+### TG-1: Git Workflow for US-1
+- **Status**: [ ] Pending | **Trigger**: After T1.1–T1.7 done
+- **Steps**:
+  - [ ] TG-1.1: All US-1 tests green locally
+  - [ ] TG-1.2: Push PR 213-1 branch → `gh pr create` → `/qa-review --pr N` → absolute-zero → squash merge
+  - [ ] TG-1.3: Post-merge smoke via auto-dispatched subagent
+  - [ ] TG-1.4: Repeat for PR 213-2 portions, PR 213-5 portions
+
+---
+
+## US-2: Pipeline-readiness gate (P1)
+
+**Parent ACs**: AC-2.1 through AC-2.4
+
+### T2.1: PipelineReadyResponse + PipelineReadyState (PR 213-1)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T0.2 | **[P]**: with T1.1, T1.2
+- **TDD Steps**:
+  - [ ] T2.1.R: test `PipelineReadyState` Literal values (`pending|ready|degraded|failed`), `venue_research_status`, `backstory_available` defaults
+  - [ ] T2.1.V1: FAIL
+  - [ ] T2.1.G: Implement per FR-2a
+  - [ ] T2.1.V2: PASS
+  - [ ] T2.1.C1–C2: test + impl commits
+
+### T2.2: GET /pipeline-ready/{user_id} route (PR 213-4)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: M | **Deps**: T2.1, T3.2 merged
+- **TDD Steps**:
+  - [ ] T2.2.R: `test_pipeline_ready_states` parametrized over 4 states
+  - [ ] T2.2.V1: FAIL (404)
+  - [ ] T2.2.G: Implement route + JSONB read
+  - [ ] T2.2.V2: PASS
+  - [ ] T2.2.C1–C2
+
+### T2.3: Cross-user 403 body (PR 213-4)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T2.2 | **[P]**: with T2.4
+- **TDD Steps**: R→V1→G→V2 (AC-2.4 exact body shape `{"detail":"Not authorized"}`) → C1→C2
+
+### T2.4: Polling terminates + max_wait degraded (PR 213-4)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: M | **Deps**: T2.2 | **[P]**: with T2.3
+- **TDD Steps**:
+  - [ ] T2.4.R: ASGI-level test; `AsyncMock(side_effect=[{"pipeline_state":"pending"}]*4 + [{"pipeline_state":"ready"}])`; assert loop exits ≤5; sibling `[{"pipeline_state":"failed"}]` → immediate exit; 10 trials parametrize. Plus `test_max_wait_returns_degraded`
+  - [ ] rest of TDD + commits
+
+### T2.5: Venue/backstory status fields exposed (FR-2a tail)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T2.2
+- **TDD**: parametrize `venue_research_status` over (`pending|complete|degraded`), `backstory_available` over (True|False) → assert response shape
+
+### T2.6: main.py include_router registration (PR 213-4) — FR-13 coverage
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T2.2
+- **TDD Steps**:
+  - [ ] T2.6.R: integration test `tests/api/test_main_routes.py::test_portal_onboarding_router_registered` — request `GET /api/v1/onboarding/pipeline-ready/{uuid}` returns status ≠ 404
+  - [ ] T2.6.V1: FAIL (404)
+  - [ ] T2.6.G: Add to `nikita/api/main.py` lifespan: `app.include_router(portal_onboarding.router, prefix='/api/v1/onboarding', tags=['Portal Onboarding'])` after existing onboarding.router (line ~265)
+  - [ ] T2.6.V2: PASS
+  - [ ] T2.6.C1: `test(api): verify portal_onboarding router registered`
+  - [ ] T2.6.C2: `feat(api): register portal_onboarding.router in main.py`
+- **ACs**:
+  - [ ] AC-T2.6.1: Resolves architecture finding AR2-L1 (main.py registration)
+
+### TG-2: Git Workflow for US-2 → part of PR 213-4 merge
+
+---
+
+## US-3: City research timeout graceful (P1)
+
+### T3.1: Facade process() with VENUE_RESEARCH_TIMEOUT_S (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: M | **Deps**: T1.1–T1.6 merged
+- **TDD Steps**:
+  - [ ] T3.1.R: `test_venue_timeout` — patch `nikita.services.venue_research.VenueResearchService.research_venues` with sleep(30); assert `time.monotonic()` measured under `VENUE_RESEARCH_TIMEOUT_S + 1s`; assert caplog has `event="portal_handoff.venue_research"`, `outcome="timeout"`, `error_class="TimeoutError"`
+  - [ ] V1 FAIL; G implement `asyncio.wait_for` wrapper; V2 PASS
+  - [ ] C1–C2
+
+### T3.2: Pipeline state transitions in _bootstrap_pipeline (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: M | **Deps**: T3.1
+- **TDD**: FR-5.1 transitions (pending→ready, degraded, failed) all exercised; use `update_onboarding_profile_key` helper (FR-5.2)
+
+### T3.3: First message falls back to scene-only on timeout (PR 213-5)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T5.1
+- **TDD**: `test_first_message_falls_back_to_scene_only` (AC-3.3)
+
+### T3.4: pipeline_state="degraded" on timeout (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T3.2
+- **TDD**: caplog + JSONB-read mock asserts state=degraded (AC-3.4)
+
+### TG-3: part of PR 213-3 / 213-5 merges
+
+---
+
+## US-4: Backstory failure graceful (P1)
+
+### T4.1: Facade catches BackstoryGeneratorService exceptions → returns [] (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T3.1 | **[P]**: with T4.2
+- **TDD**: `test_backstory_failure_returns_empty` — patch `nikita.services.backstory_generator.BackstoryGeneratorService.generate_scenarios` → `RuntimeError` → assert `[]` (AC-4.1). C1–C2.
+
+### T4.2: Log redaction on backstory fail (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T4.1 | **[P]**: with T4.1
+- **TDD**: `test_backstory_failure_log_no_pii` — caplog contains event/outcome/error_class fields, NO PII fields (AC-4.3). C1–C2.
+
+### T4.3: pipeline_state="degraded" on backstory fail (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T3.2, T4.1
+- **TDD**: state transition assertion (AC-4.4)
+
+### T4.4: First message keeps flavor on backstory fail (PR 213-5)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T5.1
+- **TDD**: `test_first_message_keeps_flavor_on_backstory_fail` (AC-4.2). C1–C2.
+
+### TG-4: part of PR 213-3 / 213-5 merges
+
+---
+
+## US-5: R8 conversation continuity (P1)
+
+### T5.1: FirstMessageGenerator FR-6 (PR 213-5)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: M | **Deps**: T1.1, T3.2 merged
+- **TDD**: build_first_message consumes profile + scenarios; unit tests for each flavor branch (backstory hit, backstory empty, venue timeout). C1–C2.
+
+### T5.2: test_loads_seeded_turn (AC-5.1) (PR 213-5)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T5.1
+- **TDD**: mock `ConversationRepository.get` returning conv with `[T]`; assert history loaded. C1–C2.
+
+### T5.3: test_agent_receives_history (AC-5.2) (PR 213-5)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T5.1 | **[P]**: with T5.4
+- **TDD**: assert `mock_run.call_args.kwargs["messages"]` contains `{"role":"assistant","content":T}`. C1–C2.
+
+### T5.4: test_no_denial_phrases N=10 parametrize (AC-5.3) (PR 213-5)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T5.1 | **[P]**: with T5.3
+- **TDD**: patch `nikita.agents.text.agent.NikitaAgent.run` with `AsyncMock(return_value=MagicMock(output="..."))`; loop 10x; regex `r"I never said|you must be mistaken"` is None. C1–C2.
+
+### TG-5: part of PR 213-5 merge
+
+---
+
+## US-6: Re-onboarding resumes (P2)
+
+### T6.1: PATCH /onboarding/profile route (PR 213-4)
+- **Status**: [ ] Pending | **Priority**: P2 | **Est**: M | **Deps**: T3.1 merged
+- **TDD**: integration test — partial update preserves JSONB keys not in payload. C1–C2.
+
+### T6.2: test_patch_preserves_wizard_step (AC-6.1) (PR 213-4)
+- **Status**: [ ] Pending | **Priority**: P2 | **Est**: S | **Deps**: T6.1
+- **TDD**: JSONB read after PATCH still contains `wizard_step=5`; response does NOT echo `wizard_step` (not in frozen contract).
+
+### T6.3: test_patch_merges_jsonb (AC-6.2) (PR 213-4)
+- **Status**: [ ] Pending | **Priority**: P2 | **Est**: S | **Deps**: T6.1 | **[P]**: with T6.4
+
+### T6.4: test_patch_returns_null_for_unset_fields (AC-6.3) (PR 213-4)
+- **Status**: [ ] Pending | **Priority**: P2 | **Est**: S | **Deps**: T6.1 | **[P]**: with T6.3
+
+### T6.5: test_cache_hit_skips_claude (AC-6.4) cross-endpoint (PR 213-4)
+- **Status**: [ ] Pending | **Priority**: P2 | **Est**: M | **Deps**: T3.1, T6.1, TX.1
+- **TDD**: full flow preview→POST asserts Claude called EXACTLY ONCE.
+
+### TG-6: part of PR 213-4 merge
+
+---
+
+## US-7: Voice-first user routing (P2)
+
+### T7.1: Voice pre-call webhook consumes OnboardingV2ProfileResponse (PR 213-5)
+- **Status**: [ ] Pending | **Priority**: P2 | **Est**: S | **Deps**: T1.1, T5.1 merged
+- **TDD**: payload shape assertion
+
+### T7.2: test_payload_includes_v2_profile_response (AC-7.2) (PR 213-5)
+- **Status**: [ ] Pending | **Priority**: P2 | **Est**: S | **Deps**: T7.1
+
+### T7.3: test_voice_prompt_includes_backstory (AC-7.3) (PR 213-5)
+- **Status**: [ ] Pending | **Priority**: P2 | **Est**: S | **Deps**: T5.1, T7.1 | **[P]**: with T7.2
+- **TDD**: patch `BACKSTORY_HOOK_PROBABILITY` to 1.0 → assert `"Berghain"` in result; patch to 0.0 → assert absent.
+
+### TG-7: part of PR 213-5 merge
+
+---
+
+## Cross-cutting: FR-4a preview backstory endpoint
+
+### TX.1: POST /onboarding/preview-backstory + BackstoryPreviewRequest/Response (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: M | **Deps**: T1.1, T3.1
+- **TDD**: happy path: request returns scenarios + venues_used + cache_key + degraded=False. C1–C2.
+
+### TX.2: _PreviewRateLimiter overrides _get_minute_window() (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: TX.1
+- **TDD**: override returns `f"preview:{super()._get_minute_window()}"`; 6th call in 1min → 429 `Retry-After: 60`.
+
+### TX.3: facade unit tests (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: TX.1 | **[P]**: with TX.2
+- **TDD**:
+  - [ ] `test_cache_key_stable` (same inputs → identical cache_key)
+  - [ ] `test_degraded_returns_empty` (backstory service failure → `degraded=True`, `scenarios=[]`, `venues_used=<venue_names>`)
+
+### TX.4: route integration tests (PR 213-4)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: M | **Deps**: TX.1, T6.1
+- **TDD**:
+  - [ ] `test_profile_post_reuses_cache` (preview → POST profile reuses cache, no duplicate Claude call)
+  - [ ] `test_rate_limit` (6th call → 429 + Retry-After:60)
+  - [ ] `test_stateless_no_jsonb_write` (preview does NOT mutate users.onboarding_profile)
+
+---
+
+## Cross-cutting: PII + RLS + observability
+
+### TP.1: Fix PII echo at onboarding.py:154,:239 (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: None
+- **TDD**: `test_log_observability.py` caplog asserts NO PII fields (name/age/occupation/phone) in exception records; asserts `extra={"user_id": ...}` pattern. C1–C2.
+
+### TP.2: RLS DDL in migration (PR 213-2)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T1.5
+- **TDD**: `test_rls_user_profiles.py` asserts UPDATE policy `WITH CHECK (id = (SELECT auth.uid()))`; DELETE subquery form. Part of T1.5 DDL.
+
+### TP.3: NFR-3 log observability for 4 events (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: M | **Deps**: TP.1 | **[P]**: with TP.1
+- **TDD**: 4 events with schema: `portal_handoff.venue_research`, `portal_handoff.backstory`, `portal_handoff.pipeline_state_transition`, `portal_handoff.first_message_sent`.
+
+---
+
+## Cross-cutting: pipeline bootstrap idempotence (FR-11)
+
+### TB.1: _bootstrap_pipeline reads pipeline_state; skip if ready (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T3.2
+- **TDD**: `test_idempotent_double_call` uses `side_effect=[state_none, state_ready]` (NOT `return_value=None` per non-empty-fixture rule).
+
+### TB.2: Orchestrator signature unchanged (PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: TB.1 | **[P]**: with TB.1
+- **TDD**: assert orchestrator public signature untouched (AR-L1 resolved).
+
+### TB.3: Session isolation test (FR-14 coverage, PR 213-3)
+- **Status**: [ ] Pending | **Priority**: P1 | **Est**: S | **Deps**: T3.1
+- **TDD Steps**:
+  - [ ] TB.3.R: `tests/services/test_portal_onboarding_facade.py::test_portal_onboarding_session_isolation` — call facade.process(profile, session=mock); assert `get_session_maker` NOT invoked inside facade (patch `nikita.services.portal_onboarding.get_session_maker` and assert `.call_count == 0`)
+  - [ ] TB.3.V1: FAIL if facade spawns own session
+  - [ ] TB.3.G: verify facade accepts injected session only (FR-14)
+  - [ ] TB.3.V2: PASS
+  - [ ] TB.3.C1: `test(services): facade session isolation regression`
+  - [ ] TB.3.C2: follow-up impl commit if facade refactor required
+- **ACs**:
+  - [ ] AC-TB.3.1: Facade never creates its own `AsyncSession`; FR-14 pattern preserved
+
+---
+
+## Finalization
+
+### TD-1: Documentation Sync + ROADMAP update (PR 213-5)
+- **Status**: [ ] Pending | **Priority**: P0 | **Trigger**: After all US tasks complete
+- **Steps**:
+  - [ ] TD-1.1: Run `/doc-sync --focus implementation`
+  - [ ] TD-1.2: Review audit report
+  - [ ] TD-1.3: Apply all CRITICAL + HIGH + MEDIUM + LOW fixes (absolute-zero policy)
+  - [ ] TD-1.4: `/roadmap update 213 COMPLETE`
+  - [ ] TD-1.5: Update event-stream.md: `[ISO] MERGE: Spec 213 complete, all 5 PRs merged`
+  - [ ] TD-1.6: Move Spec 213 from `specs/` to `specs/archive/` ONLY IF superseded (not default — spec remains living)
+- **ACs**:
+  - [ ] Doc-sync audit generated; 0 findings across all severities
+  - [ ] ROADMAP.md shows Spec 213 = COMPLETE
+  - [ ] event-stream.md updated
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph LR
+    T0.1 --> T0.2
+    T0.2 --> T1.1
+    T0.2 --> T1.2
+    T0.2 --> T1.3
+    T0.2 --> T2.1
+    T1.1 --> T1.4
+    T1.3 --> T1.4
+    T1.4 --> T1.5
+    T1.5 --> T1.6
+    T1.1 --> T3.1
+    T1.6 --> T3.1
+    T3.1 --> T3.2
+    T3.2 --> T3.3
+    T3.2 --> T3.4
+    T3.1 --> T4.1
+    T4.1 --> T4.2
+    T4.1 --> T4.3
+    T1.1 --> T5.1
+    T3.2 --> T5.1
+    T5.1 --> T5.2
+    T5.1 --> T5.3
+    T5.1 --> T5.4
+    T5.1 --> T1.7
+    T5.1 --> T4.4
+    T2.1 --> T2.2
+    T3.2 --> T2.2
+    T2.2 --> T2.3
+    T2.2 --> T2.4
+    T2.2 --> T2.5
+    T3.1 --> T6.1
+    T6.1 --> T6.2
+    T6.1 --> T6.3
+    T6.1 --> T6.4
+    T6.1 --> T6.5
+    T1.1 --> T7.1
+    T5.1 --> T7.1
+    T7.1 --> T7.2
+    T7.1 --> T7.3
+    T1.1 --> TX.1
+    T3.1 --> TX.1
+    TX.1 --> TX.2
+    TX.1 --> TX.3
+    TX.1 --> TX.4
+    T6.1 --> TX.4
+    T3.2 --> TB.1
+    TB.1 --> TB.2
+    T1.5 --> TP.2
+    TP.1 --> TP.3
+    TG-1 --> TG-2 --> TG-3 --> TG-4 --> TG-5 --> TG-6 --> TG-7 --> TD-1
+```
+
+## Parallelization
+
+| Group | Tasks | Reason |
+|-------|-------|--------|
+| P1.A (PR 213-1) | T1.1, T1.2, T1.3, T2.1 | Independent contract definitions |
+| P3.A (PR 213-3) | TX.2, TX.3 | Post-TX.1 both independent |
+| P3.B (PR 213-3) | TP.1, TP.3 | Independent PII+log tasks |
+| P3.C (PR 213-3) | T4.1, T4.2 | Failure-path tests |
+| P3.D (PR 213-3) | TB.1, TB.2 | Bootstrap idempotence pair |
+| P4.A (PR 213-4) | T6.2, T6.3, T6.4 | All read-only after T6.1 |
+| P4.B (PR 213-4) | T2.3, T2.4 | Pipeline-ready sub-assertions |
+| P5.A (PR 213-5) | T5.3, T5.4, T7.3 | All read agent output, no mutation |
+
+## Task Organization Rules (Article V compliance)
+
+1. ✓ Tasks grouped by User Story (P1 US-1..5 → P2 US-6,7) + cross-cutting
+2. ✓ Deps explicit; no circular refs
+3. ✓ Every task links ≥1 AC
+4. ✓ No orphan tasks — all trace to spec FR or AC
+5. ✓ TDD steps on every T* implementation task
+6. ✓ TG-X per US; TD-1 finalization
+
+## Validation Self-Check
+
+- [x] Every AC (30 total) has an implementing task
+- [x] Every task has TDD steps (R→V1→G→V2→[B]→C1→C2)
+- [x] Every PR has its own branch (T0.1)
+- [x] TG-X per US + TD-1 doc-sync present
+- [x] Dependency graph is valid DAG (no cycles)
+- [x] Article IX TDD + Article X git workflow enforced inline

--- a/specs/213-onboarding-backend-foundation/validation-findings.md
+++ b/specs/213-onboarding-backend-foundation/validation-findings.md
@@ -1,0 +1,67 @@
+# Validation Findings Manifest — Spec 213 (GATE 2 FINAL)
+
+**Spec**: `specs/213-onboarding-backend-foundation/spec.md` (850+ lines, 14 FRs, 7 USs, 30 ACs)
+**User Policy**: ABSOLUTE ZERO across ALL severities (CRITICAL + HIGH + MEDIUM + LOW)
+**Final Status**: ✅ **PASS** — GATE 2 achieved
+**Iterations**: 5 (1 → 2 → 3 → 4 → 5)
+
+## Final Iteration Convergence
+
+| Validator | Iter 1 | Iter 2 | Iter 3 | Iter 4 | Iter 5 | Final |
+|---|---|---|---|---|---|---|
+| frontend | 0/0/2/2 | 0/0/0/1 | 0/0/0/0 | — | — | ✅ PASS |
+| data-layer | 1/3/5/4 | 0/1/1/1 | 0/0/0/0 | — | — | ✅ PASS |
+| testing | 0/3/5/3 | 0/0/2/2 | 0/0/0/0 | — | — | ✅ PASS |
+| architecture | 0/3/4/2 | 0/0/0/2 | 0/0/0/0 | — | — | ✅ PASS |
+| auth | 0/1/3/4 | 0/0/0/1 | 0/0/0/1 | 0/0/0/0 | — | ✅ PASS |
+| api | 3/6/4/2 | 1/2/2/2 | 2/2/0/0 | 0/0/1/0 | 0/0/0/0 | ✅ PASS |
+| **Totals** | **60** | **14** | **4** | **1** | **0** | |
+
+## Finding Resolution Summary
+
+**Iter 1 (60 findings)** — addressed by comprehensive spec rewrite:
+- All 4 CRITICAL fixed (3 API + 1 data-layer)
+- All 16 HIGH fixed (service wiring, adapter, RLS, schema, test infrastructure)
+- All 23 MEDIUM fixed (logging schema, re-onboarding, migration conventions, test files)
+- All 17 LOW fixed (imports, signatures, documentation gaps)
+
+**Iter 2 (14 new findings)** — iteration added its own issues:
+- 1 CRIT (BackstoryScenario→BackstoryOption conversion) → fixed FR-3.2
+- 2 HIGH (VenueResearchResult unpacking, cache_key function def) → fixed FR-3 step 5 + step 3
+- 4 MED + 7 LOW → fixed inline
+
+**Iter 3 (4 new findings)** — surfaced implementation bugs:
+- 2 CRIT (adapter return type `UserProfile` wrong — duck-typed required; `cast(value, JSONB)` invalid for strings)
+- 2 HIGH (missing `backstory_service` instantiation; Out-of-Scope contradiction)
+
+**Iter 4 (1 new finding)**:
+- 1 MED (router double-prefix risk if both `APIRouter(prefix=...)` and `include_router(prefix=...)`)
+
+**Iter 5**: CLEAN 0/0/0/0 ✅
+
+## Convergent Root Causes (Multi-Validator)
+
+Strong signals that emerged across multiple validators in iter 1:
+- `pipeline_state` write contract → API + Auth + Data-layer + Architecture all flagged → resolved via FR-5.1 + FR-5.2
+- 403 body shape → Frontend + API + Auth flagged → resolved via FR-5
+- Pydantic↔ORM adapter → API + Architecture flagged → resolved via FR-3.1 + BackstoryPromptProfile duck-typing
+- Contract type definitions → Frontend + API flagged → resolved via FR-2 complete bodies
+
+## GH Issues Created
+
+Per CLAUDE.md SDD rule 8: no CRITICAL/HIGH findings remain, so no GH issues needed.
+All MEDIUM findings addressed inline (no defer/accept decisions).
+All LOW findings addressed inline (none logged as residuals).
+
+## User Approval Checkbox
+
+- [ ] User reviewed spec.md end-to-end
+- [ ] User approved proceeding to Phase 5 (/plan 213)
+
+## Handoff to Phase 5
+
+Spec 213 GATE 2 complete. Next phase: `/plan 213` — author plan.md with:
+- 5-PR decomposition (213-1 through 213-5) per Spec § Implementation Notes
+- TDD task pairs per FR
+- Dependency DAG across PRs
+- Verification strategy per spec's Test Strategy section

--- a/specs/213-onboarding-backend-foundation/validation-reports/api.md
+++ b/specs/213-onboarding-backend-foundation/validation-reports/api.md
@@ -1,0 +1,123 @@
+# API Validation Report — Spec 213
+
+**Spec**: `specs/213-onboarding-backend-foundation/spec.md`
+**Status**: FAIL (iteration 2)
+**Timestamp**: 2026-04-14T17:30:00Z
+**Validator**: sdd-api-validator
+
+---
+
+## Summary
+
+| Severity | Count |
+|---|---|
+| CRITICAL | 1 |
+| HIGH | 2 |
+| MEDIUM | 2 |
+| LOW | 2 |
+
+**Iteration 1 recap**: All 3 CRITICAL + 6 HIGH + 4 MEDIUM + 2 LOW from iteration 1 are RESOLVED in this revision. The findings below are NEW gaps introduced by the iteration-2 rewrite (particularly FR-3 and FR-12).
+
+---
+
+## Critical Findings
+
+| ID | Category | Issue | Location | Recommendation |
+|---|---|---|---|---|
+| A-C1 | Response Schema | `BackstoryScenario → BackstoryOption` conversion completely unspecified: `generate_scenarios()` returns `BackstoryScenariosResult` (containing `list[BackstoryScenario]` dataclass, which has NO `id` field), but the facade's return type is `list[BackstoryOption]` (Pydantic, requires `id: str`). No conversion step, no `id` generation formula, and no tone validation (`BackstoryScenario.tone` is `str`; `BackstoryOption.tone` is `Literal["romantic","intellectual","chaotic"]`) are specified anywhere in the spec. | spec.md:168-181 (FR-3 step 5), backstory_generator.py:28-39 | Add a conversion function to FR-3 (or FR-12): `def _scenario_to_option(cache_key: str, index: int, s: BackstoryScenario) -> BackstoryOption: return BackstoryOption(id=hashlib.sha256(f"{cache_key}:{index}".encode()).hexdigest()[:12], venue=s.venue, context=s.context, the_moment=s.the_moment, unresolved_hook=s.unresolved_hook, tone=s.tone)` — define this in `portal_onboarding.py` and specify the id-generation formula explicitly. Also specify that `tone` from the LLM must match the Literal; add a fallback or validation step if LLM returns unexpected value. |
+
+---
+
+## High Findings
+
+| ID | Category | Issue | Location | Recommendation |
+|---|---|---|---|---|
+| A-H1 | Request Schema | `VenueResearchResult.venues` not unpacked in facade. FR-3 step 5 says: `await asyncio.wait_for(venue_service.research_venues(profile.city, profile.social_scene), ...)`, then passes the result as `venues` to `generate_scenarios(orm_profile, venues)`. But `research_venues()` returns `VenueResearchResult` (a dataclass with `.venues: list[Venue]` and `.fallback_used: bool`), NOT `list[Venue]`. `generate_scenarios(orm_profile, venues)` expects `list[Venue]` (actual signature at `backstory_generator.py:81`). Without unpacking, this produces a `TypeError` at runtime. Mocked unit tests will pass silently. | spec.md:177-179 (FR-3 step 5), venue_research.py:79-83, backstory_generator.py:81-85 | Fix FR-3 step 5 to read: "Assign result to `venue_result = await asyncio.wait_for(...)`. On success, extract `venues = venue_result.venues` and pass to backstory step. If `venue_result.fallback_used`, skip backstory generation and return `[]` (or proceed with empty venues — specify which)." |
+| A-H2 | Routes | `compute_backstory_cache_key` function called in FR-3 step 3 but never defined: no module path, no function signature, no cache key format string. The function uses `AGE_BUCKETS` and `OCCUPATION_CATEGORIES` from `tuning.py` but the bucketing algorithm (how to construct the final key string from city + scene + bucketed age + bucketed occupation) is unspecified. Without this, two implementors will produce incompatible cache keys, making the cache ineffective. | spec.md:174 (FR-3 step 3) | Add a concrete definition in FR-3 or FR-4: `def compute_backstory_cache_key(profile: UserOnboardingProfile) -> str` — specify key format as `f"{profile.city.lower()}:{profile.social_scene}:{_age_bucket(profile.age)}:{_occupation_bucket(profile.occupation)}"` (or equivalent) and place this function in `portal_onboarding.py` with helpers `_age_bucket(age) -> str` and `_occupation_bucket(occ) -> str`. List the module path explicitly. |
+
+---
+
+## Medium Findings
+
+| ID | Severity | Issue | Location | Recommendation |
+|---|---|---|---|---|
+| A-M1 | MEDIUM | `BackstoryCacheRepository.get()` deserialization contract unspecified. ORM column `scenarios: Mapped[list[dict]]` stores raw JSONB. The return type signature says `list[BackstoryOption] | None`, but no serialization/deserialization step is documented (e.g., `[BackstoryOption(**d) for d in row.scenarios]` on read, `.model_dump(mode="json")` on write). Same gap for `set()`. Implementors will correctly guess this, but inconsistency in how `id` field roundtrips (BackstoryOption.id stored in JSONB, retrieved correctly) needs to be explicit given that id generation depends on `cache_key + index`. | spec.md:423-432 (FR-12 repository) | Add to FR-12 repository section: "On `get()`: deserialize via `[BackstoryOption.model_validate(d) for d in row.scenarios]`. On `set()`: serialize via `[o.model_dump(mode='json') for o in scenarios]`. The `id` field is stored verbatim; do not regenerate on retrieval." |
+| A-M2 | MEDIUM | `chosen_option` in `OnboardingV2ProfileResponse` is described as "null until user picks" but no backend endpoint or mechanism exists to set it. The spec defines `POST /onboarding/profile`, `PATCH /onboarding/profile`, and `GET /pipeline-ready/{user_id}` — none of which accept a backstory choice. If this field is always `null` from the backend, its presence in the response contract is misleading. If the write mechanism is owned by Spec 214, the spec should say so explicitly. | spec.md:138 | Add a note: "The `chosen_option` field is always `null` in responses from this spec's endpoints. Spec 214 is responsible for defining the backstory selection endpoint (e.g., `POST /onboarding/backstory-choice`) that persists the user's pick and returns the updated `OnboardingV2ProfileResponse` with `chosen_option` populated." |
+
+---
+
+## Low Findings
+
+| ID | Severity | Issue | Location | Recommendation |
+|---|---|---|---|---|
+| A-L1 | LOW | FR-13 states "Both routers mounted under `/api/v1/onboarding/` prefix" but does not specify the `include_router` addition to `nikita/api/main.py`. The new `portal_onboarding.router` needs a concrete `app.include_router(portal_onboarding.router, prefix="/api/v1/onboarding", tags=["Portal Onboarding"])` call. | spec.md:445 | Add to FR-13: "In `nikita/api/main.py`, after the existing onboarding router mount at line 265-269, add: `from nikita.api.routes import portal_onboarding; app.include_router(portal_onboarding.router, prefix='/api/v1/onboarding', tags=['Portal Onboarding'])`." |
+| A-L2 | LOW | FR-5.2 code snippet uses `func`, `cast`, `JSONB`, and `update` without specifying the required SQLAlchemy imports. The repository file currently imports only `select` from `sqlalchemy` (user_repository.py:12). Implementors must add: `from sqlalchemy import func, cast, update` and `from sqlalchemy.dialects.postgresql import JSONB`. | spec.md:311-320 (FR-5.2) | Add import list to FR-5.2: "Required imports: `from sqlalchemy import func, cast, update` and `from sqlalchemy.dialects.postgresql import JSONB`." |
+
+---
+
+## Iteration 1 Finding Resolution Status
+
+All 15 iteration-1 findings are confirmed RESOLVED:
+
+| ID | Status | Evidence |
+|---|---|---|
+| A-C1 (PortalProfileRequest constraints) | RESOLVED | FR-1d lines 87-93: full Field constraints for name/age/occupation |
+| A-C2 (contract types bodies missing) | RESOLVED | FR-2 lines 101-156: all 6 Pydantic class bodies with field-level constraints |
+| A-C3 (pipeline_state write path) | RESOLVED | FR-5.1 lines 296-307: 5-transition table + `update_onboarding_profile_key` call |
+| A-H1 (403/404 body shapes) | RESOLVED | FR-5 line 280: explicit body strings for 403 and 404 |
+| A-H2 (adapter not specified) | RESOLVED | FR-3.1 lines 189-212: `ProfileFromOnboardingProfile` class + field mapping |
+| A-H3 (VenueResearchService injection) | RESOLVED | FR-3 step 1 lines 171-172: `VenueCacheRepository(session)` → `VenueResearchService(venue_cache_repository=repo)` |
+| A-H4 (pipeline_state write missing) | RESOLVED | Covered by FR-5.1 |
+| A-H5 (log schema error_class missing) | RESOLVED | FR-3 logging spec line 184 + NFR-3 table line 578: `error_class: str | None` in both events |
+| A-H6 (name vs user_name ambiguity) | RESOLVED | FR-1e lines 95: canonical key = `"name"`, fallback to `"user_name"`, update sites named |
+| A-M1 (no poll_interval_s in response) | RESOLVED | `OnboardingV2ProfileResponse` includes `poll_interval_seconds` + `poll_max_wait_seconds` |
+| A-M2 (pipeline_ready.poll log ambiguity) | RESOLVED | NFR-3 line 581 explicitly scopes client-side metrics to Spec 214 |
+| A-M3 (bucketing before key construction) | RESOLVED | FR-3 step 3 line 174: bucketing applied before key |
+| A-M4 (404 for unknown user_id) | RESOLVED | FR-5 line 280 |
+| A-L1 (FirstMessageGenerator signature) | RESOLVED | FR-6 lines 330-336: new keyword-only param signature |
+| A-L2 (BACKSTORY_HOOK_PROBABILITY) | RESOLVED | tuning.py lines 244-247 |
+
+---
+
+## API Inventory
+
+| Method | Endpoint | Purpose | Auth | Request | Response |
+|---|---|---|---|---|---|
+| POST | `/api/v1/onboarding/profile` | Save portal profile + trigger pipeline | User JWT | `OnboardingV2ProfileRequest` | `OnboardingV2ProfileResponse` |
+| PATCH | `/api/v1/onboarding/profile` | Partial profile update for resume | User JWT | partial `OnboardingV2ProfileRequest` | `OnboardingV2ProfileResponse` |
+| GET | `/api/v1/onboarding/pipeline-ready/{user_id}` | Poll pipeline readiness | User JWT (own only) | — | `PipelineReadyResponse` |
+
+### Error Codes
+
+| Status | Body | Trigger |
+|---|---|---|
+| 403 | `{"detail": "Not authorized"}` | Cross-user pipeline-ready access |
+| 404 | `{"detail": "User not found"}` | Unknown user_id on pipeline-ready |
+| 422 | FastAPI validation error | Invalid request body |
+
+---
+
+## Contract Module Inventory (FR-2)
+
+All 6 types confirmed fully defined in spec:
+
+| Type | Module | Status |
+|---|---|---|
+| `PipelineReadyState` | `nikita.onboarding.contracts` | Defined (Literal) |
+| `BackstoryOption` | `nikita.onboarding.contracts` | Defined (5 fields + tone Literal) — conversion from `BackstoryScenario` missing (A-C1) |
+| `OnboardingV2ProfileRequest` | `nikita.onboarding.contracts` | Defined (10 fields with constraints) |
+| `OnboardingV2ProfileResponse` | `nikita.onboarding.contracts` | Defined (7 fields) — `chosen_option` write path deferred (A-M2) |
+| `PipelineReadyResponse` | `nikita.onboarding.contracts` | Defined (3 fields) |
+| `ErrorResponse` | `nikita.onboarding.contracts` | Defined (1 field, matches existing pattern) |
+
+---
+
+## Verdict
+
+**FAIL** — 1 CRITICAL + 2 HIGH block implementation. Per CLAUDE.md SDD rule 7: fix spec + re-validate (iteration 3 of max 3).
+
+**Priority fixes required before iteration 3**:
+
+1. **(A-C1 — CRITICAL)** Add `BackstoryScenario → BackstoryOption` conversion function to FR-3, including `id` generation formula and `tone` validation strategy.
+2. **(A-H1 — HIGH)** Fix FR-3 step 5 to explicitly unpack `venue_result.venues` from `VenueResearchResult` and specify behavior when `fallback_used=True`.
+3. **(A-H2 — HIGH)** Define `compute_backstory_cache_key` function: module path, signature, and key format string.

--- a/specs/213-onboarding-backend-foundation/validation-reports/architecture.md
+++ b/specs/213-onboarding-backend-foundation/validation-reports/architecture.md
@@ -1,0 +1,163 @@
+# Architecture Validation Report — Spec 213 (Iteration 2)
+
+**Spec**: `specs/213-onboarding-backend-foundation/spec.md`
+**Status**: FAIL
+**Timestamp**: 2026-04-14T00:00:00Z
+**Validator**: sdd-architecture-validator
+**Iteration**: 2 (re-validation of iteration 1 findings + fresh pass)
+
+---
+
+## Summary
+
+| Severity | Count |
+|---|---|
+| CRITICAL | 0 |
+| HIGH | 0 |
+| MEDIUM | 0 |
+| LOW | 2 |
+
+**User policy**: ABSOLUTE ZERO across all severities. Status = FAIL until LOW count = 0.
+
+---
+
+## Iteration 1 Findings — Resolution Status
+
+All 9 iteration-1 findings (AR-H1, AR-H2, AR-H3, AR-M1, AR-M2, AR-M3, AR-M4, AR-L1, AR-L2) are RESOLVED in the iteration-2 spec rewrite:
+
+| ID | Was | Resolution |
+|---|---|---|
+| AR-H1 | HIGH — session leak | FR-14 mandates fresh session pattern, names call site (`onboarding.py:821-827`), atomic with FR-13 route move |
+| AR-H2 | HIGH — no route split | FR-13 creates `nikita/api/routes/portal_onboarding.py` with explicit endpoint list (POST profile, PATCH profile, GET pipeline-ready) |
+| AR-H3 | HIGH — adapter duplication | FR-3.1 promotes `_ProfileFromAnswers` to `nikita/onboarding/adapters.py` as `ProfileFromOnboardingProfile`; both Telegram and portal paths import from shared module |
+| AR-M1 | MEDIUM — contracts.py isolation | FR-2 explicit constraint: "MUST NOT import from `nikita.onboarding.models`, `nikita/db/models/`, or `nikita.engine.constants`" |
+| AR-M2 | MEDIUM — BackstoryCache file paths | FR-12 names both files: `nikita/db/models/backstory_cache.py` + `nikita/db/repositories/backstory_cache_repository.py` |
+| AR-M3 | MEDIUM — pipeline_state write path | FR-5.1 defines all 5 state transitions: entry→`"pending"`, success→`"ready"`, degraded→`"degraded"`, exception→`"failed"`, re-entry-when-ready→no-op |
+| AR-M4 | MEDIUM — tuning.py isolation | FR-4 explicit constraint: "MUST NOT import from `nikita.engine.constants` — different domain" |
+| AR-L1 | LOW — orchestrator coupling | FR-11 states idempotence handled in `_bootstrap_pipeline` via JSONB read; orchestrator signature unchanged |
+| AR-L2 | LOW — PII logger redaction | FR-7 mandates per-call discipline; SC-6 requires `caplog` test asserting absence of PII in all log records |
+
+---
+
+## New Findings (Iteration 2)
+
+### AR2-L1 — `main.py` Router Registration Not Specified
+
+| Field | Value |
+|---|---|
+| **Severity** | LOW |
+| **Category** | Module Organization |
+| **Location** | `nikita/api/main.py` (lifespan registration block, line ~263) |
+| **Issue** | FR-13 creates `nikita/api/routes/portal_onboarding.py` and says "Both routers mounted under `/api/v1/onboarding/` prefix," but the spec does not state that `portal_onboarding.router` must be added to `main.py` via `include_router()`. Every existing router (`onboarding`, `portal`, `voice`, `admin`, `auth_bridge`) has an explicit `app.include_router(...)` call in `main.py`'s lifespan. Omitting this step means the new route file exists but is unreachable. |
+| **Fix** | Add to FR-13: "`main.py` MUST register `portal_onboarding.router` via `app.include_router(portal_onboarding.router, prefix='/api/v1/onboarding', tags=['Portal Onboarding'])` in the lifespan function, after the existing `onboarding.router` registration (line ~265)." |
+
+### AR2-L2 — `BackstoryCacheRepository.get()` Return Type Cross-Layer Import
+
+| Field | Value |
+|---|---|
+| **Severity** | LOW |
+| **Category** | Import Patterns / Separation of Concerns |
+| **Location** | `nikita/db/repositories/backstory_cache_repository.py` (FR-12) |
+| **Issue** | FR-12 specifies `BackstoryCacheRepository.get()` returning `list[BackstoryOption] | None`. `BackstoryOption` is defined in `nikita.onboarding.contracts`. This creates a `db.repositories` → `nikita.onboarding.contracts` module-level import. The established precedent in this codebase is that `db/repositories` returns ORM model objects or raw `list[dict]` — not domain contract types. `VenueCacheRepository` (the nearest sibling, `profile_repository.py:397-482`) returns `VenueCache` ORM objects and `list[dict[str, Any]]`, never a domain Pydantic type. The inconsistency is confirmed: `VenueCacheRepository.store()` accepts `venues: list[dict[str, Any]]`; the facade (`VenueResearchService`) owns the conversion. The `BackstoryCacheRepository` should follow the same pattern. Note: `nikita.db.models.profile` already has a lazy import from `nikita.onboarding.validation` (line 325), so no circular cycle is introduced — the concern is pattern consistency, not correctness. |
+| **Fix** | Revise FR-12 `BackstoryCacheRepository` signatures: `get(cache_key: str) -> list[dict] | None` and `set(cache_key: str, scenarios: list[dict], ttl_days: int) -> None`. The **facade** (`portal_onboarding.py`) performs the deserialization: `[BackstoryOption(**s) for s in raw_dicts]` after the cache hit, and `[s.model_dump() for s in scenarios]` before the cache set. This keeps the `db` layer free of domain contract types and matches the `VenueCacheRepository` pattern exactly. |
+
+---
+
+## Module Dependency Graph (Post-Fix Architecture)
+
+```
+nikita/onboarding/contracts.py       (standalone Pydantic — no upstream imports)
+       ↑                                     ↑
+nikita/services/portal_onboarding.py ←→ nikita/onboarding/adapters.py
+       ↑                                     ↑
+nikita/db/repositories/              nikita/platforms/telegram/onboarding/handler.py
+  backstory_cache_repository.py      (both import adapters.py)
+  (returns list[dict], NOT BackstoryOption)
+       ↑
+nikita/db/models/backstory_cache.py
+
+nikita/api/routes/portal_onboarding.py → nikita/services/portal_onboarding.py
+                                        → nikita/onboarding/contracts.py (request/response shapes)
+nikita/api/main.py → include_router(portal_onboarding.router, ...)  ← AR2-L1 fix
+```
+
+No cycles. `contracts.py` is a leaf node (imports only stdlib + pydantic).
+
+---
+
+## Separation of Concerns Analysis
+
+| Layer | Responsibility | Violations (post-fix) |
+|---|---|---|
+| `nikita/onboarding/contracts.py` | Frozen API contract types | None — standalone |
+| `nikita/onboarding/tuning.py` | Timeout/cache constants for onboarding domain | None — no engine.constants import |
+| `nikita/onboarding/adapters.py` | Pydantic↔ORM bridge (single source of truth) | None — replaces two unsynchronized adapters |
+| `nikita/services/portal_onboarding.py` | Facade: venue research + backstory generation | None — no own session, no business logic |
+| `nikita/db/repositories/backstory_cache_repository.py` | Cache persistence (raw JSONB) | None after AR2-L2 fix (returns `list[dict]`) |
+| `nikita/api/routes/portal_onboarding.py` | HTTP interface: POST/PATCH profile + GET pipeline-ready | None — separated from voice-onboarding concerns (FR-13) |
+| `nikita/api/routes/onboarding.py` | Voice-onboarding: initiate, status, server-tool, webhook, skip | None — reduced to 5 concerns (was 6+) |
+| `nikita/onboarding/handoff.py::_bootstrap_pipeline` | Pipeline bootstrap + JSONB state writes | None — fresh session via `get_session_maker()()` (FR-14) |
+
+---
+
+## Import Pattern Checklist
+
+- [x] `contracts.py` standalone: no imports from `nikita.onboarding.models`, `nikita.db.*`, `nikita.engine.*`
+- [x] `tuning.py` standalone: no imports from `nikita.engine.constants`
+- [x] `adapters.py` imports from `nikita.onboarding.models` (valid — same domain package) and `nikita.db.models.profile` (valid — constructing ORM object)
+- [x] `portal_onboarding.py` (service) imports `contracts.py`, `tuning.py`, `adapters.py` — all inward-facing, no cycles
+- [x] `portal_onboarding.py` (route) imports from `portal_onboarding.py` (service) and `contracts.py` — no cycles
+- [x] `_trigger_portal_handoff` background task: no request-scoped `AsyncSession` passed (FR-14)
+- [ ] `backstory_cache_repository.py` return type: PENDING AR2-L2 fix (should return `list[dict]`, not `list[BackstoryOption]`)
+- [ ] `main.py` router registration: PENDING AR2-L1 fix (must add `include_router` for `portal_onboarding.router`)
+
+---
+
+## Security Architecture Checklist
+
+- [x] PII fields (`name`, `age`, `occupation`, `phone`) excluded from structured logs — FR-7 + SC-6 caplog test
+- [x] Exception echoes sanitized — FR-7 mandates `logger.exception(extra={"user_id": ...})` pattern
+- [x] RLS: existing 5 `user_profiles` policies cover new columns automatically (PostgreSQL row-level)
+- [x] RLS: `user_profiles` UPDATE policy `WITH CHECK (id = auth.uid())` — tracked as Phase 8 impl task
+- [x] `backstory_cache` RLS: admin-only (users do not query directly) — FR-12
+- [x] `/pipeline-ready/{user_id}` cross-user 403 — FR-5 + AC-2.4 test specified
+- [x] `OnboardingV2ProfileRequest` field validation constraints match DB CHECK constraints (FR-1d / FR-1a alignment)
+- [x] `users.onboarding_completed_at` non-existent column acknowledged — FR-9 uses `onboarding_status` field instead (verified via Supabase MCP, per constraints section)
+
+---
+
+## Proposed Structure (Confirmed Against Existing Codebase)
+
+```
+nikita/
+├── onboarding/              # EXISTING
+│   ├── contracts.py         # NEW (PR 213-1) — frozen contract surface
+│   ├── tuning.py            # NEW (PR 213-1) — domain constants
+│   ├── adapters.py          # NEW (PR 213-1) — promoted from handler.py:41-56
+│   ├── handoff.py           # MODIFIED — FR-5.1 state writes + FR-11 idempotence
+│   └── models.py            # MODIFIED — FR-1c `name` field addition
+├── services/
+│   └── portal_onboarding.py # NEW (PR 213-3) — thin facade
+├── db/
+│   ├── models/
+│   │   ├── backstory_cache.py  # NEW (PR 213-2) — ORM model
+│   │   └── profile.py       # MODIFIED — FR-1b name/occupation/age ORM columns
+│   └── repositories/
+│       ├── backstory_cache_repository.py  # NEW (PR 213-2) — returns list[dict] (post AR2-L2 fix)
+│       └── user_repository.py  # MODIFIED — FR-5.2 update_onboarding_profile_key()
+└── api/
+    ├── main.py              # MODIFIED — register portal_onboarding.router (AR2-L1 fix)
+    └── routes/
+        ├── portal_onboarding.py  # NEW (PR 213-4) — POST/PATCH profile + GET pipeline-ready
+        └── onboarding.py    # MODIFIED — POST profile MOVED OUT; FR-14 session fix
+```
+
+---
+
+## Recommendations
+
+1. **AR2-L1 (LOW)** — Add to FR-13: "Ship `main.py` router registration as part of PR 213-4. Call: `app.include_router(portal_onboarding.router, prefix='/api/v1/onboarding', tags=['Portal Onboarding'])`." One sentence addition.
+
+2. **AR2-L2 (LOW)** — Revise FR-12 `BackstoryCacheRepository` signatures to return `list[dict]` (raw JSONB). Update FR-3 facade description to show the deserialization step: `[BackstoryOption(**s) for s in raw]` on cache hit, `[s.model_dump() for s in scenarios]` before cache set. This matches the `VenueCacheRepository` precedent exactly.
+
+Both fixes are additive (1-2 sentences each). No structural rework required. After these two fixes, the architecture is **PASS-ready**.

--- a/specs/213-onboarding-backend-foundation/validation-reports/auth.md
+++ b/specs/213-onboarding-backend-foundation/validation-reports/auth.md
@@ -1,0 +1,47 @@
+# Auth Validation Report — Spec 213
+
+**Spec**: `specs/213-onboarding-backend-foundation/spec.md`
+**Status**: FAIL (iteration 1)
+**Timestamp**: 2026-04-14T15:55:00Z
+**Validator**: sdd-auth-validator
+
+## Summary
+| Severity | Count |
+|---|---|
+| CRITICAL | 0 |
+| HIGH | 1 |
+| MEDIUM | 3 |
+| LOW | 4 |
+
+## High Findings
+
+| ID | Issue | Fix |
+|---|---|---|
+| AU-H1 | `_bootstrap_pipeline` doesn't write `pipeline_state` JSONB key — `/pipeline-ready` endpoint will always return `pending`. Same root cause as A-C3. | Add FR-5.1: `_bootstrap_pipeline` writes `pipeline_state` to `users.onboarding_profile` on entry (`pending`), success (`ready`), timeout/partial (`degraded`), exception (`failed`) |
+
+## Medium Findings
+
+| ID | Issue | Fix |
+|---|---|---|
+| AU-M1 | Pre-existing PII violations at `nikita/api/routes/onboarding.py:154` and `:239` — `logger.error(f"...: {e}")` may echo PII | Replace with `logger.exception("...", extra={"user_id": str(user_id)})`. Spec FR-7 covers these files explicitly. |
+| AU-M2 | `onboarding_completed_at` column existence in `users` table not verified | Verify via Supabase MCP `information_schema.columns`. If missing, FR-9 must use `onboarding_status` field instead OR add migration |
+| AU-M3 | Re-onboarding partial-update mechanism unclear — existing idempotency guard at `:752-769` returns early on `onboarding_status == "completed"` | FR-9 must specify: separate `PATCH /onboarding/profile` endpoint OR conditional bypass logic in `save_portal_profile` |
+
+## Low Findings
+
+| ID | Issue | Fix |
+|---|---|---|
+| AU-L1 | AC-2.4 `/pipeline-ready` 403 body shape unstated | Add to AC-2.4: body = `{"detail": "Not authorized"}` matching existing onboarding pattern at `:140` |
+| AU-L2 | `user_profiles` UPDATE RLS policy missing `WITH CHECK (id = auth.uid())` | Add `WITH CHECK` clause via Supabase MCP — belt-and-suspenders |
+| AU-L3 | FR-10 voice webhook auth: confirm Spec 212 HMAC pattern unchanged when payload enriched | Add explicit note in FR-10 |
+| AU-L4 | FR-9 `onboarding_completed_at`: column vs JSONB key not specified | Clarify (likely top-level column on `users`, set by `update_onboarding_status`) |
+
+## Verified
+- Supabase RLS on `user_profiles`: 5 policies exist (SELECT own/admin, INSERT/UPDATE/DELETE own). New columns auto-covered.
+- Cross-user 403 pattern matches existing impl at `onboarding.py:134-140`.
+- JWT algorithm pinned `HS256`, audience `authenticated`. No algorithm-confusion risk.
+- Current happy-path logs (FR-7 compliant); violation is exception-handler only.
+- `_bootstrap_pipeline` confirmed missing `pipeline_state` write (verified by reading `handoff.py:551-625`).
+
+## Verdict
+**FAIL** — 1 HIGH (AU-H1) + spec needs 7 additional issues addressed for absolute-zero compliance per user directive.

--- a/specs/213-onboarding-backend-foundation/validation-reports/data-layer.md
+++ b/specs/213-onboarding-backend-foundation/validation-reports/data-layer.md
@@ -1,0 +1,143 @@
+# Data Layer Validation Report
+
+**Spec:** `specs/213-onboarding-backend-foundation/spec.md`
+**Status:** FAIL
+**Timestamp:** 2026-04-14T18:30:00Z
+**Iteration:** 2 (re-validation against iteration 1 findings)
+**Validator:** sdd-data-layer-validator
+
+---
+
+### Summary
+
+| Severity | Count |
+|----------|-------|
+| CRITICAL | 0 |
+| HIGH | 1 |
+| MEDIUM | 1 |
+| LOW | 1 |
+
+---
+
+### Iteration 1 Findings — Resolution Status
+
+All 13 iteration-1 findings are RESOLVED in this spec iteration. Verified against DB state and spec text:
+
+| ID | Finding | Resolution |
+|----|---------|------------|
+| D-C1 (CRITICAL) | `onboarding_completed_at` column does not exist | RESOLVED — FR-9 rewritten to use `onboarding_status` field; DB confirmed `onboarding_status` exists as `text DEFAULT 'pending'` |
+| D-H1 (HIGH) | `user_profiles` ORM missing `name`/`occupation`/`age` mapped_column entries | RESOLVED — FR-1b now specifies all three with correct types (`SmallInteger`, `String`) |
+| D-H2 (HIGH) | `pipeline_state` JSONB key has no writer defined | RESOLVED — FR-5.1 added with full state transition table and `update_onboarding_profile_key` repo method (FR-5.2) |
+| D-H3 (HIGH) | `backstory_cache` table had no DDL | RESOLVED — FR-12 now specifies complete DDL, ORM model, and Repository interface |
+| D-M1 (MEDIUM) | Migration naming used `0091_*` format | RESOLVED — FR-1a now uses `YYYYMMDDHHMMSS_*` format with explicit note matching project convention |
+| D-M2 (MEDIUM) | No CHECK constraint on `age SMALLINT` | RESOLVED — FR-1a DDL includes `CHECK (age IS NULL OR (age BETWEEN 18 AND 99))` |
+| D-M3 (MEDIUM) | BackstoryCache TTL strategy unclear | RESOLVED — FR-12 documents query-time filter `WHERE expires_at > NOW()` as authoritative strategy |
+| D-M4 (MEDIUM) | Cache key composite uniqueness unspecified | RESOLVED — FR-12 uses single `cache_key TEXT` with `CONSTRAINT uq_backstory_cache_key UNIQUE (cache_key)`; bucketing happens in Python |
+| D-M5 (MEDIUM) | `wizard_step` JSONB write atomicity unspecified | RESOLVED — Out of Scope explicitly delegates write ownership to Spec 214; FR-9 PATCH uses `jsonb_set` |
+| D-L1 (LOW) | RLS coverage not acknowledged for new columns | RESOLVED — FR-1a now states "existing 5 policies cover new columns automatically (PostgreSQL is row-level, not column-level)" |
+| D-L2 (LOW) | Migration rollback not documented | RESOLVED — FR-1a includes rollback script `ALTER TABLE user_profiles DROP COLUMN name, DROP COLUMN occupation, DROP COLUMN age` |
+| D-L3 (LOW) | Pydantic vs DB CHECK constraint duplication | RESOLVED — FR-1d documents intentional dual enforcement with rationale |
+| D-L4 (LOW) | Index for onboarding detection column | RESOLVED — `onboarding_completed_at` not added; FR-9 uses PK-indexed `user_id` lookup on existing `onboarding_status` column; no index gap |
+
+---
+
+### Findings
+
+| Severity | Category | Issue | Location | Recommendation |
+|----------|----------|-------|----------|----------------|
+| HIGH | RLS / Schema | `backstory_cache` migration DDL in FR-12 includes no `ALTER TABLE backstory_cache ENABLE ROW LEVEL SECURITY` and no `CREATE POLICY` statement. The table will be created with RLS disabled (PostgreSQL default). Any authenticated session can execute `SELECT * FROM backstory_cache`, exposing all bucketed profile shapes and their scenario JSONB. The spec prose in FR-12 says "RLS: deny by default (admin-only via `is_admin()` policy)" but this is not represented in the DDL block — prose is not a migration. | `spec.md` FR-12, migration DDL block (lines 398–407) | Add to the FR-12 migration SQL block: `ALTER TABLE backstory_cache ENABLE ROW LEVEL SECURITY;` followed by `CREATE POLICY "Admins can manage backstory cache" ON backstory_cache FOR ALL TO public USING (is_admin()) WITH CHECK (is_admin());` The `is_admin()` function already exists in the project (used by `user_profiles` and `user_backstories`). Verified: `backstory_cache` table does not yet exist in DB — the fix goes in the NEW migration only. |
+| MEDIUM | RLS | `user_profiles` UPDATE policy has no `WITH CHECK` clause (DB-verified: `with_check=null` on "Users can update own profile"). Spec FR-7 identifies this gap and flags it as a needed fix but defers it to "Phase 8 implementation (out of spec scope)" without providing the DDL or an accepted-risk declaration. Under the user's absolute-zero policy, a spec-identified security gap with no resolution DDL and no explicit risk-acceptance is not passing. The implementation note says "Add WITH CHECK (id = auth.uid()) to UPDATE policy — belt-and-suspenders" — this must be in the spec, not just the implementation notes. | `spec.md` FR-7 and Implementation Notes (lines 344, 707–709) | Move the WITH CHECK fix from implementation notes into FR-7 with explicit DDL: `ALTER POLICY "Users can update own profile" ON user_profiles WITH CHECK (id = (SELECT auth.uid()));` This is a single DDL statement that can ship in PR 213-2 (the migration PR). Alternatively, mark FR-7 with an explicit "accepted risk: without WITH CHECK, a bug in the USING clause could allow cross-user writes; mitigated by application-layer auth check" — but the former is strongly preferred. |
+| LOW | RLS | `user_profiles` DELETE policy uses bare `auth.uid()` (DB-verified: `qual = "(id = auth.uid())"`) rather than the subquery form `(id = (SELECT auth.uid()))`. This is a pre-existing issue not introduced by this spec, but the spec modifies `user_profiles` policies (FR-7) and audits all 5 existing policies, making this the appropriate time to fix it. The subquery form evaluates `auth.uid()` once per query rather than once per row — relevant for batch DELETE operations. | `spec.md` FR-7 (lines 344–347); DB policy "Users can delete own profile" | Add to FR-7: "Also update DELETE policy to use subquery form: `ALTER POLICY "Users can delete own profile" ON user_profiles USING (id = (SELECT auth.uid()));`" This is a one-line change that can be included in PR 213-2. Pre-existing issue: `user_profiles` DELETE, `users` "Users can read own data" and "Users can update own data" policies all use bare `auth.uid()` — the latter two are out of scope for this spec. |
+
+---
+
+### Entity Inventory
+
+| Entity | Attributes | PK | FK | RLS | Notes |
+|--------|------------|----|----|-----|-------|
+| `user_profiles` (ALTER) | +`name TEXT NULL`, +`occupation TEXT NULL`, +`age SMALLINT NULL CHECK (age IS NULL OR age BETWEEN 18 AND 99)` | `id UUID` | `id` → `auth.users(id)` | Enabled — 5 policies cover new columns automatically | DB-verified: columns NOT YET present; migration pending |
+| `backstory_cache` (CREATE) | `id UUID PK`, `cache_key TEXT NOT NULL UNIQUE`, `scenarios JSONB NOT NULL`, `created_at TIMESTAMPTZ DEFAULT now()`, `expires_at TIMESTAMPTZ NOT NULL` | `id UUID` | none | MISSING RLS ENABLE + POLICY DDL (HIGH finding) | Table does not yet exist in DB |
+| `users` (method only) | `onboarding_profile JSONB` — new key `pipeline_state` written via `update_onboarding_profile_key` | `id UUID` | — | Enabled — 5 policies | DB-verified: `onboarding_profile JSONB DEFAULT '{}'` exists; `pipeline_state` key written by FR-5.1 |
+
+---
+
+### Relationship Map
+
+```
+users 1──1 user_profiles (id → id)
+backstory_cache ── (no FK; keyed by computed cache_key string)
+users.onboarding_profile JSONB ── pipeline_state key written by _bootstrap_pipeline
+```
+
+---
+
+### RLS Policy Checklist
+
+- [x] `user_profiles` SELECT (own) — `(id = (SELECT auth.uid()))` subquery form — PASS
+- [x] `user_profiles` INSERT — `WITH CHECK (id = (SELECT auth.uid()))` — PASS
+- [ ] `user_profiles` UPDATE — USING uses subquery form but `with_check=null` — FAIL (MEDIUM finding)
+- [ ] `user_profiles` DELETE — bare `auth.uid()` not subquery form — FAIL (LOW finding)
+- [x] `user_profiles` SELECT (admin) — `is_admin()` — PASS
+- [ ] `backstory_cache` — RLS not enabled, no policy DDL in migration — FAIL (HIGH finding)
+- [x] `users.onboarding_profile` write — uses `update_onboarding_profile_key` via service_role or user's own session — PASS (FR-5.2 specifies atomic `jsonb_set`)
+
+---
+
+### Index Requirements
+
+| Table | Column(s) | Type | Query Pattern | Status |
+|-------|-----------|------|---------------|--------|
+| `user_profiles` | `age` WHERE age IS NOT NULL | Partial btree | FR-1a specifies `idx_user_profiles_age`; no query pattern yet documented (future analytics) | Specified in spec; not yet in DB |
+| `backstory_cache` | `expires_at` | btree | Query-time TTL filter cleanup | Specified in FR-12; not yet in DB |
+| `backstory_cache` | `cache_key` | Unique btree (auto via UNIQUE constraint) | Cache lookup `WHERE cache_key = ?` | Implicit via UNIQUE constraint |
+
+---
+
+### Recommendations
+
+1. **HIGH — Add RLS DDL to FR-12 `backstory_cache` migration**
+   - Add these two statements to the `YYYYMMDDHHMMSS_create_backstory_cache.sql` migration, after the `CREATE TABLE` and `CREATE INDEX` statements:
+     ```sql
+     ALTER TABLE backstory_cache ENABLE ROW LEVEL SECURITY;
+     CREATE POLICY "Admins can manage backstory cache"
+       ON backstory_cache FOR ALL TO public
+       USING (is_admin())
+       WITH CHECK (is_admin());
+     ```
+   - Verify `is_admin()` function exists: confirmed present on `user_profiles` and `user_backstories` policies.
+   - No user-facing READ access is needed; the facade reads via the session that runs as the calling user but `is_admin()` ensures only admin-role can enumerate. Alternatively, use service_role for all backstory cache operations (no user-facing policy needed), which is cleaner.
+
+2. **MEDIUM — Add WITH CHECK to user_profiles UPDATE policy in FR-7**
+   - Include in the FR-7 specification body (not just implementation notes) the exact DDL:
+     ```sql
+     ALTER POLICY "Users can update own profile" ON user_profiles
+       WITH CHECK (id = (SELECT auth.uid()));
+     ```
+   - Place in PR 213-2 alongside the user_profiles column migration.
+
+3. **LOW — Fix user_profiles DELETE policy to use subquery auth.uid() form**
+   - Include in FR-7 alongside the UPDATE WITH CHECK fix:
+     ```sql
+     ALTER POLICY "Users can delete own profile" ON user_profiles
+       USING (id = (SELECT auth.uid()));
+     ```
+   - Can ship in same PR 213-2 with zero risk — pure performance improvement, identical access semantics.
+
+---
+
+### Migration Strategy Assessment
+
+| Migration | Type | Status | Risk |
+|-----------|------|--------|------|
+| `YYYYMMDDHHMMSS_alter_user_profiles_add_name_occupation_age.sql` | DDL ALTER TABLE (3 nullable columns) | New; not yet in DB | Low — nullable columns, no default constraint issues |
+| `YYYYMMDDHHMMSS_create_backstory_cache.sql` | DDL CREATE TABLE | New; not yet in DB | Medium — HIGH finding: missing RLS statements |
+
+Both migrations target new columns/tables — no data migration risk, no existing row impact.
+
+---
+
+### Verdict
+
+**FAIL** — 0 CRITICAL, 1 HIGH, 1 MEDIUM, 1 LOW
+
+The HIGH finding (backstory_cache RLS missing from migration DDL) is a security gap that prevents implementation clearance. The MEDIUM (UPDATE policy WITH CHECK deferred without DDL in spec) and LOW (DELETE policy bare auth.uid()) are fixable with small spec edits to FR-7 and FR-12. All 13 iteration-1 findings are fully resolved. One targeted spec edit pass to FR-7 and FR-12 should reach PASS in iteration 3.

--- a/specs/213-onboarding-backend-foundation/validation-reports/frontend.md
+++ b/specs/213-onboarding-backend-foundation/validation-reports/frontend.md
@@ -1,0 +1,98 @@
+# Frontend Validation Report — Spec 213 (Iteration 2)
+
+**Spec**: `specs/213-onboarding-backend-foundation/spec.md`
+**Status**: FAIL
+**Timestamp**: 2026-04-14T16:30:00Z
+**Validator**: sdd-frontend-validator
+**Iteration**: 2 (re-validation after comprehensive rewrite)
+**User Policy**: ABSOLUTE ZERO across ALL severities (CRITICAL + HIGH + MEDIUM + LOW)
+
+---
+
+## Summary
+
+| Severity | Count |
+|---|---|
+| CRITICAL | 0 |
+| HIGH | 0 |
+| MEDIUM | 0 |
+| LOW | 1 |
+
+**Scope**: Spec 213 is backend-only. Portal UX is out of scope (Spec 214). Findings restricted to contract surface that Spec 214 will consume.
+
+---
+
+## Iteration 1 Finding Resolution
+
+All four iteration-1 findings are confirmed RESOLVED:
+
+| ID | Finding | Resolution | Spec Location |
+|---|---|---|---|
+| F-M1 | `OnboardingV2ProfileResponse` fields not enumerated | RESOLVED — full Pydantic class with 7 fields now defined | FR-2, spec.md:132-141 |
+| F-M2 | `/pipeline-ready` portal action per state not specified | RESOLVED — Portal Behavior Contract table with ARIA `role="status"` + `aria-live="polite"` annotations | FR-5, spec.md:286-292 |
+| F-L1 | `BackstoryOption` shape not enumerated | RESOLVED — full Pydantic class with 6 fields now defined | FR-2, spec.md:106-113 |
+| F-L2 | 403 body shape not specified for poll-loop | RESOLVED — body `{"detail": "Not authorized"}` and 404 body `{"detail": "User not found"}` both named | FR-5, spec.md:280; AC-2.4, spec.md:490 |
+
+---
+
+## New Findings (Iteration 2)
+
+| ID | Severity | Category | Issue | Location | Recommendation |
+|---|---|---|---|---|---|
+| F2-L1 | LOW | Component Specification | AC-6.1 asserts "backend returns `wizard_step` in `OnboardingV2ProfileResponse`" but that field is absent from the frozen `OnboardingV2ProfileResponse` contract defined in FR-2. The Out of Scope section confirms `wizard_step` WRITE is Spec 214's domain. AC-6.1's test assertion ("portal navigation tested in Spec 214") suggests the AC is describing Spec 214 behavior, not backend behavior — but phrasing it as "backend returns `wizard_step` in `OnboardingV2ProfileResponse`" implies a contract field that does not exist and will not exist after PR #1 freezes the type. | spec.md:539 (AC-6.1) vs spec.md:132-141 (FR-2 `OnboardingV2ProfileResponse` definition) | Two acceptable fixes: (a) Reword AC-6.1 to "backend preserves `wizard_step` in `users.onboarding_profile` JSONB so Spec 214 can read it from the GET response or a dedicated resume endpoint", removing the implication that `OnboardingV2ProfileResponse` carries this field. OR (b) Add `wizard_step: int \| None` to `OnboardingV2ProfileResponse` in FR-2 if the intent is for the POST response to tell the portal where to resume. Option (a) is preferred — avoids widening the frozen contract. |
+
+---
+
+## Component Inventory
+
+| Contract Type | Type | Defined | Notes |
+|---|---|---|---|
+| `OnboardingV2ProfileRequest` | Pydantic (input) | FR-2, spec.md:116-129 | 9 fields; `wizard_step` present here (input side) — correct |
+| `OnboardingV2ProfileResponse` | Pydantic (output) | FR-2, spec.md:132-141 | 7 fields; `wizard_step` NOT present — inconsistent with AC-6.1 |
+| `BackstoryOption` | Pydantic | FR-2, spec.md:106-113 | 6 fields; all enumerated with descriptions |
+| `PipelineReadyState` | Literal string | FR-2, spec.md:100-101 | 4 values: pending/ready/degraded/failed |
+| `PipelineReadyResponse` | Pydantic | FR-2, spec.md:143-147 | 3 fields: `state`, `message`, `checked_at` |
+| `ErrorResponse` | Pydantic | FR-2, spec.md:152-155 | 1 field: `detail` |
+
+---
+
+## Accessibility Checklist (Portal Behavior Contract)
+
+- [x] Spinner state: `role="status"` + `aria-live="polite"` specified (spec.md:289)
+- [x] Ready state: dismiss action specified (spec.md:290)
+- [x] Degraded state: toast warning with user-facing message specified (spec.md:291)
+- [x] Failed state: error banner + retry CTA + non-blocking redirect after 2 retries specified (spec.md:292)
+- [x] 403 error body specified for consumer error-path handling (spec.md:280)
+- [x] 404 error body specified (spec.md:280)
+
+---
+
+## Responsive / Dark Mode / Form
+
+N/A — backend-only spec. All UI concerns deferred to Spec 214.
+
+---
+
+## Recommendations
+
+### F2-L1 (LOW): AC-6.1 wizard_step response field inconsistency
+
+**Option A (preferred)** — Reword AC-6.1 to remove the implication:
+
+> "User with `users.onboarding_profile = {"wizard_step": 5, ...}` and `onboarding_status != "completed"` → re-entering portal reads `wizard_step` from JSONB and Spec 214's portal navigates to step 5. Backend preserves but does not echo `wizard_step` in `OnboardingV2ProfileResponse`; resume detection tested in Spec 214."
+
+**Option B** — If the intent is for the POST/PATCH response to carry resume state, add to FR-2 `OnboardingV2ProfileResponse`:
+```python
+wizard_step: int | None = None  # populated on resume; null on first submission
+```
+Note: this widens the frozen contract and requires re-coordination with Spec 214.
+
+**Option A is preferred**: the Out of Scope section already declares wizard_step WRITE is Spec 214's domain, and the test annotation "portal navigation tested in Spec 214" confirms Option A was the author's intent.
+
+---
+
+## Pass/Fail Rationale
+
+**FAIL** — 0 CRITICAL + 0 HIGH + 0 MEDIUM + **1 LOW**.
+
+Per user policy (ABSOLUTE ZERO across all severities), this single LOW finding is a gate blocker. All four iteration-1 findings are confirmed resolved. One new LOW finding introduced by the rewrite (AC-6.1 / FR-2 response contract mismatch on `wizard_step`). Fix is a one-line reword of AC-6.1. No contract additions required if Option A is chosen.

--- a/specs/213-onboarding-backend-foundation/validation-reports/testing.md
+++ b/specs/213-onboarding-backend-foundation/validation-reports/testing.md
@@ -1,0 +1,180 @@
+# Testing Validation Report — Spec 213
+
+**Spec**: `specs/213-onboarding-backend-foundation/spec.md`
+**Status**: FAIL (iteration 2)
+**Timestamp**: 2026-04-14T17:30:00Z
+**Validator**: sdd-testing-validator
+**Iteration**: 2 (re-validation after iteration-1 rewrite)
+
+---
+
+## Summary
+
+| Severity | Count |
+|---|---|
+| CRITICAL | 0 |
+| HIGH | 0 |
+| MEDIUM | 2 |
+| LOW | 2 |
+
+**Iteration 1 → Iteration 2 delta**: 3 HIGH resolved, 5 MEDIUM resolved to 2, 3 LOW resolved to 2.
+
+---
+
+## Iteration 1 HIGH Findings — Resolution Status
+
+| ID | Original Issue | Status |
+|---|---|---|
+| T-H1 | No test file names for NFR-3 log events | RESOLVED — `tests/onboarding/test_log_observability.py` added to inventory (spec:626) |
+| T-H2 | No ASGI integration test for SC-2 blocking gate | RESOLVED — `tests/onboarding/test_pipeline_gate_integration.py` named in inventory (spec:622) with ASGI transport |
+| T-H3 | AC-2.2 polling mock fixture undefined (vacuous-pass risk) | RESOLVED — `side_effect=[{"pipeline_state":"pending"}]*4 + [{"pipeline_state":"ready"}]` explicitly specified in AC-2.2 (spec:488) |
+
+---
+
+## Findings
+
+### MEDIUM Findings
+
+| ID | Category | Issue | Location | Recommendation |
+|---|---|---|---|---|
+| T-M1 | Coverage Infrastructure | NFR-7 CI command omits `nikita.api.routes.portal_onboarding` from `--cov=` arguments. The route file has an explicit 85% target but will not be measured or gated by the CI command as written. Additionally, `--cov-fail-under=90` is a single combined threshold and cannot enforce the per-module split (100% for contracts/tuning/adapters vs 85% for routes vs 90% for facade). | spec:606 | Replace single `--cov-fail-under` with per-module `--cov-fail-under` or use `pytest-cov` `[coverage:report]` config. At minimum add `--cov=nikita.api.routes.portal_onboarding` to the CI command. Accept that enforcement of 100% vs 85% split requires either separate CI steps or `omit`/`fail_under` in `setup.cfg`/`pyproject.toml`. |
+| T-M2 | Test Inventory Completeness | Two test file/function names are referenced in AC bodies but absent from the Test File Inventory table (spec:612-628): (1) `tests/api/routes/test_voice_pre_call_webhook.py::test_payload_includes_v2_profile_response` (AC-7.2, spec:553) and (2) `test_portal_onboarding_session_isolation` (Risks table, spec:690). The first file does not exist on disk. An implementer doing TDD strictly from the inventory misses these tests, leaving AC-7.2 (voice webhook V2 payload shape — P2) and the CRITICAL-impact session-leak risk without verified coverage. | spec:553, spec:690 | Add `tests/api/routes/test_voice_pre_call_webhook.py` and `test_portal_onboarding_session_isolation` (proposed home: `tests/services/test_portal_onboarding_facade.py`) to the Test File Inventory with their purpose and marker. |
+
+### LOW Findings
+
+| ID | Category | Issue | Location | Recommendation |
+|---|---|---|---|---|
+| T-L1 | Spec Accuracy | `compute_backstory_cache_key(profile)` is called in FR-3 (spec:174) but the function is not defined in any FR, not assigned to a module, and does not exist in the codebase. FR-4 defines `AGE_BUCKETS` and `OCCUPATION_CATEGORIES` which are inputs to this function, implying it lives in `tuning.py` or `portal_onboarding.py`, but the spec is silent. An implementer must infer the home module. | spec:174 | Add one sentence to FR-3: "Function `compute_backstory_cache_key` defined in `nikita/onboarding/tuning.py` (FR-4 module); signature: `def compute_backstory_cache_key(profile: UserOnboardingProfile) -> str`." |
+| T-L2 | Coverage Gap (minor) | `test_tuning_constants.py` is described as "regression guards on every constant" (spec:616) but FR-4 defines 8 constants including `AGE_BUCKETS` (a tuple of tuples) and `OCCUPATION_CATEGORIES` (a dict). These compound types require non-trivial equality assertions. The spec does not specify what "regression guard" means for compound types — a simple `assert constant == expected_value` check may not catch structural drift (e.g., bucket boundary shift). | spec:274, spec:616 | Add a note to the Test File Inventory row for `test_tuning_constants.py`: "Compound constants (`AGE_BUCKETS`, `OCCUPATION_CATEGORIES`) use deep-equality assertion; `AGE_BUCKETS` checks that every boundary is inclusive via range membership test." |
+
+---
+
+## Testing Pyramid Analysis
+
+**Target**: Unit ~70% / Integration ~25% / E2E ~5%
+
+**Spec inventory (13 test files):**
+
+```
+Unit       (~70%): test_tuning_constants, test_contracts, test_adapters,
+                   test_pipeline_bootstrap, test_handoff (extended), 
+                   test_r8_conversation_continuity, test_log_observability,
+                   test_backstory_cache_repository
+                   → 8 files, 62%
+
+Integration (~25%): test_portal_onboarding_facade, test_portal_onboarding (routes),
+                    test_pipeline_gate_integration, test_rls_user_profiles
+                    → 4 files, 31%
+
+E2E          (~5%): test_e2e (extended)
+                    → 1 file, 7%
+```
+
+**Assessment**: Pyramid is ACCEPTABLE. The spec correctly deviates from strict 70/20/10 toward 62/31/7 — justified by the heavy JSONB + async integration surface (facade with two external services, pipeline gate, RLS policies). Integration layer at 31% is elevated but appropriate for the integration density of this spec.
+
+---
+
+## AC Testability Analysis
+
+| AC ID | AC Description | Testable | Test Type | Issue |
+|---|---|---|---|---|
+| AC-1.1 | POST accepts name/age/occupation without 422 | Yes | Integration | — |
+| AC-1.2 | JSONB contains all fields after submission | Yes | Integration (Supabase MCP) | Supabase MCP read acceptable for integration gate |
+| AC-1.3 | user_profiles row contains new columns | Yes | Integration | — |
+| AC-1.4 | First Telegram message in 25s with 2 tokens | Yes | E2E | Marked e2e, excluded from unit CI — correct |
+| AC-1.5 | No "So we meet again" fallback opener | Yes | Unit | Regex assert — clear |
+| AC-2.1 | pipeline-ready returns all 4 states | Yes | Integration | Parametrized over 4 states — clear |
+| AC-2.2 | Polling terminates | Yes | Integration | side_effect fixture explicitly specified — no vacuous-pass risk |
+| AC-2.3 | 20s timeout → degraded | Yes | Integration | — |
+| AC-2.4 | Cross-user 403 with correct body | Yes | Integration | — |
+| AC-3.1 | Venue timeout: returns within budget+1s | Yes | Integration | time.monotonic() assertion specified |
+| AC-3.2 | caplog contains timeout record | Yes | Integration | caplog fields enumerated |
+| AC-3.3 | First message on scene-only fallback | Yes | Unit | — |
+| AC-3.4 | pipeline_state → "degraded" on timeout | Yes | Unit | — |
+| AC-4.1 | BackstoryGenerator RuntimeError → [] | Yes | Integration | patch target specified at source module |
+| AC-4.2 | First message keeps flavor on backstory fail | Yes | Unit | — |
+| AC-4.3 | caplog on backstory failure, no PII | Yes | Integration | caplog fields + PII assertion specified |
+| AC-4.4 | pipeline_state → "degraded" on backstory fail | Yes | Unit | — |
+| AC-5.1 | Pipeline loads seeded turn | Yes | Unit | — |
+| AC-5.2 | Agent prompt includes prior assistant turn | Yes | Unit | call_args assertion specified |
+| AC-5.3 | No denial phrases N=10 | Yes | Unit | patch target + loop count specified |
+| AC-5.4 | Independent from US-1 | Yes | Unit | — |
+| AC-6.1 | wizard_step returned in response | Yes | Integration | portal navigation deferred to Spec 214 — correct scope |
+| AC-6.2 | PATCH merges JSONB without reset | Yes | Integration | — |
+| AC-6.3 | null fields for unset fields | Yes | Integration | — |
+| AC-6.4 | Cache hit skips Claude | Yes | Integration | — |
+| AC-7.1 | Phone → execute_handoff_with_voice_callback | Yes | Unit | Existing test referenced |
+| AC-7.2 | Webhook receives OnboardingV2ProfileResponse | Yes | Integration | File not in Test File Inventory — see T-M2 |
+| AC-7.3 | Voice prompt includes backstory hooks | Yes | Unit | — |
+| AC-7.4 | Voice-callback failure falls back to Telegram | Yes | Unit | Existing per Spec 212 |
+| SC-6 | PII absent from structured logs | Yes | Unit | caplog test named; static rg audit also specified |
+| SC-7 | RLS covers new columns | Yes | Integration | @pytest.mark.integration, live Supabase, non-blocking |
+| SC-9 | Coverage thresholds met | Partial | CI gate | See T-M1 — CI command incomplete |
+
+---
+
+## Test Scenario Inventory
+
+**E2E Scenarios:**
+
+| Scenario | Priority | User Flow | Status |
+|---|---|---|---|
+| `test_full_profile_personalizes_first_message` | P1 | Portal profile → Telegram first message with ≥2 tokens | Named in spec:628, @pytest.mark.e2e |
+
+**Integration Test Points:**
+
+| Component | Integration Point | Mock Required |
+|---|---|---|
+| `portal_onboarding.process()` | VenueResearchService + BackstoryGeneratorService | AsyncMock with side_effect |
+| `GET /pipeline-ready/{user_id}` | UserRepository JSONB read | mock_user_repo.get.return_value |
+| `POST /onboarding/profile` | FastAPI TestClient | test_portal_onboarding.py |
+| `PATCH /onboarding/profile` | jsonb_set merge semantics | test_portal_onboarding.py |
+| Pipeline gate ASGI test | ASGI transport + poll loop | test_pipeline_gate_integration.py |
+| RLS on user_profiles | Live Supabase | @pytest.mark.integration only |
+| BackstoryCacheRepository | upsert + TTL filter | AsyncMock session |
+
+**Unit Test Coverage:**
+
+| Module | Functions/Classes | Coverage Target |
+|---|---|---|
+| `contracts.py` | 6 Pydantic types | 100% |
+| `tuning.py` | 8 constants | 100% |
+| `adapters.py` | ProfileFromOnboardingProfile.from_pydantic | 100% |
+| `portal_onboarding.py` (service) | process() — happy/timeout/failure/cache | ≥90% line+branch |
+| `portal_onboarding.py` (routes) | POST, PATCH, GET pipeline-ready | ≥85% line |
+| `handoff.py` (extended) | FirstMessageGenerator.generate with backstory | unit coverage via existing file |
+
+---
+
+## TDD Readiness Checklist
+
+- [x] ACs are specific — all ACs name exact test file + assertion type
+- [x] ACs are measurable — quantified: N=10, ≤200ms, ≥2 tokens, 20s cap, etc.
+- [x] Test types clear per AC — unit/integration/e2e marker specified per file
+- [x] Red-green-refactor path clear — Test File Inventory provides the full TDD surface
+- [x] Non-empty fixtures required — AC-2.2 and FR-11 explicitly specify side_effect lists
+- [x] Patch targets at source module — FR-3 Patch Convention section (spec:636-639) lists source-module patches
+- [ ] Test File Inventory complete — 2 referenced test names absent (T-M2)
+
+---
+
+## Coverage Requirements
+
+- [x] Overall target specified (NFR-7, spec:600-606)
+- [x] Critical path coverage — contracts/tuning/adapters at 100%; facade at 90%
+- [ ] Per-module enforcement in CI — `--cov-fail-under=90` single threshold; route file absent from `--cov=` args (T-M1)
+- [x] Exclusions documented — RLS tests `@pytest.mark.integration` excluded from unit CI gate; E2E `@pytest.mark.e2e` excluded
+
+---
+
+## Recommendations
+
+1. **(T-M1 — Medium)** Add `--cov=nikita.api.routes.portal_onboarding` to the NFR-7 CI command. To enforce per-module thresholds, add a `[coverage:report]` section to `pyproject.toml` with `fail_under` per module, or run two separate `pytest --cov` commands in CI (one for ≥100% modules, one for ≥85% route). Current command silently allows the route file to have 0% coverage.
+
+2. **(T-M2 — Medium)** Add the following rows to the Test File Inventory table:
+   - `tests/api/routes/test_voice_pre_call_webhook.py` | AC-7.2: verify V2 profile response shape in voice pre-call webhook payload | integration
+   - Row in `tests/services/test_portal_onboarding_facade.py` already covers the facade; add a note that `test_portal_onboarding_session_isolation` lives there, verifying that background tasks open fresh sessions (FR-14 mitigation for CRITICAL-impact risk).
+
+3. **(T-L1 — Low)** Assign `compute_backstory_cache_key` to a module explicitly in FR-3 or FR-4 (recommended: `nikita/onboarding/tuning.py`, since it uses `AGE_BUCKETS` and `OCCUPATION_CATEGORIES`). Add its signature to FR-3 prose and include it in `test_tuning_constants.py` coverage scope.
+
+4. **(T-L2 — Low)** Annotate the `test_tuning_constants.py` inventory row to specify that `AGE_BUCKETS` and `OCCUPATION_CATEGORIES` regression tests use deep-equality plus a structural sanity check (e.g., bucket count, key membership) rather than bare value comparison. This prevents silent drift if a bucket boundary shifts without a failing test.

--- a/tests/onboarding/test_adapters.py
+++ b/tests/onboarding/test_adapters.py
@@ -214,6 +214,42 @@ class TestDuckTypeCompatibility:
 # ---------------------------------------------------------------------------
 
 
+class TestDrugToleranceDefaults:
+    """Spec FR-3.1 requires ``drug_tolerance: int`` — the adapter enforces that
+    even when duck-typed callers omit or None-out the ``darkness_level`` field."""
+
+    def test_missing_darkness_level_defaults_to_3(self):
+        """A SimpleNamespace without a ``darkness_level`` attribute maps to 3."""
+        profile_no_darkness = SimpleNamespace(
+            city="Berlin",
+            social_scene="techno",
+            life_stage=None,
+            interest=None,
+            age=None,
+            occupation=None,
+        )
+        # no darkness_level attribute at all
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), profile_no_darkness)
+        assert result.drug_tolerance == 3
+        assert isinstance(result.drug_tolerance, int)
+
+    def test_explicit_none_darkness_level_defaults_to_3(self):
+        """A SimpleNamespace with ``darkness_level=None`` also maps to 3 — keeps
+        the dataclass annotation (``int``) honest."""
+        profile_none_darkness = SimpleNamespace(
+            city="Berlin",
+            social_scene="techno",
+            darkness_level=None,
+            life_stage=None,
+            interest=None,
+            age=None,
+            occupation=None,
+        )
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), profile_none_darkness)
+        assert result.drug_tolerance == 3
+        assert isinstance(result.drug_tolerance, int)
+
+
 class TestForwardCompatNameField:
     """Per spec constraints: `name` is net-new in PR 213-2. Adapter must not crash
     on profiles that predate the field (forward-compat with existing Pydantic models)."""
@@ -274,6 +310,17 @@ def test_module_isolation_imports():
                     )
         elif isinstance(node, ast.ImportFrom):
             module = node.module or ""
+            # Relative imports (``from . import X`` / ``from ..engine import Y``)
+            # bypass absolute-path prefix checks. Reject any forbidden relative
+            # target by resolving the level to the sibling module name.
+            if node.level > 0:
+                # Level 1 = `from .X import Y` → sibling onboarding module; OK
+                # Level 2+ = `from ..X.Y` → escapes onboarding package; forbidden
+                assert node.level == 1, (
+                    f"adapters.py uses a parent-escaping relative import "
+                    f"(level={node.level}, module={module!r}) — disallowed"
+                )
+                continue
             for prefix in forbidden_prefixes:
                 assert not module.startswith(prefix), (
                     f"adapters.py imports from {module} (forbids {prefix}.*)"

--- a/tests/onboarding/test_adapters.py
+++ b/tests/onboarding/test_adapters.py
@@ -249,6 +249,32 @@ class TestDrugToleranceDefaults:
         assert result.drug_tolerance == 3
         assert isinstance(result.drug_tolerance, int)
 
+    def test_zero_darkness_level_preserved(self):
+        """``darkness_level=0`` is preserved as 0 — NOT coerced to 3 via falsy-or.
+
+        Regression guard for the QA iter-6 finding: a naïve ``or 3`` guard would
+        silently replace the legitimate value 0 with 3. The adapter uses an
+        explicit ``is None`` check, so concretely-provided falsy ints round-trip.
+
+        Production paths cannot reach here because both ``OnboardingV2ProfileRequest``
+        and ``BackstoryPreviewRequest`` constrain ``Field(ge=1, le=5)``. This
+        guard therefore protects against:
+          - duck-typed test stubs with ``darkness_level=0``
+          - future callers bypassing Pydantic validation (e.g., repository seeds)
+        """
+        profile_zero = SimpleNamespace(
+            city="Berlin",
+            social_scene="techno",
+            darkness_level=0,
+            life_stage=None,
+            interest=None,
+            age=None,
+            occupation=None,
+        )
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), profile_zero)
+        assert result.drug_tolerance == 0
+        assert isinstance(result.drug_tolerance, int)
+
 
 class TestForwardCompatNameField:
     """Per spec constraints: `name` is net-new in PR 213-2. Adapter must not crash

--- a/tests/onboarding/test_adapters.py
+++ b/tests/onboarding/test_adapters.py
@@ -1,0 +1,218 @@
+"""Tests for Spec 213 Pydantic↔ORM adapter (FR-3.1).
+
+Validates that `ProfileFromOnboardingProfile.from_pydantic` returns a
+`BackstoryPromptProfile` dataclass with DUCK-TYPED attribute names matching
+what `BackstoryGeneratorService._build_scenario_prompt` actually reads
+(NOT the `UserProfile` ORM column names).
+
+Load-bearing: the generator reads `.city` (NOT `.location_city`) and
+`.primary_passion` (NOT `.primary_interest`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import is_dataclass
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from nikita.onboarding.adapters import BackstoryPromptProfile, ProfileFromOnboardingProfile
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rich_profile():
+    """SimpleNamespace standing in for a UserOnboardingProfile with all fields set."""
+    return SimpleNamespace(
+        city="Berlin",
+        social_scene="techno",
+        life_stage="tech",
+        interest="underground music",
+        darkness_level=4,
+        name="Alex",
+        age=29,
+        occupation="Software Engineer",
+    )
+
+
+@pytest.fixture
+def sparse_profile():
+    """Profile with only required fields (city + scene + darkness_level + all optionals None)."""
+    return SimpleNamespace(
+        city="Paris",
+        social_scene="art",
+        life_stage=None,
+        interest=None,
+        darkness_level=2,
+        name=None,
+        age=None,
+        occupation=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# BackstoryPromptProfile dataclass shape
+# ---------------------------------------------------------------------------
+
+
+class TestBackstoryPromptProfileDataclass:
+    """Confirm the duck-typed shape matches BackstoryGeneratorService reads."""
+
+    def test_is_dataclass(self):
+        assert is_dataclass(BackstoryPromptProfile)
+
+    def test_has_city_not_location_city(self):
+        """CRITICAL: generator reads profile.city (NOT profile.location_city)."""
+        fields = {f.name for f in BackstoryPromptProfile.__dataclass_fields__.values()}
+        assert "city" in fields
+        assert "location_city" not in fields
+
+    def test_has_primary_passion_not_primary_interest(self):
+        """CRITICAL: generator reads profile.primary_passion (NOT profile.primary_interest)."""
+        fields = {f.name for f in BackstoryPromptProfile.__dataclass_fields__.values()}
+        assert "primary_passion" in fields
+        assert "primary_interest" not in fields
+
+    def test_has_drug_tolerance_not_darkness_level(self):
+        """Generator legacy field name is drug_tolerance (ORM-adjacent)."""
+        fields = {f.name for f in BackstoryPromptProfile.__dataclass_fields__.values()}
+        assert "drug_tolerance" in fields
+
+    def test_has_all_required_fields(self):
+        """Full attribute inventory per spec FR-3.1 table."""
+        fields = {f.name for f in BackstoryPromptProfile.__dataclass_fields__.values()}
+        expected = {
+            "city",
+            "social_scene",
+            "life_stage",
+            "primary_passion",
+            "drug_tolerance",
+            "name",
+            "age",
+            "occupation",
+        }
+        assert expected.issubset(fields)
+
+
+# ---------------------------------------------------------------------------
+# from_pydantic: field mapping
+# ---------------------------------------------------------------------------
+
+
+class TestFromPydanticFieldMapping:
+    """Validates the Pydantic→duck-typed-dataclass mapping per spec FR-3.1 table."""
+
+    def test_city_passes_through(self, rich_profile):
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
+        assert result.city == "Berlin"
+
+    def test_social_scene_passes_through(self, rich_profile):
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
+        assert result.social_scene == "techno"
+
+    def test_life_stage_passes_through(self, rich_profile):
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
+        assert result.life_stage == "tech"
+
+    def test_interest_maps_to_primary_passion(self, rich_profile):
+        """NAME-COLLISION mapping: Pydantic.interest → dataclass.primary_passion."""
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
+        assert result.primary_passion == "underground music"
+
+    def test_darkness_level_maps_to_drug_tolerance(self, rich_profile):
+        """Legacy name mapping: Pydantic.darkness_level → dataclass.drug_tolerance."""
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
+        assert result.drug_tolerance == 4
+
+    def test_name_passes_through(self, rich_profile):
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
+        assert result.name == "Alex"
+
+    def test_age_passes_through(self, rich_profile):
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
+        assert result.age == 29
+
+    def test_occupation_passes_through(self, rich_profile):
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
+        assert result.occupation == "Software Engineer"
+
+    def test_returns_dataclass_instance(self, rich_profile):
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
+        assert isinstance(result, BackstoryPromptProfile)
+
+
+class TestFromPydanticNoneFields:
+    """Optional fields pass through as None without errors."""
+
+    def test_all_optionals_none(self, sparse_profile):
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), sparse_profile)
+        assert result.life_stage is None
+        assert result.primary_passion is None
+        assert result.name is None
+        assert result.age is None
+        assert result.occupation is None
+        # Required fields still populated
+        assert result.city == "Paris"
+        assert result.social_scene == "art"
+        assert result.drug_tolerance == 2
+
+
+# ---------------------------------------------------------------------------
+# Duck-typing compatibility with BackstoryGeneratorService
+# ---------------------------------------------------------------------------
+
+
+class TestDuckTypeCompatibility:
+    """Ensure the returned object exposes EXACTLY the attributes the generator reads."""
+
+    def test_not_a_user_profile_orm(self, rich_profile):
+        """CRITICAL: result is a dataclass, NOT a UserProfile ORM object.
+
+        UserProfile has `location_city` and `primary_interest` — attempting to
+        construct one would require a DB session + SQLAlchemy machinery. The
+        adapter deliberately returns a lightweight dataclass instead.
+        """
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
+        # Confirm it's NOT any SQLAlchemy model
+        cls = type(result)
+        # No `__tablename__` (SQLAlchemy models have it), no `_sa_instance_state`
+        assert not hasattr(cls, "__tablename__")
+        assert not hasattr(result, "_sa_instance_state")
+
+    def test_all_generator_reads_succeed(self, rich_profile):
+        """Simulate what BackstoryGeneratorService does: attribute access."""
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
+        # These are the attribute accesses made at backstory_generator.py:180, 183, 220
+        _ = result.city
+        _ = result.primary_passion
+        _ = result.social_scene  # plus the other reads used by _build_scenario_prompt
+
+
+# ---------------------------------------------------------------------------
+# Forward-compat (name field is net-new per FR-1c; adapter handles absence)
+# ---------------------------------------------------------------------------
+
+
+class TestForwardCompatNameField:
+    """Per spec constraints: `name` is net-new in PR 213-2. Adapter must not crash
+    on profiles that predate the field (forward-compat with existing Pydantic models)."""
+
+    def test_name_missing_from_profile_yields_none(self):
+        """A profile without a `name` attribute produces `name=None`, not AttributeError."""
+        profile_no_name = SimpleNamespace(
+            city="Tokyo",
+            social_scene="nature",
+            life_stage=None,
+            interest=None,
+            darkness_level=1,
+            age=None,
+            occupation=None,
+        )
+        # no `name` attribute at all
+        result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), profile_no_name)
+        assert result.name is None

--- a/tests/onboarding/test_adapters.py
+++ b/tests/onboarding/test_adapters.py
@@ -190,21 +190,23 @@ class TestDuckTypeCompatibility:
         Covers the COMPLETE set of attributes the generator reads on the
         profile passed into ``generate_scenarios``. Missing any of these at
         runtime would raise ``AttributeError`` deep inside the service — the
-        adapter must guarantee all reads succeed. Keep this list in sync
-        with ``nikita/services/backstory_generator.py``.
+        adapter must guarantee all reads succeed AND return the expected
+        mapped values. Keep this list in sync with
+        ``nikita/services/backstory_generator.py``.
         """
         result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
         # Complete set of reads made inside BackstoryGeneratorService
-        # (backstory_generator.py:{180,183,185,220} and related sites). All
-        # must resolve without AttributeError.
-        _ = result.city
-        _ = result.primary_passion
-        _ = result.social_scene
-        _ = result.life_stage
-        _ = result.drug_tolerance
-        _ = result.name
-        _ = result.age
-        _ = result.occupation
+        # (backstory_generator.py:{180,183,185,220} and related sites). Each
+        # assertion pins the VALUE to catch silent field-mapping regressions,
+        # not just AttributeError absence.
+        assert result.city == "Berlin"
+        assert result.primary_passion == "underground music"
+        assert result.social_scene == "techno"
+        assert result.life_stage == "tech"
+        assert result.drug_tolerance == 4
+        assert result.name == "Alex"
+        assert result.age == 29
+        assert result.occupation == "Software Engineer"
 
 
 # ---------------------------------------------------------------------------
@@ -230,3 +232,49 @@ class TestForwardCompatNameField:
         # no `name` attribute at all
         result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), profile_no_name)
         assert result.name is None
+
+
+# ---------------------------------------------------------------------------
+# Module isolation guard
+# ---------------------------------------------------------------------------
+
+
+def test_module_isolation_imports():
+    """FR-3.1 isolation: adapters.py is a lightweight bridge.
+
+    It MUST NOT import from:
+      - nikita.engine.*           (different domain)
+      - nikita.db.*               (no persistence — returns plain dataclass)
+
+    The adapter MAY import from ``nikita.onboarding.models`` (the Pydantic
+    domain) since it explicitly bridges that surface to the duck-typed
+    dataclass. Current implementation uses ``getattr`` + ``object`` typing
+    and does not import the Pydantic class — the guard here preserves that
+    freedom while still forbidding engine/db coupling.
+
+    Inspects the AST rather than source text (docstring mentions the
+    forbidden paths as a negation — 'MUST NOT import' — which would produce
+    a false positive on a text-substring match).
+    """
+    import ast
+    import inspect
+
+    from nikita.onboarding import adapters
+
+    forbidden_prefixes = ("nikita.engine", "nikita.db")
+
+    src = inspect.getsource(adapters)
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                for prefix in forbidden_prefixes:
+                    assert not alias.name.startswith(prefix), (
+                        f"adapters.py imports {alias.name} (forbids {prefix}.*)"
+                    )
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for prefix in forbidden_prefixes:
+                assert not module.startswith(prefix), (
+                    f"adapters.py imports from {module} (forbids {prefix}.*)"
+                )

--- a/tests/onboarding/test_adapters.py
+++ b/tests/onboarding/test_adapters.py
@@ -185,12 +185,26 @@ class TestDuckTypeCompatibility:
         assert not hasattr(result, "_sa_instance_state")
 
     def test_all_generator_reads_succeed(self, rich_profile):
-        """Simulate what BackstoryGeneratorService does: attribute access."""
+        """Simulate what BackstoryGeneratorService does: attribute access.
+
+        Covers the COMPLETE set of attributes the generator reads on the
+        profile passed into ``generate_scenarios``. Missing any of these at
+        runtime would raise ``AttributeError`` deep inside the service — the
+        adapter must guarantee all reads succeed. Keep this list in sync
+        with ``nikita/services/backstory_generator.py``.
+        """
         result = ProfileFromOnboardingProfile.from_pydantic(uuid4(), rich_profile)
-        # These are the attribute accesses made at backstory_generator.py:180, 183, 220
+        # Complete set of reads made inside BackstoryGeneratorService
+        # (backstory_generator.py:{180,183,185,220} and related sites). All
+        # must resolve without AttributeError.
         _ = result.city
         _ = result.primary_passion
-        _ = result.social_scene  # plus the other reads used by _build_scenario_prompt
+        _ = result.social_scene
+        _ = result.life_stage
+        _ = result.drug_tolerance
+        _ = result.name
+        _ = result.age
+        _ = result.occupation
 
 
 # ---------------------------------------------------------------------------

--- a/tests/onboarding/test_contracts.py
+++ b/tests/onboarding/test_contracts.py
@@ -513,6 +513,51 @@ class TestErrorResponse:
 # ---------------------------------------------------------------------------
 
 
+def test_module_isolation_imports():
+    """FR-2 isolation: contracts.py is the frozen API surface.
+
+    It MUST NOT import from:
+      - nikita.onboarding.models  (would re-couple frozen surface to Pydantic domain)
+      - nikita.db.*               (would couple contracts to persistence)
+      - nikita.engine.*           (different domain; spec FR-2)
+
+    Inspects the AST rather than source text (module docstring mentions the
+    forbidden paths as a negation — 'MUST NOT import' — which would produce a
+    false positive on a text-substring match).
+    """
+    import ast
+    import inspect
+
+    from nikita.onboarding import contracts
+
+    forbidden_prefixes = ("nikita.engine", "nikita.db")
+    forbidden_exact = {"nikita.onboarding.models"}
+
+    src = inspect.getsource(contracts)
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                for prefix in forbidden_prefixes:
+                    assert not alias.name.startswith(prefix), (
+                        f"contracts.py imports {alias.name} (FR-2 forbids {prefix}.*)"
+                    )
+                assert alias.name not in forbidden_exact, (
+                    f"contracts.py imports {alias.name} (FR-2 isolation — "
+                    f"frozen surface must not re-couple to Pydantic domain)"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for prefix in forbidden_prefixes:
+                assert not module.startswith(prefix), (
+                    f"contracts.py imports from {module} (FR-2 forbids {prefix}.*)"
+                )
+            assert module not in forbidden_exact, (
+                f"contracts.py imports from {module} (FR-2 isolation — "
+                f"frozen surface must not re-couple to Pydantic domain)"
+            )
+
+
 class TestPipelineReadyState:
     def test_type_alias_has_expected_literal_values(self):
         """Regression guard: PipelineReadyState must expose the 4 values

--- a/tests/onboarding/test_contracts.py
+++ b/tests/onboarding/test_contracts.py
@@ -1,0 +1,521 @@
+"""Tests for nikita.onboarding.contracts (Spec 213 PR 213-1).
+
+TDD: RED phase — all tests must FAIL until contracts.py is implemented.
+Tests cover:
+- T1.1: OnboardingV2ProfileRequest/Response validation
+- T1.2: BackstoryOption tone Literal validation
+- T2.1: PipelineReadyResponse + PipelineReadyState + new FR-2a fields
+- BackstoryPreviewRequest/Response basic shape
+- ErrorResponse
+"""
+
+import pytest
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pydantic
+
+
+# ---------------------------------------------------------------------------
+# T1.1: OnboardingV2ProfileRequest validation
+# ---------------------------------------------------------------------------
+
+
+class TestOnboardingV2ProfileRequest:
+    def test_rejects_age_below_18(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            OnboardingV2ProfileRequest(
+                location_city="Berlin",
+                social_scene="techno",
+                drug_tolerance=3,
+                age=17,
+            )
+
+    def test_rejects_age_above_99(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            OnboardingV2ProfileRequest(
+                location_city="Berlin",
+                social_scene="techno",
+                drug_tolerance=3,
+                age=100,
+            )
+
+    def test_accepts_valid_age_18(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        req = OnboardingV2ProfileRequest(
+            location_city="Berlin",
+            social_scene="techno",
+            drug_tolerance=3,
+            age=18,
+        )
+        assert req.age == 18
+
+    def test_accepts_valid_age_99(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        req = OnboardingV2ProfileRequest(
+            location_city="Berlin",
+            social_scene="techno",
+            drug_tolerance=3,
+            age=99,
+        )
+        assert req.age == 99
+
+    def test_rejects_empty_city(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            OnboardingV2ProfileRequest(
+                location_city="",
+                social_scene="techno",
+                drug_tolerance=3,
+            )
+
+    def test_rejects_city_too_short(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            OnboardingV2ProfileRequest(
+                location_city="X",
+                social_scene="techno",
+                drug_tolerance=3,
+            )
+
+    def test_rejects_phone_too_short(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            OnboardingV2ProfileRequest(
+                location_city="Berlin",
+                social_scene="techno",
+                drug_tolerance=3,
+                phone="+1",
+            )
+
+    def test_accepts_name_age_occupation(self):
+        """AC-T1.1.2: Optional fields name, age, occupation accepted."""
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        req = OnboardingV2ProfileRequest(
+            location_city="Paris",
+            social_scene="art",
+            drug_tolerance=2,
+            name="Alex",
+            age=28,
+            occupation="designer",
+        )
+        assert req.name == "Alex"
+        assert req.age == 28
+        assert req.occupation == "designer"
+
+    def test_accepts_all_social_scenes(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        valid_scenes = ["techno", "art", "food", "cocktails", "nature"]
+        for scene in valid_scenes:
+            req = OnboardingV2ProfileRequest(
+                location_city="Berlin",
+                social_scene=scene,
+                drug_tolerance=3,
+            )
+            assert req.social_scene == scene
+
+    def test_rejects_invalid_social_scene(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            OnboardingV2ProfileRequest(
+                location_city="Berlin",
+                social_scene="clubbing",  # not in Literal
+                drug_tolerance=3,
+            )
+
+    def test_rejects_drug_tolerance_below_1(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            OnboardingV2ProfileRequest(
+                location_city="Berlin",
+                social_scene="techno",
+                drug_tolerance=0,
+            )
+
+    def test_rejects_drug_tolerance_above_5(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            OnboardingV2ProfileRequest(
+                location_city="Berlin",
+                social_scene="techno",
+                drug_tolerance=6,
+            )
+
+    def test_wizard_step_accepted_valid(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        req = OnboardingV2ProfileRequest(
+            location_city="Berlin",
+            social_scene="techno",
+            drug_tolerance=3,
+            wizard_step=5,
+        )
+        assert req.wizard_step == 5
+
+    def test_wizard_step_rejects_zero(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            OnboardingV2ProfileRequest(
+                location_city="Berlin",
+                social_scene="techno",
+                drug_tolerance=3,
+                wizard_step=0,
+            )
+
+    def test_wizard_step_rejects_above_11(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            OnboardingV2ProfileRequest(
+                location_city="Berlin",
+                social_scene="techno",
+                drug_tolerance=3,
+                wizard_step=12,
+            )
+
+
+# ---------------------------------------------------------------------------
+# T1.1: OnboardingV2ProfileResponse validation
+# ---------------------------------------------------------------------------
+
+
+class TestOnboardingV2ProfileResponse:
+    def test_chosen_option_defaults_to_none(self):
+        """AC-T1.1.3: chosen_option is ALWAYS None from Spec 213 endpoints."""
+        from nikita.onboarding.contracts import OnboardingV2ProfileResponse
+
+        user_id = uuid4()
+        resp = OnboardingV2ProfileResponse(
+            user_id=user_id,
+            pipeline_state="pending",
+            backstory_options=[],
+            chosen_option=None,
+            poll_endpoint=f"/api/v1/onboarding/pipeline-ready/{user_id}",
+            poll_interval_seconds=2.0,
+            poll_max_wait_seconds=20.0,
+        )
+        assert resp.chosen_option is None
+
+    def test_includes_all_required_fields(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileResponse
+
+        user_id = uuid4()
+        resp = OnboardingV2ProfileResponse(
+            user_id=user_id,
+            pipeline_state="pending",
+            backstory_options=[],
+            chosen_option=None,
+            poll_endpoint=f"/api/v1/onboarding/pipeline-ready/{user_id}",
+            poll_interval_seconds=2.0,
+            poll_max_wait_seconds=20.0,
+        )
+        assert resp.user_id == user_id
+        assert resp.pipeline_state == "pending"
+        assert resp.backstory_options == []
+
+    def test_accepts_valid_pipeline_states(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileResponse
+
+        user_id = uuid4()
+        for state in ("pending", "ready", "degraded", "failed"):
+            resp = OnboardingV2ProfileResponse(
+                user_id=user_id,
+                pipeline_state=state,
+                backstory_options=[],
+                chosen_option=None,
+                poll_endpoint="/api/v1/onboarding/pipeline-ready/x",
+                poll_interval_seconds=2.0,
+                poll_max_wait_seconds=20.0,
+            )
+            assert resp.pipeline_state == state
+
+    def test_rejects_invalid_pipeline_state(self):
+        from nikita.onboarding.contracts import OnboardingV2ProfileResponse
+
+        user_id = uuid4()
+        with pytest.raises(pydantic.ValidationError):
+            OnboardingV2ProfileResponse(
+                user_id=user_id,
+                pipeline_state="unknown",  # not in Literal
+                backstory_options=[],
+                chosen_option=None,
+                poll_endpoint="/api/v1/onboarding/pipeline-ready/x",
+                poll_interval_seconds=2.0,
+                poll_max_wait_seconds=20.0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# T1.2: BackstoryOption tone Literal
+# ---------------------------------------------------------------------------
+
+
+class TestBackstoryOption:
+    def test_tone_literal_rejects_bad_string(self):
+        """T1.2: invalid tone string must be rejected by Pydantic."""
+        from nikita.onboarding.contracts import BackstoryOption
+
+        with pytest.raises(pydantic.ValidationError):
+            BackstoryOption(
+                id="abc123",
+                venue="A jazz bar",
+                context="Dim lights and saxophone",
+                the_moment="Our eyes met",
+                unresolved_hook="She left before I could ask her name",
+                tone="mysterious",  # NOT in spec Literal — tasks.md T1.2 says: romantic|intellectual|chaotic
+            )
+
+    def test_tone_accepts_valid_values(self):
+        from nikita.onboarding.contracts import BackstoryOption
+
+        for tone in ("romantic", "intellectual", "chaotic"):
+            opt = BackstoryOption(
+                id="abc123",
+                venue="A jazz bar",
+                context="Dim lights",
+                the_moment="Our eyes met",
+                unresolved_hook="She left",
+                tone=tone,
+            )
+            assert opt.tone == tone
+
+    def test_all_required_fields_present(self):
+        from nikita.onboarding.contracts import BackstoryOption
+
+        opt = BackstoryOption(
+            id="abc123456789",
+            venue="Rooftop bar",
+            context="Summer night with city lights",
+            the_moment="A stranger dropped a book",
+            unresolved_hook="She disappeared into the crowd",
+            tone="chaotic",
+        )
+        assert opt.id == "abc123456789"
+        assert opt.venue == "Rooftop bar"
+        assert opt.unresolved_hook == "She disappeared into the crowd"
+
+
+# ---------------------------------------------------------------------------
+# T2.1: PipelineReadyResponse + PipelineReadyState + FR-2a fields
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineReadyResponse:
+    def test_required_fields(self):
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        now = datetime.now(tz=timezone.utc)
+        resp = PipelineReadyResponse(
+            state="ready",
+            checked_at=now,
+        )
+        assert resp.state == "ready"
+        assert resp.checked_at == now
+        assert resp.message is None
+
+    def test_defaults_venue_research_status_to_pending(self):
+        """FR-2a: venue_research_status defaults to 'pending' when key absent."""
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        resp = PipelineReadyResponse(
+            state="pending",
+            checked_at=datetime.now(tz=timezone.utc),
+        )
+        assert resp.venue_research_status == "pending"
+
+    def test_defaults_backstory_available_to_false(self):
+        """FR-2a: backstory_available defaults to False when key absent."""
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        resp = PipelineReadyResponse(
+            state="pending",
+            checked_at=datetime.now(tz=timezone.utc),
+        )
+        assert resp.backstory_available is False
+
+    def test_accepts_venue_research_status_values(self):
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        now = datetime.now(tz=timezone.utc)
+        for status in ("pending", "complete", "failed", "cache_hit"):
+            resp = PipelineReadyResponse(
+                state="ready",
+                checked_at=now,
+                venue_research_status=status,
+            )
+            assert resp.venue_research_status == status
+
+    def test_rejects_invalid_venue_research_status(self):
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        with pytest.raises(pydantic.ValidationError):
+            PipelineReadyResponse(
+                state="ready",
+                checked_at=datetime.now(tz=timezone.utc),
+                venue_research_status="unknown",
+            )
+
+    def test_backstory_available_can_be_true(self):
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        resp = PipelineReadyResponse(
+            state="ready",
+            checked_at=datetime.now(tz=timezone.utc),
+            backstory_available=True,
+        )
+        assert resp.backstory_available is True
+
+    def test_accepts_all_pipeline_states(self):
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        now = datetime.now(tz=timezone.utc)
+        for state in ("pending", "ready", "degraded", "failed"):
+            resp = PipelineReadyResponse(state=state, checked_at=now)
+            assert resp.state == state
+
+    def test_rejects_invalid_pipeline_state(self):
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        with pytest.raises(pydantic.ValidationError):
+            PipelineReadyResponse(
+                state="not_a_state",
+                checked_at=datetime.now(tz=timezone.utc),
+            )
+
+    def test_full_payload_with_all_fr2a_fields(self):
+        """AC-2.5: response includes venue_research_status + backstory_available."""
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        resp = PipelineReadyResponse(
+            state="ready",
+            checked_at=datetime.now(tz=timezone.utc),
+            venue_research_status="complete",
+            backstory_available=True,
+        )
+        assert resp.venue_research_status == "complete"
+        assert resp.backstory_available is True
+
+
+# ---------------------------------------------------------------------------
+# BackstoryPreviewRequest/Response
+# ---------------------------------------------------------------------------
+
+
+class TestBackstoryPreviewRequest:
+    def test_accepts_minimal_valid_payload(self):
+        from nikita.onboarding.contracts import BackstoryPreviewRequest
+
+        req = BackstoryPreviewRequest(
+            city="Berlin",
+            social_scene="techno",
+            darkness_level=3,
+        )
+        assert req.city == "Berlin"
+        assert req.social_scene == "techno"
+        assert req.darkness_level == 3
+
+    def test_rejects_city_too_short(self):
+        from nikita.onboarding.contracts import BackstoryPreviewRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            BackstoryPreviewRequest(city="X", social_scene="techno", darkness_level=3)
+
+    def test_rejects_darkness_level_below_1(self):
+        from nikita.onboarding.contracts import BackstoryPreviewRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            BackstoryPreviewRequest(city="Berlin", social_scene="techno", darkness_level=0)
+
+    def test_rejects_darkness_level_above_5(self):
+        from nikita.onboarding.contracts import BackstoryPreviewRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            BackstoryPreviewRequest(city="Berlin", social_scene="techno", darkness_level=6)
+
+    def test_age_optional(self):
+        from nikita.onboarding.contracts import BackstoryPreviewRequest
+
+        req = BackstoryPreviewRequest(city="Berlin", social_scene="techno", darkness_level=3)
+        assert req.age is None
+
+    def test_rejects_age_below_18(self):
+        from nikita.onboarding.contracts import BackstoryPreviewRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            BackstoryPreviewRequest(
+                city="Berlin", social_scene="techno", darkness_level=3, age=17
+            )
+
+
+class TestBackstoryPreviewResponse:
+    def test_basic_shape(self):
+        from nikita.onboarding.contracts import BackstoryPreviewResponse
+
+        resp = BackstoryPreviewResponse(
+            scenarios=[],
+            venues_used=["The Tresor", "Berghain"],
+            cache_key="abc123",
+            degraded=False,
+        )
+        assert resp.scenarios == []
+        assert resp.venues_used == ["The Tresor", "Berghain"]
+        assert resp.cache_key == "abc123"
+        assert resp.degraded is False
+
+    def test_degraded_true(self):
+        from nikita.onboarding.contracts import BackstoryPreviewResponse
+
+        resp = BackstoryPreviewResponse(
+            scenarios=[],
+            venues_used=[],
+            cache_key="x",
+            degraded=True,
+        )
+        assert resp.degraded is True
+
+
+# ---------------------------------------------------------------------------
+# ErrorResponse
+# ---------------------------------------------------------------------------
+
+
+class TestErrorResponse:
+    def test_error_response_has_detail(self):
+        from nikita.onboarding.contracts import ErrorResponse
+
+        err = ErrorResponse(detail="Not authorized")
+        assert err.detail == "Not authorized"
+
+    def test_error_response_rejects_missing_detail(self):
+        from nikita.onboarding.contracts import ErrorResponse
+
+        with pytest.raises(pydantic.ValidationError):
+            ErrorResponse()  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# PipelineReadyState type alias
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineReadyState:
+    def test_type_alias_exported(self):
+        from nikita.onboarding.contracts import PipelineReadyState
+
+        # Should be importable (type alias, not a class — just check it's something)
+        assert PipelineReadyState is not None

--- a/tests/onboarding/test_contracts.py
+++ b/tests/onboarding/test_contracts.py
@@ -568,6 +568,13 @@ def test_module_isolation_imports():
                 )
         elif isinstance(node, ast.ImportFrom):
             module = node.module or ""
+            # Guard against relative imports (`from . import X`) which would
+            # bypass absolute-path prefix checks. Frozen surface must stay a
+            # dependency-free leaf within the package.
+            assert node.level == 0, (
+                f"contracts.py uses a relative import (level={node.level}) — "
+                f"disallowed; frozen surface must remain a dependency-free leaf"
+            )
             for prefix in forbidden_prefixes:
                 assert not module.startswith(prefix), (
                     f"contracts.py imports from {module} (FR-2 forbids {prefix}.*)"

--- a/tests/onboarding/test_contracts.py
+++ b/tests/onboarding/test_contracts.py
@@ -461,6 +461,26 @@ class TestBackstoryPreviewRequest:
                 city="Berlin", social_scene="techno", darkness_level=3, age=17
             )
 
+    def test_rejects_age_above_99(self):
+        """Upper-edge boundary: same ``Field(ge=18, le=99)`` constraint as the
+        sibling ``OnboardingV2ProfileRequest`` — enforce it here too."""
+        from nikita.onboarding.contracts import BackstoryPreviewRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            BackstoryPreviewRequest(
+                city="Berlin", social_scene="techno", darkness_level=3, age=100
+            )
+
+    def test_rejects_invalid_social_scene(self):
+        """``social_scene`` is a Literal; values outside the 5-member set are
+        rejected at validation, not silently accepted."""
+        from nikita.onboarding.contracts import BackstoryPreviewRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            BackstoryPreviewRequest(
+                city="Berlin", social_scene="sportsbar", darkness_level=3
+            )
+
 
 class TestBackstoryPreviewResponse:
     def test_basic_shape(self):

--- a/tests/onboarding/test_contracts.py
+++ b/tests/onboarding/test_contracts.py
@@ -514,8 +514,15 @@ class TestErrorResponse:
 
 
 class TestPipelineReadyState:
-    def test_type_alias_exported(self):
+    def test_type_alias_has_expected_literal_values(self):
+        """Regression guard: PipelineReadyState must expose the 4 values
+        spec FR-2/§FR-5.1 defines (pending, ready, degraded, failed).
+
+        A trivial `is not None` check would pass even if the alias was
+        accidentally reassigned to `True` or a different Literal set.
+        """
+        from typing import get_args
+
         from nikita.onboarding.contracts import PipelineReadyState
 
-        # Should be importable (type alias, not a class — just check it's something)
-        assert PipelineReadyState is not None
+        assert get_args(PipelineReadyState) == ("pending", "ready", "degraded", "failed")

--- a/tests/onboarding/test_contracts.py
+++ b/tests/onboarding/test_contracts.py
@@ -113,6 +113,24 @@ class TestOnboardingV2ProfileRequest:
         assert req.age == 28
         assert req.occupation == "designer"
 
+    def test_rejects_empty_occupation(self):
+        """Spec §FR-1c requires ``min_length=1`` on final-submit occupation.
+
+        Paired with ``TestBackstoryPreviewRequest::
+        test_accepts_empty_occupation_spec_intentional_asymmetry`` to make the
+        deliberate schema divergence visible in the test suite — preview
+        accepts empty (exploratory), final submit rejects empty (strict).
+        """
+        from nikita.onboarding.contracts import OnboardingV2ProfileRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            OnboardingV2ProfileRequest(
+                location_city="Berlin",
+                social_scene="techno",
+                drug_tolerance=3,
+                occupation="",
+            )
+
     def test_accepts_all_social_scenes(self):
         from nikita.onboarding.contracts import OnboardingV2ProfileRequest
 
@@ -479,6 +497,43 @@ class TestBackstoryPreviewRequest:
         with pytest.raises(pydantic.ValidationError):
             BackstoryPreviewRequest(
                 city="Berlin", social_scene="sportsbar", darkness_level=3
+            )
+
+    def test_accepts_empty_occupation_spec_intentional_asymmetry(self):
+        """Spec 213 §FR-4a deliberately declares ``occupation`` with only
+        ``max_length=100`` (no ``min_length``) — the preview endpoint is
+        exploratory and accepts looser inputs than the final-submit schema.
+
+        This asymmetry is load-bearing for Spec 214 portal consumers that may
+        call preview-backstory with an empty occupation before the user has
+        entered their profession. The empty string buckets to ``"other"`` in
+        ``compute_backstory_cache_key`` and produces a usable preview.
+
+        Regression guard for QA iter-7 finding G1: adding ``min_length=1``
+        here would violate the frozen spec and break the preview path.
+        """
+        from nikita.onboarding.contracts import BackstoryPreviewRequest
+
+        req = BackstoryPreviewRequest(
+            city="Berlin",
+            social_scene="techno",
+            darkness_level=3,
+            occupation="",
+        )
+        assert req.occupation == ""
+
+    def test_rejects_occupation_over_max_length(self):
+        """``max_length=100`` IS enforced — upper bound preserved even though
+        ``min_length`` is absent. Complements the empty-string test above so
+        both boundary behaviors are documented in the test suite."""
+        from nikita.onboarding.contracts import BackstoryPreviewRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            BackstoryPreviewRequest(
+                city="Berlin",
+                social_scene="techno",
+                darkness_level=3,
+                occupation="a" * 101,
             )
 
 

--- a/tests/onboarding/test_tuning_constants.py
+++ b/tests/onboarding/test_tuning_constants.py
@@ -1,0 +1,317 @@
+"""Regression guards for Spec 213 tuning constants (FR-4).
+
+Per .claude/rules/tuning-constants.md: every tuning constant needs a test
+asserting its exact current value + a comment referencing the driving GH issue.
+
+Compound constants (tuple-of-tuples, dict) use deep-equality assertion AND
+explicit boundary tests (inclusive edges).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from types import SimpleNamespace
+from typing import Final
+
+import pytest
+
+from nikita.onboarding import tuning
+from nikita.onboarding.tuning import (
+    AGE_BUCKETS,
+    BACKSTORY_CACHE_TTL_DAYS,
+    BACKSTORY_GEN_TIMEOUT_S,
+    BACKSTORY_HOOK_PROBABILITY,
+    OCCUPATION_CATEGORIES,
+    PIPELINE_GATE_MAX_WAIT_S,
+    PIPELINE_GATE_POLL_INTERVAL_S,
+    PREVIEW_RATE_LIMIT_PER_MIN,
+    VENUE_RESEARCH_TIMEOUT_S,
+    _age_bucket,
+    _occupation_bucket,
+    compute_backstory_cache_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# Scalar constants — exact value + type
+# ---------------------------------------------------------------------------
+
+
+class TestScalarConstants:
+    """Regression guard: exact value for each tuning constant (GH #213)."""
+
+    def test_venue_research_timeout_s(self):
+        assert VENUE_RESEARCH_TIMEOUT_S == 15.0
+        assert isinstance(VENUE_RESEARCH_TIMEOUT_S, float)
+
+    def test_backstory_gen_timeout_s(self):
+        assert BACKSTORY_GEN_TIMEOUT_S == 20.0
+        assert isinstance(BACKSTORY_GEN_TIMEOUT_S, float)
+
+    def test_pipeline_gate_poll_interval_s(self):
+        assert PIPELINE_GATE_POLL_INTERVAL_S == 2.0
+        assert isinstance(PIPELINE_GATE_POLL_INTERVAL_S, float)
+
+    def test_pipeline_gate_max_wait_s(self):
+        assert PIPELINE_GATE_MAX_WAIT_S == 20.0
+        assert isinstance(PIPELINE_GATE_MAX_WAIT_S, float)
+
+    def test_backstory_cache_ttl_days(self):
+        assert BACKSTORY_CACHE_TTL_DAYS == 30
+        assert isinstance(BACKSTORY_CACHE_TTL_DAYS, int)
+
+    def test_backstory_hook_probability(self):
+        assert BACKSTORY_HOOK_PROBABILITY == 0.50
+        assert 0.0 <= BACKSTORY_HOOK_PROBABILITY <= 1.0
+
+    def test_preview_rate_limit_per_min(self):
+        assert PREVIEW_RATE_LIMIT_PER_MIN == 5
+        assert isinstance(PREVIEW_RATE_LIMIT_PER_MIN, int)
+
+
+# ---------------------------------------------------------------------------
+# Compound constants — deep equality + boundary tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgeBuckets:
+    """Regression + boundary guards for AGE_BUCKETS (GH #213)."""
+
+    def test_age_buckets_exact_value(self):
+        """Deep equality on the entire tuple-of-tuples."""
+        assert AGE_BUCKETS == (
+            (18, 24, "young_adult"),
+            (25, 34, "twenties"),
+            (35, 49, "midlife"),
+            (50, 99, "experienced"),
+        )
+
+    def test_age_buckets_no_gaps(self):
+        """Adjacent buckets are contiguous (high+1 == next low)."""
+        for (_, high, _), (low, _, _) in zip(AGE_BUCKETS, AGE_BUCKETS[1:]):
+            assert low == high + 1
+
+    def test_age_buckets_non_overlapping(self):
+        """All ranges strictly ordered."""
+        prev_high = -1
+        for low, high, _ in AGE_BUCKETS:
+            assert low > prev_high
+            prev_high = high
+
+
+class TestAgeToBucket:
+    """Inclusive-edge boundary tests for _age_bucket."""
+
+    @pytest.mark.parametrize(
+        "age, expected",
+        [
+            (18, "young_adult"),  # lower edge
+            (24, "young_adult"),  # upper edge of young_adult
+            (25, "twenties"),  # lower edge of twenties (off-by-one guard)
+            (34, "twenties"),
+            (35, "midlife"),
+            (49, "midlife"),
+            (50, "experienced"),
+            (99, "experienced"),  # upper edge of experienced
+        ],
+    )
+    def test_boundary_inclusive(self, age: int, expected: str):
+        assert _age_bucket(age) == expected
+
+    def test_none_returns_unknown(self):
+        assert _age_bucket(None) == "unknown"
+
+    def test_below_range_returns_unknown(self):
+        assert _age_bucket(17) == "unknown"
+
+    def test_above_range_returns_unknown(self):
+        assert _age_bucket(100) == "unknown"
+
+
+class TestOccupationCategories:
+    """Regression guard for OCCUPATION_CATEGORIES dict (GH #213)."""
+
+    def test_occupation_categories_exact_value(self):
+        """Deep equality on the full mapping."""
+        assert OCCUPATION_CATEGORIES == {
+            "engineer": "tech",
+            "developer": "tech",
+            "designer": "tech",
+            "artist": "arts",
+            "musician": "arts",
+            "writer": "arts",
+            "banker": "finance",
+            "trader": "finance",
+            "analyst": "finance",
+            "nurse": "healthcare",
+            "doctor": "healthcare",
+            "student": "student",
+            "barista": "service",
+            "server": "service",
+            "retail": "service",
+        }
+
+
+class TestOccupationToBucket:
+    """Substring-match behavior of _occupation_bucket."""
+
+    @pytest.mark.parametrize(
+        "occupation, expected",
+        [
+            ("Software Engineer", "tech"),
+            ("Senior developer", "tech"),
+            ("Visual Designer", "tech"),
+            ("Freelance artist", "arts"),
+            ("Jazz Musician", "arts"),
+            ("Investment Banker", "finance"),
+            ("Day trader", "finance"),
+            ("Data analyst", "finance"),
+            ("Registered nurse", "healthcare"),
+            ("GP Doctor", "healthcare"),
+            ("PhD student", "student"),
+            ("Coffee barista", "service"),
+            ("Waiter/server", "service"),
+            ("Retail assistant", "service"),
+        ],
+    )
+    def test_substring_match(self, occupation: str, expected: str):
+        assert _occupation_bucket(occupation) == expected
+
+    def test_none_returns_unknown(self):
+        assert _occupation_bucket(None) == "unknown"
+
+    def test_unknown_string_returns_other(self):
+        """Occupations with no matching substring bucket into 'other'."""
+        assert _occupation_bucket("Astronaut") == "other"
+        assert _occupation_bucket("Chef") == "other"
+
+    def test_empty_string_returns_other(self):
+        """Empty string has no substring matches → 'other' (NOT 'unknown' reserved for None)."""
+        assert _occupation_bucket("") == "other"
+
+
+# ---------------------------------------------------------------------------
+# compute_backstory_cache_key — determinism + shape
+# ---------------------------------------------------------------------------
+
+
+class TestComputeBackstoryCacheKey:
+    """Validates cache key determinism + bucketing behavior."""
+
+    def _make_profile(
+        self,
+        city: str | None = "Berlin",
+        social_scene: str | None = "techno",
+        darkness_level: int = 3,
+        life_stage: str | None = "tech",
+        interest: str | None = "music",
+        age: int | None = 27,
+        occupation: str | None = "Software Engineer",
+    ) -> object:
+        """Builds a SimpleNamespace matching UserOnboardingProfile duck-type."""
+        return SimpleNamespace(
+            city=city,
+            social_scene=social_scene,
+            darkness_level=darkness_level,
+            life_stage=life_stage,
+            interest=interest,
+            age=age,
+            occupation=occupation,
+        )
+
+    def test_deterministic_same_inputs_same_key(self):
+        """Same inputs → same key (required for cache coherence FR-4a)."""
+        p1 = self._make_profile()
+        p2 = self._make_profile()
+        assert compute_backstory_cache_key(p1) == compute_backstory_cache_key(p2)
+
+    def test_different_city_different_key(self):
+        k1 = compute_backstory_cache_key(self._make_profile(city="Berlin"))
+        k2 = compute_backstory_cache_key(self._make_profile(city="Paris"))
+        assert k1 != k2
+
+    def test_city_case_insensitive(self):
+        """City is lowercased for stable bucketing."""
+        k1 = compute_backstory_cache_key(self._make_profile(city="Berlin"))
+        k2 = compute_backstory_cache_key(self._make_profile(city="BERLIN"))
+        k3 = compute_backstory_cache_key(self._make_profile(city="berlin"))
+        assert k1 == k2 == k3
+
+    def test_none_fields_bucket_to_unknown(self):
+        """Missing fields don't break the key (substitute 'unknown' or 'other')."""
+        key = compute_backstory_cache_key(
+            self._make_profile(
+                city=None,
+                social_scene=None,
+                life_stage=None,
+                interest=None,
+                age=None,
+                occupation=None,
+            )
+        )
+        # key should contain 'unknown' tokens but still be a valid string
+        assert isinstance(key, str)
+        assert "unknown" in key
+
+    def test_age_bucketing_applied(self):
+        """Different ages in same bucket → same key portion; different buckets → different key."""
+        k25 = compute_backstory_cache_key(self._make_profile(age=25))
+        k30 = compute_backstory_cache_key(self._make_profile(age=30))
+        # Both in 'twenties' bucket
+        assert k25 == k30
+
+        k50 = compute_backstory_cache_key(self._make_profile(age=50))
+        # Different bucket
+        assert k25 != k50
+
+    def test_occupation_bucketing_applied(self):
+        """Same occupation category → same key."""
+        k_eng = compute_backstory_cache_key(self._make_profile(occupation="Senior Engineer"))
+        k_dev = compute_backstory_cache_key(self._make_profile(occupation="Junior Developer"))
+        # Both bucket to 'tech'
+        assert k_eng == k_dev
+
+    def test_returns_string(self):
+        assert isinstance(compute_backstory_cache_key(self._make_profile()), str)
+
+    def test_format_delimiter(self):
+        """Key uses '|' delimiter per spec FR-3 step 3."""
+        key = compute_backstory_cache_key(self._make_profile())
+        # Expected format: city|scene|darkness|life_stage|interest|age_bucket|occupation_bucket (7 parts)
+        assert key.count("|") == 6
+
+
+# ---------------------------------------------------------------------------
+# Signature test — module namespace compliance
+# ---------------------------------------------------------------------------
+
+
+def test_compute_backstory_cache_key_signature():
+    """Asserts compute_backstory_cache_key lives at nikita.onboarding.tuning (per spec FR-4)."""
+    assert hasattr(tuning, "compute_backstory_cache_key")
+    assert callable(tuning.compute_backstory_cache_key)
+
+
+def test_module_no_engine_constants_import():
+    """FR-4 isolation constraint: tuning.py MUST NOT import nikita.engine.constants.
+
+    Inspects the AST rather than source text (docstring mentions the forbidden
+    path as a negation — 'MUST NOT import' — which would produce a false positive
+    on a text-substring match).
+    """
+    import ast
+    import inspect
+
+    src = inspect.getsource(tuning)
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("nikita.engine"), (
+                    f"tuning.py imports {alias.name} (FR-4 forbids nikita.engine.*)"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            assert not module.startswith("nikita.engine"), (
+                f"tuning.py imports from {module} (FR-4 forbids nikita.engine.*)"
+            )

--- a/tests/onboarding/test_tuning_constants.py
+++ b/tests/onboarding/test_tuning_constants.py
@@ -202,7 +202,7 @@ class TestComputeBackstoryCacheKey:
         self,
         city: str | None = "Berlin",
         social_scene: str | None = "techno",
-        darkness_level: int = 3,
+        darkness_level: int | None = 3,
         life_stage: str | None = "tech",
         interest: str | None = "music",
         age: int | None = 27,
@@ -238,11 +238,17 @@ class TestComputeBackstoryCacheKey:
         assert k1 == k2 == k3
 
     def test_none_fields_bucket_to_unknown(self):
-        """Missing fields substitute 'unknown'/'other' — never the raw string 'None'."""
+        """Missing fields substitute 'unknown'/'other' — never the raw string 'None'.
+
+        Covers every field that can legitimately be None on an in-progress
+        Pydantic profile, including ``darkness_level`` (required on submit but
+        may be absent on duck-typed stand-ins).
+        """
         key = compute_backstory_cache_key(
             self._make_profile(
                 city=None,
                 social_scene=None,
+                darkness_level=None,
                 life_stage=None,
                 interest=None,
                 age=None,
@@ -252,12 +258,25 @@ class TestComputeBackstoryCacheKey:
         assert isinstance(key, str)
         assert "unknown" in key
         # Regression guard: str(None) == "None" must never leak into the key.
-        # Triggers if a None-check is accidentally removed from either bucket
+        # Triggers if a None-check is accidentally removed from any bucket
         # helper or from the f-string substitution.
         assert "None" not in key
         # Shape guard: 7 parts separated by '|' — 6 delimiters regardless of
         # whether inputs are None.
         assert key.count("|") == 6
+
+    def test_darkness_level_none_uses_unknown(self):
+        """darkness_level=None maps to 'unknown' in the key, NOT 'None'.
+
+        Explicit regression: the docstring on compute_backstory_cache_key
+        promises 'unknown substituted for None values' — darkness_level is
+        the only non-bucketed field in the key, so it needs its own targeted
+        guard beyond the all-None case.
+        """
+        key = compute_backstory_cache_key(self._make_profile(darkness_level=None))
+        parts = key.split("|")
+        assert parts[2] == "unknown"
+        assert "None" not in key
 
     def test_age_bucketing_applied(self):
         """Different ages in same bucket → same key portion; different buckets → different key."""

--- a/tests/onboarding/test_tuning_constants.py
+++ b/tests/onboarding/test_tuning_constants.py
@@ -349,6 +349,13 @@ def test_module_isolation_imports():
                 )
         elif isinstance(node, ast.ImportFrom):
             module = node.module or ""
+            # Guard against relative imports (`from . import X` / `from .models import Y`)
+            # which would bypass the absolute-path prefix checks. Reject ANY
+            # relative import — tuning.py must stay a dependency-free leaf.
+            assert node.level == 0, (
+                f"tuning.py uses a relative import (level={node.level}) — "
+                f"disallowed; module must remain a dependency-free leaf"
+            )
             for prefix in forbidden_prefixes:
                 assert not module.startswith(prefix), (
                     f"tuning.py imports from {module} (FR-4 forbids {prefix}.*)"

--- a/tests/onboarding/test_tuning_constants.py
+++ b/tests/onboarding/test_tuning_constants.py
@@ -238,7 +238,7 @@ class TestComputeBackstoryCacheKey:
         assert k1 == k2 == k3
 
     def test_none_fields_bucket_to_unknown(self):
-        """Missing fields don't break the key (substitute 'unknown' or 'other')."""
+        """Missing fields substitute 'unknown'/'other' — never the raw string 'None'."""
         key = compute_backstory_cache_key(
             self._make_profile(
                 city=None,
@@ -249,9 +249,15 @@ class TestComputeBackstoryCacheKey:
                 occupation=None,
             )
         )
-        # key should contain 'unknown' tokens but still be a valid string
         assert isinstance(key, str)
         assert "unknown" in key
+        # Regression guard: str(None) == "None" must never leak into the key.
+        # Triggers if a None-check is accidentally removed from either bucket
+        # helper or from the f-string substitution.
+        assert "None" not in key
+        # Shape guard: 7 parts separated by '|' — 6 delimiters regardless of
+        # whether inputs are None.
+        assert key.count("|") == 6
 
     def test_age_bucketing_applied(self):
         """Different ages in same bucket → same key portion; different buckets → different key."""
@@ -292,26 +298,43 @@ def test_compute_backstory_cache_key_signature():
     assert callable(tuning.compute_backstory_cache_key)
 
 
-def test_module_no_engine_constants_import():
-    """FR-4 isolation constraint: tuning.py MUST NOT import nikita.engine.constants.
+def test_module_isolation_imports():
+    """FR-4 isolation: tuning.py is a pure constants + pure-function module.
 
-    Inspects the AST rather than source text (docstring mentions the forbidden
-    path as a negation — 'MUST NOT import' — which would produce a false positive
-    on a text-substring match).
+    It MUST NOT import from:
+      - nikita.engine.*           (different domain; spec FR-4)
+      - nikita.onboarding.models  (would couple constants to Pydantic surface)
+      - nikita.db.*               (would couple constants to persistence)
+
+    Inspects the AST rather than source text (module docstring mentions the
+    forbidden paths as a negation — 'MUST NOT import' — which would produce a
+    false positive on a text-substring match).
     """
     import ast
     import inspect
+
+    forbidden_prefixes = ("nikita.engine", "nikita.db")
+    forbidden_exact = {"nikita.onboarding.models"}
 
     src = inspect.getsource(tuning)
     tree = ast.parse(src)
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                assert not alias.name.startswith("nikita.engine"), (
-                    f"tuning.py imports {alias.name} (FR-4 forbids nikita.engine.*)"
+                for prefix in forbidden_prefixes:
+                    assert not alias.name.startswith(prefix), (
+                        f"tuning.py imports {alias.name} (FR-4 forbids {prefix}.*)"
+                    )
+                assert alias.name not in forbidden_exact, (
+                    f"tuning.py imports {alias.name} (FR-4 isolation)"
                 )
         elif isinstance(node, ast.ImportFrom):
             module = node.module or ""
-            assert not module.startswith("nikita.engine"), (
-                f"tuning.py imports from {module} (FR-4 forbids nikita.engine.*)"
+            for prefix in forbidden_prefixes:
+                assert not module.startswith(prefix), (
+                    f"tuning.py imports from {module} (FR-4 forbids {prefix}.*)"
+                )
+            assert module not in forbidden_exact, (
+                f"tuning.py imports from {module} (FR-4 isolation — "
+                f"constants module must remain free of domain-model coupling)"
             )

--- a/tests/onboarding/test_tuning_constants.py
+++ b/tests/onboarding/test_tuning_constants.py
@@ -69,6 +69,34 @@ class TestScalarConstants:
         assert isinstance(PREVIEW_RATE_LIMIT_PER_MIN, int)
 
 
+class TestTimeoutRelationalInvariants:
+    """Cross-constant invariants — catch silent drift when individual
+    timeouts are tuned without considering their relationships (GH #213).
+
+    Added in QA iter-6 to guard the docstring claim that
+    ``PIPELINE_GATE_MAX_WAIT_S`` bounds both service timeouts. If any future
+    edit raises BACKSTORY_GEN_TIMEOUT_S or VENUE_RESEARCH_TIMEOUT_S above
+    20s without updating MAX_WAIT, these assertions fail — forcing the
+    author to reconcile the budget.
+    """
+
+    def test_poll_interval_smaller_than_max_wait(self):
+        """Portal must poll at least once before max-wait expires."""
+        assert PIPELINE_GATE_POLL_INTERVAL_S < PIPELINE_GATE_MAX_WAIT_S
+
+    def test_max_wait_at_least_backstory_timeout(self):
+        """MAX_WAIT must bound BACKSTORY_GEN_TIMEOUT (the dominant service)
+        so the portal does not unblock before the slower service can return
+        a concrete result on the happy path."""
+        assert PIPELINE_GATE_MAX_WAIT_S >= BACKSTORY_GEN_TIMEOUT_S
+
+    def test_max_wait_at_least_venue_research_timeout(self):
+        """MAX_WAIT must also bound VENUE_RESEARCH_TIMEOUT for the same
+        reason — parallel fanout means the slower of the two defines the
+        wait budget."""
+        assert PIPELINE_GATE_MAX_WAIT_S >= VENUE_RESEARCH_TIMEOUT_S
+
+
 # ---------------------------------------------------------------------------
 # Compound constants — deep equality + boundary tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First of 5 PRs decomposed from **Spec 213: Onboarding Backend Foundation**. Ships the **frozen Pydantic contract surface** that unblocks Spec 214 (portal wizard) to begin in parallel once this merges.

- `nikita/onboarding/contracts.py` — 7 Pydantic types (FR-2, FR-2a, FR-4a)
- `nikita/onboarding/tuning.py` — 9 `Final` constants + cache-key bucketing (FR-4)
- `nikita/onboarding/adapters.py` — duck-typed Pydantic↔generator bridge (FR-3.1)
- `nikita/onboarding/__init__.py` — package exports for Spec 214 consumers
- SDD artifacts: spec.md (1058L), plan.md (292L), tasks.md (513L), audit-report.md (PASS)

## Stats

- **7 new files** / **1563 lines** (code + tests)
- **109 new tests GREEN** (42 contracts + 49 tuning + 18 adapters)
- **446 total** in `tests/onboarding/` — zero regressions
- **10-iteration GATE 2** (60 findings → 0 at absolute-zero across all 6 validators)
- **GATE 3 audit**: 11/11 articles PASS, 100% FR + AC coverage, 0 residuals

## Key design decisions (from spec)

- **contracts.py isolation**: zero imports from `nikita.onboarding.models`, `nikita.db.*`, `nikita.engine.constants` — frozen surface, any change requires ADR
- **tuning.py isolation**: zero imports from `nikita.engine.constants` — enforced by AST-inspecting test
- **Adapter duck-typing** (load-bearing per Architecture iter-3): returns `BackstoryPromptProfile` dataclass with `.city` / `.primary_passion` / `.drug_tolerance` matching what `BackstoryGeneratorService._build_scenario_prompt` actually reads at `backstory_generator.py:{180,183,220}` — NOT a real `UserProfile` ORM row (whose columns are `location_city` / `primary_interest` / `darkness_level`)
- **Forward-compat**: `from_pydantic` uses `getattr(profile, attr, None)` so adapter tolerates profiles lacking `name` field (net-new in PR 213-2)
- **Named tuning constants** per `.claude/rules/tuning-constants.md`: every constant has prior-value + rationale docstring + regression guard

## TDD evidence

All 7 commits on this branch follow strict RED-GREEN pair discipline:

1. `docs(onboarding): Spec 213 backend foundation — SDD artifacts`
2. `test(onboarding): contracts tests for Spec 213 (FR-2, FR-2a, FR-4a)` ← RED
3. `feat(onboarding): contracts.py — frozen Pydantic contract surface` ← GREEN
4. `test(onboarding): tuning constants regression + cache_key tests (FR-4)` ← RED
5. `feat(onboarding): tuning.py — Final constants + cache-key bucketing (FR-4)` ← GREEN
6. `test(onboarding): adapters tests — duck-typed Pydantic↔generator bridge (FR-3.1)` ← RED
7. `feat(onboarding): adapters.py — duck-typed Pydantic↔generator bridge (FR-3.1)` ← GREEN
8. `feat(onboarding): export Spec 213 frozen contract surface from __init__`

## Downstream

- **Unblocks**: Spec 214 (portal wizard) — can start in parallel after merge
- **Blocks**: PRs 213-2, 213-3, 213-4, 213-5 (sequential chain)

## Test plan

- [x] `pytest tests/onboarding/test_contracts.py` — 42 passed
- [x] `pytest tests/onboarding/test_tuning_constants.py` — 49 passed
- [x] `pytest tests/onboarding/test_adapters.py` — 18 passed
- [x] `pytest tests/onboarding/` full suite — 446 passed (0 regressions)
- [x] `python -c "from nikita.onboarding import BackstoryOption, compute_backstory_cache_key, ProfileFromOnboardingProfile"` — all importable
- [ ] `/qa-review --pr N` run and converge to absolute-zero before merge
- [ ] Post-merge smoke: auto-dispatched subagent per `.claude/rules/pr-workflow.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)