### PR TITLE
chore(domain): swap stale portal URLs for nikita-mygirl.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,7 +83,7 @@ TASK_AUTH_SECRET=your-task-auth-secret
 # =============================================================================
 # PORTAL (Vercel deployment)
 # =============================================================================
-PORTAL_URL=https://portal-phi-orcin.vercel.app
+PORTAL_URL=https://nikita-mygirl.com
 BACKEND_URL=https://nikita-api-xxxxx-uc.a.run.app
 
 # =============================================================================
@@ -92,7 +92,7 @@ BACKEND_URL=https://nikita-api-xxxxx-uc.a.run.app
 API_HOST=0.0.0.0
 API_PORT=8080
 # Comma-separated list of allowed origins
-CORS_ORIGINS=["http://localhost:3000","https://portal-phi-orcin.vercel.app"]
+CORS_ORIGINS=["http://localhost:3000","https://nikita-mygirl.com","https://nikita-preview.vercel.app"]
 
 # =============================================================================
 # GAME SETTINGS

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,7 +22,7 @@ A PreToolUse hook (`guard-deploy.sh`) blocks `--min-instances` automatically.
 
 | Resource | Value |
 |----------|-------|
-| Portal URL | `https://portal-phi-orcin.vercel.app` |
+| Portal URL | `https://nikita-mygirl.com` (prod) · `https://nikita-preview.vercel.app` (preview) |
 
 **Deploy command:**
 ```bash

--- a/nikita/config/settings.py
+++ b/nikita/config/settings.py
@@ -130,8 +130,8 @@ class Settings(BaseSettings):
     cors_origins: list[str] = Field(
         default=[
             "http://localhost:3000",
-            "https://portal-phi-orcin.vercel.app",
-            "https://portal-yangsi7s-projects.vercel.app",  # Vercel preview deployments
+            "https://nikita-mygirl.com",
+            "https://nikita-preview.vercel.app",
         ],
         description="Allowed CORS origins",
     )


### PR DESCRIPTION
## Summary
- Replaces stale Vercel auto-generated portal URLs (`portal-phi-orcin.vercel.app`, `portal-yangsi7s-projects.vercel.app`) with the new custom domains: `nikita-mygirl.com` (prod) + `nikita-preview.vercel.app` (preview).
- Touches: backend CORS defaults, `.env.example` placeholder, `docs/deployment.md` reference table.

## Files changed (3 files, +5/-5)
- \`nikita/config/settings.py\` — \`cors_origins\` Field default
- \`.env.example\` — \`PORTAL_URL\` + \`CORS_ORIGINS\` placeholders
- \`docs/deployment.md\` — Portal URL row

## Out of scope (already done elsewhere)
- Vercel env vars (CLI-applied in a prior session): \`NEXT_PUBLIC_SITE_URL\` set across Production/Preview/Development; preview \`NEXT_PUBLIC_API_URL\` \`\\\\n\` bug stripped.
- GitHub Actions secrets: confirmed none reference URLs (all 4 are API keys/tokens).
- Local backend \`.env\` (gitignored): \`CORS_ORIGINS\` updated locally.

## Required after merge
- Cloud Run redeploy so the new CORS defaults take effect in prod:
  \`\`\`
  gcloud run deploy nikita-api --source . --region us-central1 --project gcp-transcribe-test --allow-unauthenticated
  \`\`\`
- Manual dashboard tasks (cannot be automated):
  - Vercel → nikita-mygirl project → Domains → confirm \`nikita-mygirl.com\` attached + route \`nikita-preview.vercel.app\` to a branch
  - Supabase → Auth → URL Configuration → Site URL = \`https://nikita-mygirl.com\`, add redirect URLs for new + preview + localhost

## Test plan
- [ ] CI green (Portal CI + Backend CI + E2E)
- [ ] After Cloud Run redeploy: \`curl -sI -H "Origin: https://nikita-mygirl.com" https://nikita-api-1040094048579.us-central1.run.app/api/v1/health\` returns \`Access-Control-Allow-Origin: https://nikita-mygirl.com\`
- [ ] After Vercel domain attach: \`curl -sI https://nikita-mygirl.com/\` returns 200
- [ ] After Supabase URL config: magic-link login from \`https://nikita-mygirl.com/login\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)