### PR TITLE
chore(deploy): Spec 213 backend → Cloud Run nikita-api-00250-4mm

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,9 +26,9 @@ version: 1.0.2
 | Pipeline stages | 11 |
 | Feature flags | 6/6 ON |
 | pg_cron jobs | 8 active |
-| Cloud Run deploy | `nikita-api-00249-mdv` (us-central1) |
+| Cloud Run deploy | `nikita-api-00250-4mm` (us-central1) |
 | Portal deploy | `portal-phi-orcin.vercel.app` |
-| Last deploy | 2026-04-15 (Spec 213 PR 213-5 — FR-6 backstory hook + R8 continuity) |
+| Last deploy | 2026-04-15 (Spec 213 backend foundation — PRs 213-1..213-5: frozen contracts, migration, facade, routes, FR-6 first-message + R8 continuity) |
 | Active specs | 1 (214 portal-wizard) |
 | In-flight | none (Spec 213 closed PR 213-5; Spec 214 portal-wizard pending) |
 


### PR DESCRIPTION
## Summary

Post-deploy ROADMAP bump after successful Cloud Run deployment of Spec 213 (onboarding backend foundation, 5 PRs 213-1..213-5 merged 2026-04-15, master tip `be546b3`).

- Updated Cloud Run revision: `nikita-api-00249-mdv` → `nikita-api-00250-4mm`
- Updated Last deploy description to reference the full Spec 213 series (not just PR 213-5 merge)

## Smoke test plan (already executed pre-PR)

- [x] `GET /health` → 200
- [x] `POST /api/v1/onboarding/preview-backstory` → 401 (auth guard firing, route registered)
- [x] `GET /api/v1/onboarding/pipeline-ready/{user_id}` → 401
- [x] `PATCH /api/v1/onboarding/profile` → 401
- [x] OpenAPI schema lists all three new routes
- [x] Cloud Run boot log clean (no errors, no tracebacks)
- [x] Legacy endpoints unaffected (`/` → 200, `/profile` GET → 405 expected)

Deployment verified by auto-dispatched read-only smoke subagent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)