### PR TITLE
feat(214-d): PUT /profile/chosen-option + wizard_step (Spec 214 PR 214-D)

### DIFF
--- a/nikita/api/middleware/rate_limit.py
+++ b/nikita/api/middleware/rate_limit.py
@@ -1,4 +1,4 @@
-"""Rate limiting dependencies for voice and preview API endpoints.
+"""Rate limiting dependencies for voice, preview, choice, and poll API endpoints.
 
 voice_rate_limit (SEC-010): checks DatabaseRateLimiter before allowing
 voice calls through. Fails open on DB errors to avoid blocking legitimate callers.
@@ -6,6 +6,15 @@ voice calls through. Fails open on DB errors to avoid blocking legitimate caller
 _PreviewRateLimiter + preview_rate_limit (Spec 213 FR-4a.1): separate
 per-user limiter for POST /onboarding/preview-backstory — limit=5/min,
 'preview:' key prefix isolates BOTH minute AND day counters from voice.
+
+Spec 214 PR 214-D additions:
+_ChoiceRateLimiter + choice_rate_limit (FR-10.1): per-user limiter for
+PUT /onboarding/profile/chosen-option — limit=10/min, 'choice:' prefix.
+429 responses include Retry-After: 60 header (RFC 6585).
+
+_PipelineReadyRateLimiter + pipeline_ready_rate_limit (AC-5.6): per-user
+limiter for GET /onboarding/pipeline-ready/{user_id} — limit=30/min,
+'poll:' prefix. 429 responses include Retry-After: 60 header.
 """
 
 import hashlib
@@ -17,7 +26,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from nikita.api.dependencies.auth import get_current_user_id
 from nikita.db.database import get_async_session
-from nikita.onboarding.tuning import PREVIEW_RATE_LIMIT_PER_MIN
+from nikita.onboarding.tuning import (
+    CHOICE_RATE_LIMIT_PER_MIN,
+    PIPELINE_POLL_RATE_LIMIT_PER_MIN,
+    PREVIEW_RATE_LIMIT_PER_MIN,
+)
 from nikita.platforms.telegram.rate_limiter import DatabaseRateLimiter
 
 logger = logging.getLogger(__name__)
@@ -148,6 +161,141 @@ async def preview_rate_limit(
     if not result.allowed:
         logger.warning(
             "[PREVIEW RATE LIMIT] Rejected user=%s reason=%s",
+            current_user_id,
+            result.reason,
+        )
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded",
+            headers={"Retry-After": "60"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Choice backstory rate limiter (Spec 214 FR-10.1)
+# ---------------------------------------------------------------------------
+
+
+class _ChoiceRateLimiter(DatabaseRateLimiter):
+    """DatabaseRateLimiter subclass for PUT /onboarding/profile/chosen-option.
+
+    Overrides:
+    - MAX_PER_MINUTE: 10 (from CHOICE_RATE_LIMIT_PER_MIN tuning constant)
+    - _get_minute_window(): adds 'choice:' prefix so choice calls are
+      counted separately from voice/preview calls in the rate_limits table.
+    - _get_day_window(): adds 'choice:' prefix so daily choice quota is
+      also isolated (mirrors _PreviewRateLimiter pattern at rate_limit.py).
+
+    CHOICE_RATE_LIMIT_PER_MIN = 10 (new in Spec 214 PR 214-D).
+    Prior values: none. Rationale: one-shot user action (no external service
+    call), idempotent endpoint; 10/min allows legitimate retries without abuse.
+    """
+
+    # CHOICE_RATE_LIMIT_PER_MIN = 10 (Spec 214 PR 214-D).
+    MAX_PER_MINUTE: int = CHOICE_RATE_LIMIT_PER_MIN
+
+    def _get_minute_window(self) -> str:
+        """Return prefixed window key to isolate choice counters from voice/preview.
+
+        Format: 'choice:minute:<YYYY-MM-DD-HH-MM>'
+        Prefix ensures the UPSERT key never collides with 'minute:<...>' (voice)
+        or 'preview:minute:<...>' in the rate_limits table.
+        """
+        return f"choice:{super()._get_minute_window()}"
+
+    def _get_day_window(self) -> str:
+        """Return prefixed day window key to isolate choice daily quota.
+
+        Format: 'choice:day:<YYYY-MM-DD>'
+        Without this override the daily counter row is shared with voice (F-03
+        precedent from _PreviewRateLimiter); must prefix both windows.
+        """
+        return f"choice:{super()._get_day_window()}"
+
+
+async def choice_rate_limit(
+    current_user_id: UUID = Depends(get_current_user_id),
+    session: AsyncSession = Depends(get_async_session),
+) -> None:
+    """FastAPI dependency: enforce 10 req/min per user on chosen-option PUT.
+
+    Uses _ChoiceRateLimiter (DatabaseRateLimiter subclass) so counters
+    persist across Cloud Run instances and survive restarts.
+
+    Raises:
+        HTTPException: 429 with Retry-After: 60 header when limit exceeded
+            (RFC 6585 — same pattern as preview_rate_limit).
+    """
+    limiter = _ChoiceRateLimiter(session)
+    result = await limiter.check(current_user_id)
+    if not result.allowed:
+        logger.warning(
+            "[CHOICE RATE LIMIT] Rejected user=%s reason=%s",
+            current_user_id,
+            result.reason,
+        )
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded",
+            headers={"Retry-After": "60"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pipeline-ready poll rate limiter (Spec 214 AC-5.6)
+# ---------------------------------------------------------------------------
+
+
+class _PipelineReadyRateLimiter(DatabaseRateLimiter):
+    """DatabaseRateLimiter subclass for GET /pipeline-ready/{user_id}.
+
+    Overrides:
+    - MAX_PER_MINUTE: 30 (from PIPELINE_POLL_RATE_LIMIT_PER_MIN tuning constant)
+    - _get_minute_window(): adds 'poll:' prefix for counter isolation.
+    - _get_day_window(): adds 'poll:' prefix for daily quota isolation.
+
+    PIPELINE_POLL_RATE_LIMIT_PER_MIN = 30 (new in Spec 214 PR 214-D, AC-5.6).
+    Prior values: none (endpoint was previously unlimited).
+    Rationale: portal polls every 2s over 20s window → 10 calls nominal. 30/min
+    allows 3× overrun (mobile reconnects, tab backgrounding) without 429.
+    """
+
+    # PIPELINE_POLL_RATE_LIMIT_PER_MIN = 30 (Spec 214 PR 214-D).
+    MAX_PER_MINUTE: int = PIPELINE_POLL_RATE_LIMIT_PER_MIN
+
+    def _get_minute_window(self) -> str:
+        """Return prefixed window key to isolate poll counters from voice/preview/choice.
+
+        Format: 'poll:minute:<YYYY-MM-DD-HH-MM>'
+        """
+        return f"poll:{super()._get_minute_window()}"
+
+    def _get_day_window(self) -> str:
+        """Return prefixed day window key to isolate poll daily quota.
+
+        Format: 'poll:day:<YYYY-MM-DD>'
+        """
+        return f"poll:{super()._get_day_window()}"
+
+
+async def pipeline_ready_rate_limit(
+    current_user_id: UUID = Depends(get_current_user_id),
+    session: AsyncSession = Depends(get_async_session),
+) -> None:
+    """FastAPI dependency: enforce 30 req/min per user on pipeline-ready GET.
+
+    Uses _PipelineReadyRateLimiter (DatabaseRateLimiter subclass) so counters
+    persist across Cloud Run instances and survive restarts.
+
+    Raises:
+        HTTPException: 429 with Retry-After: 60 header when limit exceeded
+            (RFC 6585 — same pattern as preview_rate_limit and choice_rate_limit).
+    """
+    limiter = _PipelineReadyRateLimiter(session)
+    result = await limiter.check(current_user_id)
+    if not result.allowed:
+        logger.warning(
+            "[PIPELINE READY RATE LIMIT] Rejected user=%s reason=%s",
             current_user_id,
             result.reason,
         )

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -379,6 +379,10 @@ async def put_chosen_option(
         pipeline_state,
     )
 
+    # 214-D: selection endpoint never re-emits backstory_options (per the
+    # OnboardingV2ProfileResponse contract — options are only emitted by the
+    # POST /profile + GET /pipeline-ready endpoints during the wizard's
+    # backstory-reveal step). Empty list signals "selection complete".
     return OnboardingV2ProfileResponse(
         user_id=current_user_id,
         pipeline_state=pipeline_state,

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -23,9 +23,14 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from nikita.api.dependencies.auth import get_current_user_id
+from nikita.api.middleware.rate_limit import (
+    choice_rate_limit,
+    pipeline_ready_rate_limit,
+)
 from nikita.api.middleware.rate_limit import preview_rate_limit as _preview_rate_limit
 from nikita.db.database import get_async_session
 from nikita.onboarding.contracts import (
+    BackstoryChoiceRequest,
     BackstoryPreviewRequest,
     BackstoryPreviewResponse,
     OnboardingV2ProfileRequest,
@@ -153,6 +158,7 @@ async def get_pipeline_ready(
     user_id: UUID,
     current_user_id: UUID = Depends(get_current_user_id),
     session: AsyncSession = Depends(get_async_session),
+    _: None = Depends(pipeline_ready_rate_limit),
 ) -> PipelineReadyResponse:
     """Return pipeline readiness state for the authenticated user.
 
@@ -185,6 +191,8 @@ async def get_pipeline_ready(
     pipeline_state = profile.get("pipeline_state", "pending")
     venue_research_status = profile.get("venue_research_status", "pending")
     backstory_available = profile.get("backstory_available", False)
+    # Spec 214 FR-10.2: wizard_step passthrough (None when absent)
+    wizard_step = profile.get("wizard_step")
 
     # Build optional user-facing message for degraded/failed states only
     message: str | None = None
@@ -195,11 +203,12 @@ async def get_pipeline_ready(
         )
 
     logger.info(
-        "portal_pipeline_ready.polled user_id=%s state=%s venue_status=%s backstory=%s",
+        "portal_pipeline_ready.polled user_id=%s state=%s venue_status=%s backstory=%s wizard_step=%s",
         user_id,
         pipeline_state,
         venue_research_status,
         backstory_available,
+        wizard_step,
     )
 
     return PipelineReadyResponse(
@@ -208,6 +217,7 @@ async def get_pipeline_ready(
         backstory_available=backstory_available,
         checked_at=datetime.now(UTC),
         message=message,
+        wizard_step=wizard_step,
     )
 
 
@@ -304,6 +314,76 @@ async def patch_profile(
         pipeline_state=response_state,
         backstory_options=[],
         chosen_option=None,
+        poll_endpoint=f"/api/v1/onboarding/pipeline-ready/{current_user_id}",
+        poll_interval_seconds=PIPELINE_GATE_POLL_INTERVAL_S,
+        poll_max_wait_seconds=PIPELINE_GATE_MAX_WAIT_S,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spec 214 PR 214-D: PUT /profile/chosen-option  (FR-10.1)
+# ---------------------------------------------------------------------------
+
+
+@router.put(
+    "/profile/chosen-option",
+    response_model=OnboardingV2ProfileResponse,
+    summary="Record chosen backstory scenario (Spec 214 FR-10.1)",
+    description="""
+    Validate + persist the authenticated user's backstory selection.
+
+    Idempotent: PUT with the same (user_id, chosen_option_id, cache_key)
+    returns 200 and the same snapshot on every call.
+
+    Ownership is enforced by recomputing cache_key from the user's
+    onboarding_profile JSONB (backstory_cache has no user_id column).
+    Stale profile changes between preview and PUT → 403.
+
+    Rate limited to 10 req/min per user (FR-10.1). 429 responses include
+    Retry-After: 60 header (RFC 6585).
+    """,
+)
+async def put_chosen_option(
+    body: BackstoryChoiceRequest,
+    current_user_id: UUID = Depends(get_current_user_id),
+    session: AsyncSession = Depends(get_async_session),
+    _: None = Depends(choice_rate_limit),
+) -> OnboardingV2ProfileResponse:
+    """Record the authenticated user's backstory selection.
+
+    Raises:
+        HTTPException(403): cache_key mismatch (stale/cross-user attempt).
+        HTTPException(404): no backstory_cache row for cache_key.
+        HTTPException(409): chosen_option_id not in the stored scenarios.
+        HTTPException(429): rate limit exceeded (Retry-After: 60).
+    """
+    from nikita.db.repositories.user_repository import UserRepository
+
+    facade = PortalOnboardingFacade()
+    chosen_option = await facade.set_chosen_option(
+        user_id=current_user_id,
+        chosen_option_id=body.chosen_option_id,
+        cache_key=body.cache_key,
+        session=session,
+    )
+
+    # Refresh user to pick up pipeline_state after the write above.
+    user_repo = UserRepository(session)
+    user = await user_repo.get(current_user_id)
+    profile = (user.onboarding_profile or {}) if user is not None else {}
+    pipeline_state = profile.get("pipeline_state", "pending")
+
+    logger.info(
+        "portal_put_chosen_option.done user_id=%s pipeline_state=%s",
+        current_user_id,
+        pipeline_state,
+    )
+
+    return OnboardingV2ProfileResponse(
+        user_id=current_user_id,
+        pipeline_state=pipeline_state,
+        backstory_options=[],
+        chosen_option=chosen_option,
         poll_endpoint=f"/api/v1/onboarding/pipeline-ready/{current_user_id}",
         poll_interval_seconds=PIPELINE_GATE_POLL_INTERVAL_S,
         poll_max_wait_seconds=PIPELINE_GATE_MAX_WAIT_S,

--- a/nikita/onboarding/contracts.py
+++ b/nikita/onboarding/contracts.py
@@ -5,6 +5,10 @@ Standalone Pydantic request/response types for the portal onboarding v2 API.
 CONSTRAINT: This module MUST NOT import from nikita.onboarding.models,
 nikita.db.*, or nikita.engine.constants. It is a frozen contract surface
 shared with Spec 214 (portal wizard). Any field addition requires an ADR.
+
+Spec 214 PR 214-D additive extensions (strictly backward-compatible):
+- BackstoryChoiceRequest (new — FR-10.1 chosen-option endpoint)
+- PipelineReadyResponse.wizard_step: int | None (new — FR-10.2 resume detection)
 """
 
 from __future__ import annotations
@@ -105,6 +109,9 @@ class PipelineReadyResponse(BaseModel):
     FR-2a fields (venue_research_status, backstory_available) default to
     conservative values when JSONB keys are absent — keeps the read path
     as a single-SELECT NFR-1 path (p99 ≤200ms).
+
+    Spec 214 FR-10.2 additive extension: wizard_step optional field for
+    cross-device resume detection. None if user has not advanced past step 3.
     """
 
     state: PipelineReadyState
@@ -118,6 +125,20 @@ class PipelineReadyResponse(BaseModel):
     """Venue research progress. Defaults to 'pending' if JSONB key missing."""
     backstory_available: bool = False
     """True once scenarios have been persisted to backstory_cache. Defaults False."""
+
+    # Spec 214 FR-10.2: wizard_step for cross-device resume (additive, optional)
+    wizard_step: int | None = Field(
+        default=None,
+        ge=1,
+        le=11,
+        description=(
+            "Last completed wizard step for resume detection. "
+            "None if user has not advanced past step 3 or key is absent from JSONB. "
+            "Range ge=1,le=11 mirrors OnboardingV2ProfilePatchRequest.wizard_step. "
+            "Added in Spec 214 PR 214-D (FR-10.2) — non-breaking; existing consumers "
+            "that do not reference this field are unaffected."
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -165,6 +186,44 @@ class BackstoryPreviewResponse(BaseModel):
     """Opaque cache key for debugging/observability (NOT echoed back on submit)."""
     degraded: bool
     """True if backstory service failed; scenarios will be empty or generic."""
+
+
+# ---------------------------------------------------------------------------
+# BackstoryChoiceRequest (Spec 214 FR-10.1 — PUT /profile/chosen-option)
+# ---------------------------------------------------------------------------
+
+
+class BackstoryChoiceRequest(BaseModel):
+    """Request body for PUT /api/v1/onboarding/profile/chosen-option.
+
+    Spec 214 FR-10.1 additive extension. This is the ONLY endpoint that
+    echoes cache_key — required for the idempotency guard + stale-selection
+    rejection to function across retries (future cleanup must preserve this
+    field). chosen_option_id is the sha256[:12] opaque id from BackstoryOption.
+
+    NOT in the frozen Spec 213 contract surface — added as part of Spec 214
+    PR 214-D, which is the first PR in the Spec 214 chain.
+    """
+
+    chosen_option_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description=(
+            "Opaque backstory option id (sha256[:12] format). "
+            "Must appear in the BackstoryCacheRepository row for the given cache_key."
+        ),
+    )
+    cache_key: str = Field(
+        ...,
+        min_length=1,
+        max_length=128,
+        description=(
+            "Canonical cache key echoed from BackstoryPreviewResponse. "
+            "Backend recomputes the key from the authenticated user's profile "
+            "and rejects 403 if it does not match (stale or cross-user selection)."
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/nikita/onboarding/tuning.py
+++ b/nikita/onboarding/tuning.py
@@ -93,6 +93,27 @@ with different cost profile. Separate counter key prefix 'preview:' avoids shari
 with the voice rate limiter.
 """
 
+CHOICE_RATE_LIMIT_PER_MIN: Final[int] = 10
+"""Per-user rate limit for PUT /onboarding/profile/chosen-option (Spec 214 FR-10.1).
+
+Prior values: none (new in Spec 214 PR 214-D, GH issue tracked in Spec 214).
+Rationale: selecting a backstory is a one-shot user action — no external service call
+incurred, unlike preview (5/min). 10/min is generous; allows legitimate retries
+(endpoint is idempotent) without enabling abuse. Separate 'choice:' key prefix
+isolates counters from voice (SEC-010) and preview (Spec 213 'preview:' prefix).
+Used by _ChoiceRateLimiter in nikita/api/middleware/rate_limit.py.
+"""
+
+PIPELINE_POLL_RATE_LIMIT_PER_MIN: Final[int] = 30
+"""Per-user rate limit for GET /onboarding/pipeline-ready/{user_id} (Spec 214 AC-5.6).
+
+Prior values: none (endpoint was previously unlimited; new rate limit in Spec 214 PR 214-D).
+Rationale: portal polls at PIPELINE_GATE_POLL_INTERVAL_S=2.0s → ~30 calls over the
+20s PIPELINE_GATE_MAX_WAIT_S window. 30/min matches exactly one full poll cycle without
+false-positive 429s. 'poll:' key prefix isolates from voice/preview/choice counters.
+Used by _PipelineReadyRateLimiter in nikita/api/middleware/rate_limit.py.
+"""
+
 # ---------------------------------------------------------------------------
 # Cache-key bucketing
 # ---------------------------------------------------------------------------

--- a/nikita/services/portal_onboarding.py
+++ b/nikita/services/portal_onboarding.py
@@ -17,8 +17,10 @@ import asyncio
 import hashlib
 import logging
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
+
+from fastapi import HTTPException
 
 from nikita.db.repositories.backstory_cache_repository import BackstoryCacheRepository
 from nikita.db.repositories.profile_repository import VenueCacheRepository
@@ -251,6 +253,122 @@ class PortalOnboardingFacade:
             cache_key=cache_key,
             degraded=False,
         )
+
+    async def set_chosen_option(
+        self,
+        user_id: UUID,
+        chosen_option_id: str,
+        cache_key: str,
+        session: "AsyncSession",
+    ) -> BackstoryOption:
+        """Validate + persist the user's backstory selection (Spec 214 FR-10.1).
+
+        Ownership is inferred by recomputing cache_key from the authenticated
+        user's ``users.onboarding_profile`` JSONB. ``backstory_cache`` has no
+        ``user_id`` column — the recomputed-key check is the ownership guard.
+
+        A duck-typed ``SimpleNamespace`` bridges JSONB keys to the attribute
+        names expected by ``compute_backstory_cache_key`` (``location_city →
+        city``, ``drug_tolerance → darkness_level``). This mirrors the
+        ``generate_preview`` pattern at ``portal_onboarding.py:155-163``.
+
+        Args:
+            user_id: Authenticated user UUID.
+            chosen_option_id: Opaque ``sha256[:12]`` id from BackstoryOption.
+            cache_key: Cache key echoed from ``BackstoryPreviewResponse``.
+            session: AsyncSession; caller manages lifecycle.
+
+        Returns:
+            BackstoryOption snapshot of the chosen scenario.
+
+        Raises:
+            HTTPException(403): supplied cache_key does not match recompute
+                (stale profile or cross-user attempt).
+            HTTPException(404): no ``backstory_cache`` row for ``cache_key``.
+            HTTPException(409): ``chosen_option_id`` not in stored scenarios.
+        """
+        # Local imports — mirrors _bootstrap_pipeline; prevents UserRepository
+        # appearing at module scope (see test_preview_does_not_write_jsonb) and
+        # enables tests to patch at the source module (per
+        # .claude/rules/testing.md "patch source module, not importer").
+        from nikita.db.repositories.backstory_cache_repository import (
+            BackstoryCacheRepository as _BackstoryCacheRepository,
+        )
+        from nikita.db.repositories.user_repository import UserRepository
+
+        user_repo = UserRepository(session)
+        user = await user_repo.get(user_id)
+        profile_jsonb: dict[str, Any] = (
+            (user.onboarding_profile or {}) if user is not None else {}
+        )
+
+        # SimpleNamespace bridge: JSONB keys → attr names used by
+        # compute_backstory_cache_key.
+        pseudo = SimpleNamespace(
+            city=profile_jsonb.get("location_city"),
+            darkness_level=profile_jsonb.get("drug_tolerance"),
+            social_scene=profile_jsonb.get("social_scene"),
+            life_stage=profile_jsonb.get("life_stage"),
+            interest=profile_jsonb.get("interest"),
+            age=profile_jsonb.get("age"),
+            occupation=profile_jsonb.get("occupation"),
+        )
+        recomputed_key = compute_backstory_cache_key(pseudo)
+        if recomputed_key != cache_key:
+            # FR-7/NFR-3: no PII in error detail; Nikita-voiced message.
+            raise HTTPException(
+                status_code=403,
+                detail="Clearance mismatch. Start over.",
+            )
+
+        cache_repo = _BackstoryCacheRepository(session)
+        cached_scenarios = await cache_repo.get(cache_key)
+        if cached_scenarios is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Backstory not found. Start over.",
+            )
+
+        # Locate the chosen scenario by id in the stored envelope.
+        matched: dict[str, Any] | None = None
+        for scenario in cached_scenarios:
+            if scenario.get("id") == chosen_option_id:
+                matched = scenario
+                break
+        if matched is None:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "That scenario doesn't exist. Pick one she actually "
+                    "generated for you."
+                ),
+            )
+
+        # Snapshot full 6-field BackstoryOption into JSONB (not just the id —
+        # survives backstory_cache eviction).
+        chosen_option = BackstoryOption.model_validate(matched)
+        await user_repo.update_onboarding_profile_key(
+            user_id,
+            "chosen_option",
+            chosen_option.model_dump(mode="json"),
+        )
+        await session.commit()
+
+        # FR-7/NFR-3: emit structured event with tone+venue (scenario-derived,
+        # NOT user-provided) + cache_key_hash (cache_key contains city which is
+        # PII-adjacent). Never include name/age/occupation/phone/city raw.
+        cache_key_hash = hashlib.sha256(cache_key.encode()).hexdigest()[:8]
+        logger.info(
+            "onboarding.backstory_chosen user_id=%s chosen_option_id=%s "
+            "tone=%s venue=%s cache_key_hash=%s",
+            user_id,
+            chosen_option_id,
+            chosen_option.tone,
+            chosen_option.venue,
+            cache_key_hash,
+        )
+
+        return chosen_option
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/tests/api/routes/test_portal_onboarding.py
+++ b/tests/api/routes/test_portal_onboarding.py
@@ -561,3 +561,342 @@ class TestPatchProfileResponse:
         assert response.status_code == 200
         data = response.json()
         assert data["pipeline_state"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Spec 214 PR 214-D: PUT /profile/chosen-option  (T011)
+# ---------------------------------------------------------------------------
+
+
+CACHE_KEY = "berlin|techno|3|tech|unknown|twenties|tech"
+OPTION_ID_A = "aabbccdd1122"
+
+
+def _make_chosen_option_dict() -> dict:
+    """Minimal BackstoryOption dict suitable for chosen_option assertions."""
+    return {
+        "id": OPTION_ID_A,
+        "venue": "Tresor",
+        "context": "Dark basement, peak hour.",
+        "the_moment": "She handed back my lighter.",
+        "unresolved_hook": "She knew my name before I told her.",
+        "tone": "chaotic",
+    }
+
+
+def _make_chosen_app(
+    current_user_id: UUID = USER_ID,
+    bypass_rate_limit: bool = True,
+) -> tuple[FastAPI, object]:
+    """Build test app with portal_onboarding router and optional rate-limit bypass.
+
+    Rate limit is bypassed by default (returns None) so tests can focus on
+    endpoint logic.  Set bypass_rate_limit=False to test 429 behaviour.
+    """
+    from nikita.api.routes.portal_onboarding import router
+    from nikita.api.dependencies.auth import get_current_user_id
+    from nikita.db.database import get_async_session
+    from nikita.api.middleware.rate_limit import choice_rate_limit
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1/onboarding")
+
+    app.dependency_overrides[get_current_user_id] = lambda: current_user_id
+
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    async def _session_override():
+        return mock_session
+
+    app.dependency_overrides[get_async_session] = _session_override
+
+    if bypass_rate_limit:
+        app.dependency_overrides[choice_rate_limit] = lambda: None
+
+    return app, mock_session
+
+
+VALID_CHOICE_BODY = {
+    "chosen_option_id": OPTION_ID_A,
+    "cache_key": CACHE_KEY,
+}
+
+
+class TestPutChosenOptionAccessControl:
+    """AC-10.1 / AC-10.3: access control and cache_key mismatch."""
+
+    def test_put_chosen_option_cross_user_returns_403(self):
+        """Facade raises 403 on cache_key mismatch (cross-user or stale profile)."""
+        from nikita.services.portal_onboarding import PortalOnboardingFacade
+
+        app, _ = _make_chosen_app()
+
+        with patch.object(
+            PortalOnboardingFacade,
+            "set_chosen_option",
+            side_effect=__import__("fastapi").HTTPException(
+                status_code=403, detail="Clearance mismatch. Start over."
+            ),
+        ):
+            client = TestClient(app)
+            response = client.put(
+                "/api/v1/onboarding/profile/chosen-option",
+                json=VALID_CHOICE_BODY,
+            )
+
+        assert response.status_code == 403
+        data = response.json()
+        assert isinstance(data.get("detail"), str)
+        # Must NOT leak PII
+        detail = data["detail"].lower()
+        assert "name" not in detail
+        assert "age" not in detail
+        assert "occupation" not in detail
+        assert "phone" not in detail
+
+    def test_put_chosen_option_stale_cache_key_returns_404(self):
+        """Facade raises 404 when cache row not found for valid cache_key."""
+        from nikita.services.portal_onboarding import PortalOnboardingFacade
+
+        app, _ = _make_chosen_app()
+
+        with patch.object(
+            PortalOnboardingFacade,
+            "set_chosen_option",
+            side_effect=__import__("fastapi").HTTPException(
+                status_code=404, detail="Backstory not found."
+            ),
+        ):
+            client = TestClient(app)
+            response = client.put(
+                "/api/v1/onboarding/profile/chosen-option",
+                json=VALID_CHOICE_BODY,
+            )
+
+        assert response.status_code == 404
+
+
+class TestPutChosenOptionValidation:
+    """AC-10.2: unknown chosen_option_id → 409."""
+
+    def test_put_chosen_option_unknown_option_id_returns_409(self):
+        """chosen_option_id not in cache scenarios → 409 Conflict."""
+        from nikita.services.portal_onboarding import PortalOnboardingFacade
+
+        app, _ = _make_chosen_app()
+
+        with patch.object(
+            PortalOnboardingFacade,
+            "set_chosen_option",
+            side_effect=__import__("fastapi").HTTPException(
+                status_code=409,
+                detail="That scenario doesn't exist. Pick one she actually generated for you.",
+            ),
+        ):
+            client = TestClient(app)
+            response = client.put(
+                "/api/v1/onboarding/profile/chosen-option",
+                json=VALID_CHOICE_BODY,
+            )
+
+        assert response.status_code == 409
+        data = response.json()
+        assert isinstance(data.get("detail"), str)
+
+
+class TestPutChosenOptionHappyPath:
+    """AC-10.5: success returns OnboardingV2ProfileResponse with chosen_option."""
+
+    def test_put_chosen_option_happy_path_writes_snapshot(self):
+        """Happy path: 200 with chosen_option populated in response."""
+        from nikita.services.portal_onboarding import PortalOnboardingFacade
+        from nikita.onboarding.contracts import BackstoryOption
+
+        app, _ = _make_chosen_app()
+        option = BackstoryOption(**_make_chosen_option_dict())
+        mock_user = _make_user(onboarding_profile={"pipeline_state": "ready"})
+
+        with (
+            patch.object(
+                PortalOnboardingFacade,
+                "set_chosen_option",
+                return_value=option,
+            ),
+            patch("nikita.db.repositories.user_repository.UserRepository") as MockRepo,
+        ):
+            MockRepo.return_value.get = AsyncMock(return_value=mock_user)
+            client = TestClient(app)
+            response = client.put(
+                "/api/v1/onboarding/profile/chosen-option",
+                json=VALID_CHOICE_BODY,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["chosen_option"] is not None
+        assert data["chosen_option"]["id"] == OPTION_ID_A
+        assert data["chosen_option"]["venue"] == "Tresor"
+        assert data["chosen_option"]["tone"] == "chaotic"
+        assert data["backstory_options"] == []
+
+
+class TestPutChosenOptionNoPiiInErrorBodies:
+    """AC-10.6: no PII in any error response body."""
+
+    def test_put_chosen_option_response_has_no_pii_substrings(self):
+        """Error bodies (403/404/409) must not contain name/age/occupation/phone/city."""
+        from nikita.services.portal_onboarding import PortalOnboardingFacade
+
+        pii_payloads = [
+            ("name", "Alice"),
+            ("age", "25"),
+            ("occupation", "banker"),
+            ("phone", "+49123456789"),
+            ("city", "Berlin"),
+        ]
+        app, _ = _make_chosen_app()
+
+        for pii_field, pii_value in pii_payloads:
+            with patch.object(
+                PortalOnboardingFacade,
+                "set_chosen_option",
+                side_effect=__import__("fastapi").HTTPException(
+                    status_code=403, detail="Clearance mismatch. Start over."
+                ),
+            ):
+                client = TestClient(app)
+                response = client.put(
+                    "/api/v1/onboarding/profile/chosen-option",
+                    json=VALID_CHOICE_BODY,
+                )
+
+            response_text = response.text.lower()
+            assert pii_value.lower() not in response_text, (
+                f"PII field '{pii_field}' value '{pii_value}' leaked into response: {response.text}"
+            )
+
+
+class TestPutChosenOptionRateLimit:
+    """AC-10.7 / AC-10.9: 429 includes Retry-After: 60 header."""
+
+    def test_put_chosen_option_rate_limit_429_includes_retry_after(self):
+        """Rate limit exceeded → 429 with Retry-After: 60 header."""
+        from nikita.api.routes.portal_onboarding import router
+        from nikita.api.dependencies.auth import get_current_user_id
+        from nikita.db.database import get_async_session
+        from nikita.api.middleware.rate_limit import choice_rate_limit
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1/onboarding")
+        app.dependency_overrides[get_current_user_id] = lambda: USER_ID
+
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async def _session_override():
+            return mock_session
+
+        app.dependency_overrides[get_async_session] = _session_override
+
+        # Override rate limit to raise 429 with Retry-After header
+        async def _rate_limit_429():
+            raise __import__("fastapi").HTTPException(
+                status_code=429,
+                detail="Rate limit exceeded",
+                headers={"Retry-After": "60"},
+            )
+
+        app.dependency_overrides[choice_rate_limit] = _rate_limit_429
+
+        client = TestClient(app)
+        response = client.put(
+            "/api/v1/onboarding/profile/chosen-option",
+            json=VALID_CHOICE_BODY,
+        )
+
+        assert response.status_code == 429
+        assert response.headers.get("retry-after") == "60"
+
+
+# ---------------------------------------------------------------------------
+# Spec 214 PR 214-D: wizard_step passthrough + pipeline-ready rate limit (T011)
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineReadyWizardStep:
+    """AC-10.7: GET /pipeline-ready includes wizard_step from JSONB."""
+
+    def test_pipeline_ready_wizard_step_passthrough(self):
+        """wizard_step present in onboarding_profile → included in response."""
+        app, _ = _make_app()
+        mock_user = _make_user(onboarding_profile={
+            "pipeline_state": "ready",
+            "wizard_step": 7,
+        })
+
+        with patch(
+            "nikita.db.repositories.user_repository.UserRepository"
+        ) as MockRepo:
+            MockRepo.return_value.get = AsyncMock(return_value=mock_user)
+            client = TestClient(app)
+            response = client.get(f"/api/v1/onboarding/pipeline-ready/{USER_ID}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["wizard_step"] == 7
+
+    def test_pipeline_ready_wizard_step_none_when_absent(self):
+        """wizard_step absent from JSONB → None in response (not missing)."""
+        app, _ = _make_app()
+        mock_user = _make_user(onboarding_profile={"pipeline_state": "pending"})
+        # No wizard_step key in profile
+
+        with patch(
+            "nikita.db.repositories.user_repository.UserRepository"
+        ) as MockRepo:
+            MockRepo.return_value.get = AsyncMock(return_value=mock_user)
+            client = TestClient(app)
+            response = client.get(f"/api/v1/onboarding/pipeline-ready/{USER_ID}")
+
+        assert response.status_code == 200
+        data = response.json()
+        # Field must be present in response (optional, default None)
+        assert "wizard_step" in data
+        assert data["wizard_step"] is None
+
+
+class TestPipelineReadyRateLimit:
+    """AC-5.6: GET /pipeline-ready rate-limited (429 with Retry-After: 60)."""
+
+    def test_pipeline_ready_rate_limit_429_retry_after_60(self):
+        """Rate limit dependency raises 429 with Retry-After: 60 on pipeline-ready."""
+        from nikita.api.routes.portal_onboarding import router
+        from nikita.api.dependencies.auth import get_current_user_id
+        from nikita.db.database import get_async_session
+        from nikita.api.middleware.rate_limit import pipeline_ready_rate_limit
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1/onboarding")
+        app.dependency_overrides[get_current_user_id] = lambda: USER_ID
+
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async def _session_override():
+            return mock_session
+
+        app.dependency_overrides[get_async_session] = _session_override
+
+        # Override pipeline_ready_rate_limit to raise 429
+        async def _rate_limit_429():
+            raise __import__("fastapi").HTTPException(
+                status_code=429,
+                detail="Rate limit exceeded",
+                headers={"Retry-After": "60"},
+            )
+
+        app.dependency_overrides[pipeline_ready_rate_limit] = _rate_limit_429
+
+        client = TestClient(app)
+        response = client.get(f"/api/v1/onboarding/pipeline-ready/{USER_ID}")
+
+        assert response.status_code == 429
+        assert response.headers.get("retry-after") == "60"

--- a/tests/api/routes/test_portal_onboarding.py
+++ b/tests/api/routes/test_portal_onboarding.py
@@ -41,9 +41,14 @@ def _make_app(current_user_id: UUID = USER_ID, mock_user: object = None) -> tupl
     """Build a FastAPI test app with portal_onboarding router.
 
     Returns (app, mock_session) so callers can introspect session calls.
+
+    Rate-limit deps (Spec 214 PR 214-D) default-bypassed so handler-logic tests
+    can focus on endpoint behaviour; the 429-specific tests below install their
+    own overrides.  Mirrors _make_chosen_app pattern.
     """
     from nikita.api.routes.portal_onboarding import router
     from nikita.api.dependencies.auth import get_current_user_id
+    from nikita.api.middleware.rate_limit import pipeline_ready_rate_limit
     from nikita.db.database import get_async_session
 
     app = FastAPI()
@@ -57,6 +62,7 @@ def _make_app(current_user_id: UUID = USER_ID, mock_user: object = None) -> tupl
         return mock_session
 
     app.dependency_overrides[get_async_session] = _session_override
+    app.dependency_overrides[pipeline_ready_rate_limit] = lambda: None
 
     return app, mock_session
 

--- a/tests/onboarding/test_contracts.py
+++ b/tests/onboarding/test_contracts.py
@@ -653,3 +653,150 @@ class TestPipelineReadyState:
         from nikita.onboarding.contracts import PipelineReadyState
 
         assert get_args(PipelineReadyState) == ("pending", "ready", "degraded", "failed")
+
+
+# ---------------------------------------------------------------------------
+# Spec 214 PR 214-D: BackstoryChoiceRequest + PipelineReadyResponse.wizard_step
+# (T012 additive extension assertions)
+# ---------------------------------------------------------------------------
+
+
+class TestBackstoryChoiceRequest:
+    """T012: BackstoryChoiceRequest round-trip validation (Spec 214 FR-10.1)."""
+
+    def test_backstory_choice_request_round_trip(self):
+        """JSON → model → JSON equality: all fields survive serialization."""
+        from nikita.onboarding.contracts import BackstoryChoiceRequest
+
+        payload = {
+            "chosen_option_id": "aabbccdd1122",
+            "cache_key": "berlin|techno|3|tech|unknown|twenties|tech",
+        }
+        model = BackstoryChoiceRequest(**payload)
+        serialized = model.model_dump(mode="json")
+
+        assert serialized["chosen_option_id"] == payload["chosen_option_id"]
+        assert serialized["cache_key"] == payload["cache_key"]
+
+    def test_backstory_choice_request_rejects_empty_chosen_option_id(self):
+        """chosen_option_id min_length=1 enforced."""
+        import pydantic
+
+        from nikita.onboarding.contracts import BackstoryChoiceRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            BackstoryChoiceRequest(chosen_option_id="", cache_key="some-key")
+
+    def test_backstory_choice_request_rejects_empty_cache_key(self):
+        """cache_key min_length=1 enforced."""
+        import pydantic
+
+        from nikita.onboarding.contracts import BackstoryChoiceRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            BackstoryChoiceRequest(chosen_option_id="aabbccdd1122", cache_key="")
+
+    def test_backstory_choice_request_rejects_option_id_too_long(self):
+        """chosen_option_id max_length=64 enforced."""
+        import pydantic
+
+        from nikita.onboarding.contracts import BackstoryChoiceRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            BackstoryChoiceRequest(
+                chosen_option_id="a" * 65,
+                cache_key="some-key",
+            )
+
+    def test_backstory_choice_request_rejects_cache_key_too_long(self):
+        """cache_key max_length=128 enforced."""
+        import pydantic
+
+        from nikita.onboarding.contracts import BackstoryChoiceRequest
+
+        with pytest.raises(pydantic.ValidationError):
+            BackstoryChoiceRequest(
+                chosen_option_id="aabbccdd1122",
+                cache_key="x" * 129,
+            )
+
+
+class TestPipelineReadyResponseWizardStep:
+    """T012: PipelineReadyResponse.wizard_step optional field (Spec 214 FR-10.2)."""
+
+    def test_pipeline_ready_response_wizard_step_optional(self):
+        """wizard_step defaults to None when not provided."""
+        from datetime import datetime, timezone
+
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        resp = PipelineReadyResponse(
+            state="pending",
+            checked_at=datetime.now(tz=timezone.utc),
+        )
+        # Field must exist with None default
+        assert hasattr(resp, "wizard_step")
+        assert resp.wizard_step is None
+
+    def test_pipeline_ready_response_wizard_step_ge_1(self):
+        """wizard_step ge=1 constraint enforced (0 must be rejected)."""
+        import pydantic
+        from datetime import datetime, timezone
+
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        with pytest.raises(pydantic.ValidationError):
+            PipelineReadyResponse(
+                state="pending",
+                checked_at=datetime.now(tz=timezone.utc),
+                wizard_step=0,
+            )
+
+    def test_pipeline_ready_response_wizard_step_le_11(self):
+        """wizard_step le=11 constraint enforced (12 must be rejected)."""
+        import pydantic
+        from datetime import datetime, timezone
+
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        with pytest.raises(pydantic.ValidationError):
+            PipelineReadyResponse(
+                state="pending",
+                checked_at=datetime.now(tz=timezone.utc),
+                wizard_step=12,
+            )
+
+    def test_pipeline_ready_response_wizard_step_accepts_valid_range(self):
+        """wizard_step values 1..11 are all accepted."""
+        from datetime import datetime, timezone
+
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        for step in range(1, 12):
+            resp = PipelineReadyResponse(
+                state="pending",
+                checked_at=datetime.now(tz=timezone.utc),
+                wizard_step=step,
+            )
+            assert resp.wizard_step == step
+
+    def test_pipeline_ready_response_existing_consumers_unaffected(self):
+        """Existing consumers that omit wizard_step still deserialize correctly.
+
+        Regression guard: the field is optional — adding it must NOT break
+        any existing code that constructs PipelineReadyResponse without it.
+        AC-10.8: backward-compatible.
+        """
+        from datetime import datetime, timezone
+
+        from nikita.onboarding.contracts import PipelineReadyResponse
+
+        # Simulate existing consumer code omitting wizard_step
+        resp = PipelineReadyResponse(
+            state="ready",
+            checked_at=datetime.now(tz=timezone.utc),
+            venue_research_status="complete",
+            backstory_available=True,
+        )
+        assert resp.state == "ready"
+        assert resp.wizard_step is None  # safe default

--- a/tests/services/test_portal_onboarding_facade.py
+++ b/tests/services/test_portal_onboarding_facade.py
@@ -1,0 +1,397 @@
+"""Unit tests for PortalOnboardingFacade.set_chosen_option — Spec 214 PR 214-D (T010).
+
+TDD RED phase: all tests FAIL until set_chosen_option is implemented in
+nikita/services/portal_onboarding.py.
+
+Covers:
+- AC-10.1: cache_key mismatch → 403
+- AC-10.2: missing cache row → 404
+- AC-10.4: unknown option_id → 409
+- AC-10.5: success writes full BackstoryOption snapshot
+- AC-10.6: emits onboarding.backstory_chosen structured event
+- AC-10.4 (idempotent): same choice_id → same snapshot
+
+Per .claude/rules/testing.md:
+- Every test_ has at least one assert
+- Non-empty repo fixtures
+- No zero-assertion shells
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+USER_ID = UUID("550e8400-e29b-41d4-a716-446655440000")
+CACHE_KEY = "berlin|techno|3|tech|unknown|twenties|tech"
+OPTION_ID_A = "aabbccdd1122"  # 12-char hex (sha256[:12] format)
+OPTION_ID_B = "bbccddee2233"
+
+
+def _make_option_dict(option_id: str = OPTION_ID_A) -> dict[str, Any]:
+    """Build a BackstoryOption-shaped dict as stored in backstory_cache."""
+    return {
+        "id": option_id,
+        "venue": "Tresor",
+        "context": "Dark basement, peak hour.",
+        "the_moment": "She handed back my lighter.",
+        "unresolved_hook": "She knew my name before I told her.",
+        "tone": "chaotic",
+    }
+
+
+def _make_user(profile: dict | None = None) -> MagicMock:
+    """Build a mock User ORM with onboarding_profile JSONB."""
+    user = MagicMock()
+    user.id = USER_ID
+    # Default profile yields a cache_key matching CACHE_KEY when bridge is applied
+    default_profile: dict[str, Any] = {
+        "location_city": "berlin",
+        "drug_tolerance": 3,
+        "social_scene": "techno",
+        "life_stage": "tech",
+        "interest": None,
+        "age": 28,
+        "occupation": "engineer",
+    }
+    user.onboarding_profile = profile if profile is not None else default_profile
+    return user
+
+
+# ---------------------------------------------------------------------------
+# T010-A: cache_key mismatch → 403
+# ---------------------------------------------------------------------------
+
+
+class TestSetChosenOptionCacheKeyMismatch:
+    """AC-10.1: supplied cache_key does not match recomputed key → 403."""
+
+    @pytest.mark.asyncio
+    async def test_set_chosen_option_cache_key_mismatch_raises_403(self):
+        """cache_key mismatch → HTTPException 403 'Clearance mismatch. Start over.'"""
+        from nikita.services.portal_onboarding import PortalOnboardingFacade
+
+        # User profile that would compute a DIFFERENT cache_key than what we supply
+        user = _make_user(profile={
+            "location_city": "paris",  # different city
+            "drug_tolerance": 3,
+            "social_scene": "art",
+            "life_stage": "creative",
+            "interest": None,
+            "age": 30,
+            "occupation": "artist",
+        })
+
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        with patch("nikita.db.repositories.user_repository.UserRepository") as MockRepo:
+            MockRepo.return_value.get = AsyncMock(return_value=user)
+
+            facade = PortalOnboardingFacade()
+            with pytest.raises(HTTPException) as exc_info:
+                await facade.set_chosen_option(
+                    user_id=USER_ID,
+                    chosen_option_id=OPTION_ID_A,
+                    cache_key=CACHE_KEY,  # stale/mismatched key
+                    session=mock_session,
+                )
+
+        assert exc_info.value.status_code == 403
+        assert "mismatch" in exc_info.value.detail.lower() or "clearance" in exc_info.value.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# T010-B: missing cache row → 404
+# ---------------------------------------------------------------------------
+
+
+class TestSetChosenOptionMissingCacheRow:
+    """AC-10.2: backstory_cache row missing for the given cache_key → 404."""
+
+    @pytest.mark.asyncio
+    async def test_set_chosen_option_missing_cache_row_raises_404(self):
+        """BackstoryCacheRepository.get returns None → HTTPException 404."""
+        from nikita.services.portal_onboarding import PortalOnboardingFacade
+        from nikita.onboarding.tuning import compute_backstory_cache_key
+
+        # Profile that computes EXACTLY the same cache_key we supply
+        user = _make_user()
+        pseudo = SimpleNamespace(
+            city=user.onboarding_profile.get("location_city"),
+            darkness_level=user.onboarding_profile.get("drug_tolerance"),
+            social_scene=user.onboarding_profile.get("social_scene"),
+            life_stage=user.onboarding_profile.get("life_stage"),
+            interest=user.onboarding_profile.get("interest"),
+            age=user.onboarding_profile.get("age"),
+            occupation=user.onboarding_profile.get("occupation"),
+        )
+        real_cache_key = compute_backstory_cache_key(pseudo)
+
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        with (
+            patch("nikita.db.repositories.user_repository.UserRepository") as MockRepo,
+            patch("nikita.db.repositories.backstory_cache_repository.BackstoryCacheRepository") as MockCacheRepo,
+        ):
+            MockRepo.return_value.get = AsyncMock(return_value=user)
+            MockCacheRepo.return_value.get = AsyncMock(return_value=None)  # cache miss
+
+            facade = PortalOnboardingFacade()
+            with pytest.raises(HTTPException) as exc_info:
+                await facade.set_chosen_option(
+                    user_id=USER_ID,
+                    chosen_option_id=OPTION_ID_A,
+                    cache_key=real_cache_key,
+                    session=mock_session,
+                )
+
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# T010-C: unknown option_id → 409
+# ---------------------------------------------------------------------------
+
+
+class TestSetChosenOptionUnknownOptionId:
+    """AC-10.2 (spec 409): chosen_option_id not in cache row's scenarios → 409."""
+
+    @pytest.mark.asyncio
+    async def test_set_chosen_option_unknown_option_id_raises_409(self):
+        """chosen_option_id not present in cache → HTTPException 409 Conflict."""
+        from nikita.services.portal_onboarding import PortalOnboardingFacade
+        from nikita.onboarding.tuning import compute_backstory_cache_key
+
+        user = _make_user()
+        pseudo = SimpleNamespace(
+            city=user.onboarding_profile.get("location_city"),
+            darkness_level=user.onboarding_profile.get("drug_tolerance"),
+            social_scene=user.onboarding_profile.get("social_scene"),
+            life_stage=user.onboarding_profile.get("life_stage"),
+            interest=user.onboarding_profile.get("interest"),
+            age=user.onboarding_profile.get("age"),
+            occupation=user.onboarding_profile.get("occupation"),
+        )
+        real_cache_key = compute_backstory_cache_key(pseudo)
+        cached_scenarios = [_make_option_dict(OPTION_ID_A)]  # only A in cache
+
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        with (
+            patch("nikita.db.repositories.user_repository.UserRepository") as MockRepo,
+            patch("nikita.db.repositories.backstory_cache_repository.BackstoryCacheRepository") as MockCacheRepo,
+        ):
+            MockRepo.return_value.get = AsyncMock(return_value=user)
+            MockCacheRepo.return_value.get = AsyncMock(return_value=cached_scenarios)
+
+            facade = PortalOnboardingFacade()
+            with pytest.raises(HTTPException) as exc_info:
+                await facade.set_chosen_option(
+                    user_id=USER_ID,
+                    chosen_option_id="nonexistentid99",  # NOT in scenarios
+                    cache_key=real_cache_key,
+                    session=mock_session,
+                )
+
+        assert exc_info.value.status_code == 409
+        assert "generated" in exc_info.value.detail.lower() or "exist" in exc_info.value.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# T010-D: success — writes full BackstoryOption snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestSetChosenOptionSuccess:
+    """AC-10.5: successful put writes all 6 BackstoryOption fields to JSONB."""
+
+    @pytest.mark.asyncio
+    async def test_set_chosen_option_success_writes_full_snapshot(self):
+        """Happy path: returns BackstoryOption with all 6 required fields."""
+        from nikita.services.portal_onboarding import PortalOnboardingFacade
+        from nikita.onboarding.contracts import BackstoryOption
+        from nikita.onboarding.tuning import compute_backstory_cache_key
+
+        user = _make_user()
+        pseudo = SimpleNamespace(
+            city=user.onboarding_profile.get("location_city"),
+            darkness_level=user.onboarding_profile.get("drug_tolerance"),
+            social_scene=user.onboarding_profile.get("social_scene"),
+            life_stage=user.onboarding_profile.get("life_stage"),
+            interest=user.onboarding_profile.get("interest"),
+            age=user.onboarding_profile.get("age"),
+            occupation=user.onboarding_profile.get("occupation"),
+        )
+        real_cache_key = compute_backstory_cache_key(pseudo)
+        option_dict = _make_option_dict(OPTION_ID_A)
+        cached_scenarios = [option_dict]
+
+        mock_session = AsyncMock(spec=AsyncSession)
+        mock_repo_instance = MagicMock()
+        mock_repo_instance.get = AsyncMock(return_value=user)
+        mock_repo_instance.update_onboarding_profile_key = AsyncMock()
+
+        mock_cache_repo_instance = MagicMock()
+        mock_cache_repo_instance.get = AsyncMock(return_value=cached_scenarios)
+
+        with (
+            patch("nikita.db.repositories.user_repository.UserRepository") as MockRepo,
+            patch("nikita.db.repositories.backstory_cache_repository.BackstoryCacheRepository") as MockCacheRepo,
+        ):
+            MockRepo.return_value = mock_repo_instance
+            MockCacheRepo.return_value = mock_cache_repo_instance
+
+            facade = PortalOnboardingFacade()
+            result = await facade.set_chosen_option(
+                user_id=USER_ID,
+                chosen_option_id=OPTION_ID_A,
+                cache_key=real_cache_key,
+                session=mock_session,
+            )
+
+        # Must return a BackstoryOption with all 6 fields populated
+        assert isinstance(result, BackstoryOption)
+        assert result.id == OPTION_ID_A
+        assert result.venue == option_dict["venue"]
+        assert result.context == option_dict["context"]
+        assert result.the_moment == option_dict["the_moment"]
+        assert result.unresolved_hook == option_dict["unresolved_hook"]
+        assert result.tone == option_dict["tone"]
+
+        # Verify JSONB write was called with the full option dict
+        mock_repo_instance.update_onboarding_profile_key.assert_awaited()
+        write_calls = mock_repo_instance.update_onboarding_profile_key.await_args_list
+        # Find the chosen_option write call
+        written_keys = [call[0][1] for call in write_calls]  # second positional arg is key
+        assert "chosen_option" in written_keys
+
+    @pytest.mark.asyncio
+    async def test_set_chosen_option_idempotent_same_choice(self):
+        """AC-10.4: calling twice with same chosen_option_id → same result."""
+        from nikita.services.portal_onboarding import PortalOnboardingFacade
+        from nikita.onboarding.tuning import compute_backstory_cache_key
+
+        user = _make_user()
+        pseudo = SimpleNamespace(
+            city=user.onboarding_profile.get("location_city"),
+            darkness_level=user.onboarding_profile.get("drug_tolerance"),
+            social_scene=user.onboarding_profile.get("social_scene"),
+            life_stage=user.onboarding_profile.get("life_stage"),
+            interest=user.onboarding_profile.get("interest"),
+            age=user.onboarding_profile.get("age"),
+            occupation=user.onboarding_profile.get("occupation"),
+        )
+        real_cache_key = compute_backstory_cache_key(pseudo)
+        option_dict = _make_option_dict(OPTION_ID_A)
+        cached_scenarios = [option_dict]
+
+        mock_session = AsyncMock(spec=AsyncSession)
+        mock_repo_instance = MagicMock()
+        mock_repo_instance.get = AsyncMock(return_value=user)
+        mock_repo_instance.update_onboarding_profile_key = AsyncMock()
+
+        mock_cache_repo_instance = MagicMock()
+        mock_cache_repo_instance.get = AsyncMock(return_value=cached_scenarios)
+
+        with (
+            patch("nikita.db.repositories.user_repository.UserRepository") as MockRepo,
+            patch("nikita.db.repositories.backstory_cache_repository.BackstoryCacheRepository") as MockCacheRepo,
+        ):
+            MockRepo.return_value = mock_repo_instance
+            MockCacheRepo.return_value = mock_cache_repo_instance
+
+            facade = PortalOnboardingFacade()
+            result1 = await facade.set_chosen_option(
+                user_id=USER_ID,
+                chosen_option_id=OPTION_ID_A,
+                cache_key=real_cache_key,
+                session=mock_session,
+            )
+            result2 = await facade.set_chosen_option(
+                user_id=USER_ID,
+                chosen_option_id=OPTION_ID_A,
+                cache_key=real_cache_key,
+                session=mock_session,
+            )
+
+        # Both calls produce the same result
+        assert result1.id == result2.id
+        assert result1.venue == result2.venue
+        assert result1.tone == result2.tone
+
+
+# ---------------------------------------------------------------------------
+# T010-E: structured event emitted
+# ---------------------------------------------------------------------------
+
+
+class TestSetChosenOptionEventEmission:
+    """AC-10.6: onboarding.backstory_chosen structured log event emitted."""
+
+    @pytest.mark.asyncio
+    async def test_set_chosen_option_emits_backstory_chosen_event(self, caplog):
+        """Successful set_chosen_option emits 'onboarding.backstory_chosen' log."""
+        import logging
+
+        from nikita.services.portal_onboarding import PortalOnboardingFacade
+        from nikita.onboarding.tuning import compute_backstory_cache_key
+
+        user = _make_user()
+        pseudo = SimpleNamespace(
+            city=user.onboarding_profile.get("location_city"),
+            darkness_level=user.onboarding_profile.get("drug_tolerance"),
+            social_scene=user.onboarding_profile.get("social_scene"),
+            life_stage=user.onboarding_profile.get("life_stage"),
+            interest=user.onboarding_profile.get("interest"),
+            age=user.onboarding_profile.get("age"),
+            occupation=user.onboarding_profile.get("occupation"),
+        )
+        real_cache_key = compute_backstory_cache_key(pseudo)
+        option_dict = _make_option_dict(OPTION_ID_A)
+        cached_scenarios = [option_dict]
+
+        mock_session = AsyncMock(spec=AsyncSession)
+        mock_repo_instance = MagicMock()
+        mock_repo_instance.get = AsyncMock(return_value=user)
+        mock_repo_instance.update_onboarding_profile_key = AsyncMock()
+
+        mock_cache_repo_instance = MagicMock()
+        mock_cache_repo_instance.get = AsyncMock(return_value=cached_scenarios)
+
+        with (
+            patch("nikita.db.repositories.user_repository.UserRepository") as MockRepo,
+            patch("nikita.db.repositories.backstory_cache_repository.BackstoryCacheRepository") as MockCacheRepo,
+            caplog.at_level(logging.INFO, logger="nikita.services.portal_onboarding"),
+        ):
+            MockRepo.return_value = mock_repo_instance
+            MockCacheRepo.return_value = mock_cache_repo_instance
+
+            facade = PortalOnboardingFacade()
+            await facade.set_chosen_option(
+                user_id=USER_ID,
+                chosen_option_id=OPTION_ID_A,
+                cache_key=real_cache_key,
+                session=mock_session,
+            )
+
+        # Event must include the structured tag
+        log_text = " ".join(r.message for r in caplog.records)
+        assert "onboarding.backstory_chosen" in log_text
+        # Must include tone and venue (no PII — not name/age/occupation/phone/city)
+        assert "tone" in log_text or "chaotic" in log_text
+        assert "venue" in log_text or "tresor" in log_text.lower()
+        # Must NOT include PII fields in log
+        assert "name" not in log_text
+        assert "age" not in log_text
+        assert "occupation" not in log_text
+        assert "phone" not in log_text

--- a/tests/services/test_portal_onboarding_facade.py
+++ b/tests/services/test_portal_onboarding_facade.py
@@ -275,6 +275,11 @@ class TestSetChosenOptionSuccess:
         written_keys = [call[0][1] for call in write_calls]  # second positional arg is key
         assert "chosen_option" in written_keys
 
+        # Atomicity guarantee — facade MUST commit after JSONB write so the
+        # row is durable before the structured event is emitted. Regression
+        # guard against silent commit-removal (QA review nitpick #1).
+        mock_session.commit.assert_awaited_once()
+
     @pytest.mark.asyncio
     async def test_set_chosen_option_idempotent_same_choice(self):
         """AC-10.4: calling twice with same chosen_option_id → same result."""
@@ -328,6 +333,11 @@ class TestSetChosenOptionSuccess:
         assert result1.id == result2.id
         assert result1.venue == result2.venue
         assert result1.tone == result2.tone
+
+        # Both calls commit (idempotency does not skip the commit; jsonb_set
+        # writes the same final state). Two await_count guards against a
+        # future "skip-if-unchanged" optimization silently breaking durability.
+        assert mock_session.commit.await_count == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Spec 214 backend sub-amendment. Adds the endpoint the portal wizard needs for final card selection + the `wizard_step` field for cross-device resume.

**New endpoint**: `PUT /api/v1/onboarding/profile/chosen-option`
**Contract extension**: `PipelineReadyResponse.wizard_step: int | None` (additive, optional, `ge=1,le=11`)

### What's in this PR

- `BackstoryChoiceRequest` Pydantic model (FR-10.1)
- `PortalOnboardingFacade.set_chosen_option(user_id, chosen_option_id, cache_key, session)` — recomputes `cache_key` via SimpleNamespace bridge (JSONB keys `location_city`/`drug_tolerance` → attrs `.city`/`.darkness_level` expected by `compute_backstory_cache_key`) → 403/404/409 error shapes → writes full `BackstoryOption` snapshot to `users.onboarding_profile.chosen_option` → emits `onboarding.backstory_chosen` structured event.
- `_ChoiceRateLimiter` (10/min) + `_PipelineReadyRateLimiter` (30/min), both override `_get_minute_window()` + `_get_day_window()` for prefix isolation. 429 responses include `Retry-After: 60` header.
- `get_pipeline_ready` extended to read `onboarding_profile.wizard_step` + apply `pipeline_ready_rate_limit` dep.

### Tests (RED → GREEN)

- `tests/services/test_portal_onboarding_facade.py` — NEW FILE, 6 tests (cache_key mismatch 403, unknown option_id 409, missing cache 404, happy path, event emission, idempotency)
- `tests/api/routes/test_portal_onboarding.py` — EXTENDED, 82 tests total (cross-user 403, stale cache 404, unknown id 409, happy path, PII negative, 429 Retry-After, wizard_step passthrough, pipeline-ready rate limit)
- `tests/onboarding/test_contracts.py` — EXTENDED, 10 tests (BackstoryChoiceRequest round-trip, wizard_step optional/range)

**Target suite**: 98/98 pass.
**Full suite**: 6247 pass / 3 pre-existing smoke failures (live-URL probes in `tests/smoke/test_deployment.py`, unrelated).

### LOC: +436/-4 across 6 files (GREEN commit `2ebf549`)

### Evidence refs

- `specs/214-portal-onboarding-wizard/spec.md` FR-10.1 (handler pseudocode + facade docstring iter-5 final) + FR-10.2 (wizard_step extension)
- `specs/214-portal-onboarding-wizard/plan.md` §4 PR 214-D
- `specs/214-portal-onboarding-wizard/tasks.md` Phase 2 T010-T034
- `specs/214-portal-onboarding-wizard/audit-report.md` GATE 3 PASS

### Disclosed deviations

1. **Function-local import** of `BackstoryCacheRepository` inside `set_chosen_option` (aliased `_BackstoryCacheRepository`). Rationale: tests patch at the source module per `.claude/rules/testing.md` "Patch source module, not importer" — function-local imports resolve through `sys.modules` each call.
2. **Test-helper default bypass** added for new `pipeline_ready_rate_limit` dep in `tests/api/routes/test_portal_onboarding.py`. Completes RED infrastructure the prior attempt left partial; mirrors existing `_make_chosen_app` bypass pattern.

### Grep gates (pre-QA)

- No PII format-string leakage in logs ✓
- No raw `cache_key=` in logs (only response-model kwargs) ✓
- Zero-assertion test shells ✓

## Test plan

- [x] Unit: facade + routes + contracts (98 tests GREEN)
- [x] Full suite baseline: 6247 pass, 3 pre-existing unrelated
- [x] Grep gates clean
- [ ] QA review fresh-context absolute-zero
- [ ] Post-merge smoke: probe `PUT /profile/chosen-option` 422 without body; probe `GET /pipeline-ready/{id}` wizard_step shape
- [ ] Deploy Cloud Run `nikita-api-00251-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)