### PR TITLE
chore(rules): capture PR #294 lessons — Vercel canonical CORS + subagent dispatch caps

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -118,6 +118,9 @@ Types: research, analysis, decision, pattern, bug, integration
 - Telegram MCP session expires — re-run `session_string_generator.py` in `../telegram-mcp/` if all Telegram MCP calls fail
 - E2E testing: Use `/e2e` skill (NOT the archived `/e2e-test` or `/e2e-journey`). Covers 13 epics, 363 scenarios with realistic conversation simulation, portal monitoring, and time manipulation.
 - Worktree agents cross-contaminate branches — see `.claude/rules/parallel-agents.md`
+- Vercel canonical: apex `nikita-mygirl.com` is canonical (no redirect); `www.*` → 308 → apex. CORS allowlist must match canonical (PR #294 precedent — see `.claude/rules/vercel-cors-canonical.md`)
+- Vercel REST API token at `~/Library/Application Support/com.vercel.cli/auth.json` — use for ops CLI doesn't expose (e.g., domain redirect direction). Project ID + team ID in `memory/project_vercel_domain_state.md`. See `.claude/rules/vercel-rest-api.md`
+- Subagent dispatch caps mandatory: every Agent-tool call must include `HARD CAP: <N> tool calls` + explicit scope (PR #294 precedent — uncapped dispatch crashed at 40 min)
 
 ## Maintenance
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -119,7 +119,7 @@ Types: research, analysis, decision, pattern, bug, integration
 - E2E testing: Use `/e2e` skill (NOT the archived `/e2e-test` or `/e2e-journey`). Covers 13 epics, 363 scenarios with realistic conversation simulation, portal monitoring, and time manipulation.
 - Worktree agents cross-contaminate branches — see `.claude/rules/parallel-agents.md`
 - Vercel canonical: apex `nikita-mygirl.com` is canonical (no redirect); `www.*` → 308 → apex. CORS allowlist must match canonical (PR #294 precedent — see `.claude/rules/vercel-cors-canonical.md`)
-- Vercel REST API token at `~/Library/Application Support/com.vercel.cli/auth.json` — use for ops CLI doesn't expose (e.g., domain redirect direction). Project ID + team ID in `memory/project_vercel_domain_state.md`. See `.claude/rules/vercel-rest-api.md`
+- Vercel REST API token at `~/Library/Application Support/com.vercel.cli/auth.json` — use for ops CLI doesn't expose (e.g., domain redirect direction). Project ID + team ID in auto-memory `project_vercel_domain_state.md` (`~/.claude/projects/-Users-yangsim-Nanoleq-sideProjects-nikita/memory/`). See `.claude/rules/vercel-rest-api.md`
 - Subagent dispatch caps mandatory: every Agent-tool call must include `HARD CAP: <N> tool calls` + explicit scope (PR #294 precedent — uncapped dispatch crashed at 40 min)
 
 ## Maintenance

--- a/.claude/rules/parallel-agents.md
+++ b/.claude/rules/parallel-agents.md
@@ -36,4 +36,4 @@ Every Agent-tool dispatch (reviewer, researcher, explorer) MUST include in its p
 
 **Why mandatory**: PR #294 (2026-04-16) — first QA-review subagent dispatched without caps ran 87 tool calls / 40 min then crashed with `API ConnectionRefused`. Re-dispatched with `5 tool calls / 3 files / "report CLEAN or N findings"` cap, converged in seconds. The cost of caps is two prompt lines; the cost of uncapped crash is one full re-dispatch + lost context.
 
-Enforcement: orchestrator must reject (not dispatch) any prompt missing all 3 elements. See `feedback_subagent_dispatch_caps.md` for precedent.
+Enforcement: orchestrator must reject (not dispatch) any prompt missing all 3 elements. See auto-memory `feedback_subagent_dispatch_caps.md` (`~/.claude/projects/-Users-yangsim-Nanoleq-sideProjects-nikita/memory/`) for precedent.

--- a/.claude/rules/parallel-agents.md
+++ b/.claude/rules/parallel-agents.md
@@ -22,3 +22,18 @@ globs: ["**"]
 ## Batch Checkpointing
 - For multi-item batch work, save progress after EACH item to `$CLAUDE_PROJECT_DIR/batch-progress.json`
 - Commit per-item if applicable — rate limits only cost one retry, not full restart
+
+## Subagent Dispatch Caps (mandatory)
+
+Every Agent-tool dispatch (reviewer, researcher, explorer) MUST include in its prompt:
+
+1. **Hard tool-call cap**: `HARD CAP: <N> tool calls max. Stop and report partial findings if exceeded.`
+   - QA review: 5 (review only, no fix)
+   - Codebase research: 10
+   - Deep exploration: 15
+2. **Explicit scope clause**: `Review/explore ONLY these files: X, Y, Z` — no scope creep allowed
+3. **Defined exit criterion**: `Report CLEAN: 0 findings` OR `Return first 3 candidates` OR `Stop after <N> tool calls` — no open-ended
+
+**Why mandatory**: PR #294 (2026-04-16) — first QA-review subagent dispatched without caps ran 87 tool calls / 40 min then crashed with `API ConnectionRefused`. Re-dispatched with `5 tool calls / 3 files / "report CLEAN or N findings"` cap, converged in seconds. The cost of caps is two prompt lines; the cost of uncapped crash is one full re-dispatch + lost context.
+
+Enforcement: orchestrator must reject (not dispatch) any prompt missing all 3 elements. See `feedback_subagent_dispatch_caps.md` for precedent.

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -15,7 +15,7 @@ globs: ["**"]
 1. `git checkout -b {type}/{issue}-{description}`
 2. Implement with TDD (tests first)
 3. `gh pr create --title "..." --body "..."`
-4. `/qa-review --pr N` — auto-dispatch via Agent (subagent). Fix all findings, then dispatch a NEW review agent (fresh context). Repeat until the fresh review returns **0 findings across ALL severities** (0 blocking + 0 important + 0 nitpick). Never self-certify a fix — the fresh reviewer is the authority. Never prompt user for permission — this loop is mandatory.
+4. `/qa-review --pr N` — auto-dispatch via Agent (subagent). Fix all findings, then dispatch a NEW review agent (fresh context). Repeat until the fresh review returns **0 findings across ALL severities** (0 blocking + 0 important + 0 nitpick). Never self-certify a fix — the fresh reviewer is the authority. Never prompt user for permission — this loop is mandatory. **Every dispatch MUST include `HARD CAP: 5 tool calls` + explicit changed-files list** (per `.claude/rules/parallel-agents.md` Subagent Dispatch Caps). PR #294 precedent: uncapped first dispatch ran 40 min and crashed with `API ConnectionRefused`; capped re-dispatch converged in seconds.
 5. Squash merge ONLY after a fresh QA review returns absolute zero findings + CI green
 6. `gh issue close N --comment "Fixed in PR #M"`
 7. Post-merge verification (auto-dispatched subagent): smoke test the deployed change (curl probe, log sweep, or dogfood scenario as appropriate). Do not skip. Do not ask permission.

--- a/.claude/rules/vercel-cors-canonical.md
+++ b/.claude/rules/vercel-cors-canonical.md
@@ -1,0 +1,60 @@
+---
+description: Vercel domain canonical-redirect coupling with backend CORS allowlist
+globs: ["nikita/config/**", "portal/vercel.json", ".env*", "docs/deployment.md"]
+---
+
+# Vercel Domain ↔ CORS Canonical Coupling
+
+When Vercel redirects apex↔www (or any custom-domain redirect), the post-redirect domain is what the browser puts in the `Origin` header on subsequent API calls. The backend CORS allowlist MUST contain the **canonical** (post-redirect) domain, not the URL the user types.
+
+## Mandatory pre-CORS check (3 commands)
+
+Before adding/changing any entry in `nikita/config/settings.py:cors_origins` or `.env CORS_ORIGINS`:
+
+```bash
+# 1. Detect canonical via redirect-follow
+curl -sI https://nikita-mygirl.com/ | grep -iE "(http/|location)"
+curl -sI https://www.nikita-mygirl.com/ | grep -iE "(http/|location)"
+# Expect ONE 200 + ONE 308/307 with Location pointing to the 200 host
+
+# 2. Confirm Vercel redirect direction via REST API
+TOKEN=$(jq -r .token "$HOME/Library/Application Support/com.vercel.cli/auth.json")
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.vercel.com/v9/projects/prj_mP2qGV9ICPdNilcT6Zrf18HY9O7p/domains/nikita-mygirl.com?teamId=team_tzoCYvqmW3v3OvvzyZOZ2VlT" \
+  | jq '{name,redirect,redirectStatusCode}'
+
+# 3. Verify CORS preflight from canonical domain reaches backend
+curl -sI -H "Origin: https://nikita-mygirl.com" -X OPTIONS \
+  "https://nikita-api-1040094048579.us-central1.run.app/api/v1/health" \
+  | grep -iE "(http/|access-control-allow-origin)"
+# Expect: 2xx + access-control-allow-origin matches the Origin header
+```
+
+If step 3 returns HTTP 400 or no `access-control-allow-origin` header, CORS list is wrong — fix before merge. PR #294 (Apr 16, 2026) precedent: apex was in CORS but Vercel redirected apex→www, would have broken every authenticated portal API call.
+
+## Vercel CLI command catalog (memorized)
+
+| Operation | Command |
+|---|---|
+| List domains in team | `vercel domains ls` |
+| List aliases for project | `vercel alias ls` (filter `grep <project>`) |
+| Inspect deployment + aliases | `vercel inspect <deployment-url>` (⚠ cached) |
+| Add alias to deployment | `vercel alias set <deployment-url> <domain-or-subdomain>` |
+| Remove alias | `vercel alias rm <alias> --yes` |
+| List env vars | `vercel env ls` |
+| Add env var | `vercel env add <NAME> <env>` (interactive) |
+| Remove env var | `vercel env rm <NAME> <env> --yes` |
+| List projects | `vercel project ls` |
+
+`.vercel.app` subdomains are first-class: `vercel alias set <deployment> nikita-preview.vercel.app` works for any unclaimed name.
+
+## Gotchas (PR #294 evidence)
+
+- **Project rename ≠ alias cleanup**: renaming a Vercel project leaves all old auto-generated aliases (`portal-phi-orcin.vercel.app`, `portal-yangsi7s-projects.vercel.app`, etc.) attached to current production. After every rename, audit `vercel inspect <prod-deployment>` and `vercel alias rm` each stale entry.
+- **`vercel inspect` is cached** after `vercel alias rm` — the alias list won't update for several minutes. Always verify removal via `curl -sI <removed-alias>` returning 404.
+- **Apex+www both attached**: Vercel auto-creates one as canonical, the other as redirect. Default direction is unpredictable. Always set explicitly via REST API (see `vercel-rest-api.md`).
+
+## Reference
+- Cross-rule: `vercel-rest-api.md` for canonical-redirect direction changes
+- Memory: `feedback_vercel_cors_canonical.md`
+- Deployment doc: `docs/deployment.md` "Custom Domain Management"

--- a/.claude/rules/vercel-rest-api.md
+++ b/.claude/rules/vercel-rest-api.md
@@ -1,6 +1,11 @@
+---
+description: Vercel REST API recipes for operations the CLI doesn't expose (canonical redirect, bulk inspections)
+globs: ["**"]
+---
+
 # Vercel REST API — Operations CLI Doesn't Expose
 
-The Vercel CLI handles routine ops (alias set/rm, env add/rm, domains ls), but the REST API is required for things like canonical-redirect direction, project domain config patches, and bulk inspections. Per `feedback_infra_config_autonomy.md`: do this autonomously, don't offload to dashboard.
+The Vercel CLI handles routine ops (alias set/rm, env add/rm, domains ls), but the REST API is required for things like canonical-redirect direction, project domain config patches, and bulk inspections. Per auto-memory `feedback_infra_config_autonomy.md` (`~/.claude/projects/-Users-yangsim-Nanoleq-sideProjects-nikita/memory/`): do this autonomously, don't offload to dashboard.
 
 ## Auth recipe (works from any session)
 
@@ -50,5 +55,5 @@ curl -sI https://www.nikita-mygirl.com/  # → 308 + Location: https://nikita-my
 
 ## Reference
 - Full Vercel REST API: https://vercel.com/docs/rest-api
-- Project IDs: see `project_vercel_domain_state.md` memory
+- Project IDs: see auto-memory `project_vercel_domain_state.md` (`~/.claude/projects/-Users-yangsim-Nanoleq-sideProjects-nikita/memory/`)
 - Auth: `~/Library/Application Support/com.vercel.cli/auth.json` — token rotates if you re-login via CLI

--- a/.claude/rules/vercel-rest-api.md
+++ b/.claude/rules/vercel-rest-api.md
@@ -1,0 +1,54 @@
+# Vercel REST API — Operations CLI Doesn't Expose
+
+The Vercel CLI handles routine ops (alias set/rm, env add/rm, domains ls), but the REST API is required for things like canonical-redirect direction, project domain config patches, and bulk inspections. Per `feedback_infra_config_autonomy.md`: do this autonomously, don't offload to dashboard.
+
+## Auth recipe (works from any session)
+
+```bash
+TOKEN=$(jq -r .token "$HOME/Library/Application Support/com.vercel.cli/auth.json")
+TEAM_ID=$(curl -s -H "Authorization: Bearer $TOKEN" "https://api.vercel.com/v2/teams" \
+  | jq -r '.teams[] | select(.slug=="5meo-inc") | .id')
+PROJECT="prj_mP2qGV9ICPdNilcT6Zrf18HY9O7p"  # nikita-mygirl
+```
+
+## Endpoint matrix (most-used)
+
+| Operation | Method | Path |
+|---|---|---|
+| Get domain config (incl. redirect) | GET | `/v9/projects/{projectId}/domains/{name}?teamId=…` |
+| Set domain redirect direction | PATCH | `/v9/projects/{projectId}/domains/{name}?teamId=…` body `{"redirect":"<target>","redirectStatusCode":308}` |
+| Remove domain redirect (make canonical) | PATCH | `/v9/projects/{projectId}/domains/{name}?teamId=…` body `{"redirect":null,"redirectStatusCode":null}` |
+| List teams | GET | `/v2/teams` |
+| List project deployments | GET | `/v6/deployments?projectId={projectId}&teamId=…` |
+| Get specific deployment | GET | `/v13/deployments/{idOrUrl}?teamId=…` |
+| List env vars | GET | `/v9/projects/{projectId}/env?teamId=…` |
+
+## Worked example: flip apex↔www canonical (PR #294 precedent)
+
+Goal: make apex `nikita-mygirl.com` canonical (no redirect), redirect www → apex with 308.
+
+```bash
+# 1. Remove redirect from apex
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"redirect":null,"redirectStatusCode":null}' \
+  "https://api.vercel.com/v9/projects/$PROJECT/domains/nikita-mygirl.com?teamId=$TEAM_ID"
+
+# 2. Add www → apex 308
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"redirect":"nikita-mygirl.com","redirectStatusCode":308}' \
+  "https://api.vercel.com/v9/projects/$PROJECT/domains/www.nikita-mygirl.com?teamId=$TEAM_ID"
+
+# 3. Verify with curl
+curl -sI https://nikita-mygirl.com/  # → 200
+curl -sI https://www.nikita-mygirl.com/  # → 308 + Location: https://nikita-mygirl.com/
+```
+
+## When to drop from CLI to REST API
+- CLI command not found / not implemented (e.g., domain redirect direction)
+- Need bulk inspection (e.g., audit all env vars across 5 projects)
+- Need read-only programmatic access without state changes (CLI commands can have side effects)
+
+## Reference
+- Full Vercel REST API: https://vercel.com/docs/rest-api
+- Project IDs: see `project_vercel_domain_state.md` memory
+- Auth: `~/Library/Application Support/com.vercel.cli/auth.json` — token rotates if you re-login via CLI

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,16 +53,16 @@ vercel alias rm <alias> --yes                                      # remove alia
 **Canonical-redirect changes via REST API** (CLI doesn't support this):
 ```bash
 TOKEN=$(jq -r .token "$HOME/Library/Application Support/com.vercel.cli/auth.json")
-TEAM=team_tzoCYvqmW3v3OvvzyZOZ2VlT
-PROJ=prj_mP2qGV9ICPdNilcT6Zrf18HY9O7p
+TEAM_ID=team_tzoCYvqmW3v3OvvzyZOZ2VlT
+PROJECT=prj_mP2qGV9ICPdNilcT6Zrf18HY9O7p
 
 # Flip canonical to apex (apex no redirect, www → apex 308)
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{"redirect":null,"redirectStatusCode":null}' \
-  "https://api.vercel.com/v9/projects/$PROJ/domains/nikita-mygirl.com?teamId=$TEAM"
+  "https://api.vercel.com/v9/projects/$PROJECT/domains/nikita-mygirl.com?teamId=$TEAM_ID"
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{"redirect":"nikita-mygirl.com","redirectStatusCode":308}' \
-  "https://api.vercel.com/v9/projects/$PROJ/domains/www.nikita-mygirl.com?teamId=$TEAM"
+  "https://api.vercel.com/v9/projects/$PROJECT/domains/www.nikita-mygirl.com?teamId=$TEAM_ID"
 ```
 
 **CORS verification** (run after any domain or backend change):

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,6 +36,43 @@ source ~/.nvm/nvm.sh && nvm use 22 && cd portal && npm run build && vercel --pro
 
 `vercel.json` includes API rewrites that proxy `/api/v1/*` to the Cloud Run backend + security headers.
 
+### Custom Domain Management (post-PR-#294)
+
+**Canonical**: apex `nikita-mygirl.com` (no redirect, returns 200). `www.nikita-mygirl.com` → 308 → apex.
+
+**CRITICAL**: backend CORS allowlist (`nikita/config/settings.py:cors_origins`) MUST match the canonical, not the URL users type. If you flip canonical, also update CORS + redeploy Cloud Run. See `.claude/rules/vercel-cors-canonical.md` for the 3-step pre-CORS check.
+
+**Routine ops via CLI:**
+```bash
+vercel domains ls                                                  # list team domains
+vercel inspect <deployment-url>                                    # see aliases (cached — verify with curl)
+vercel alias set <deployment-url> <domain>                         # add alias
+vercel alias rm <alias> --yes                                      # remove alias
+```
+
+**Canonical-redirect changes via REST API** (CLI doesn't support this):
+```bash
+TOKEN=$(jq -r .token "$HOME/Library/Application Support/com.vercel.cli/auth.json")
+TEAM=team_tzoCYvqmW3v3OvvzyZOZ2VlT
+PROJ=prj_mP2qGV9ICPdNilcT6Zrf18HY9O7p
+
+# Flip canonical to apex (apex no redirect, www → apex 308)
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"redirect":null,"redirectStatusCode":null}' \
+  "https://api.vercel.com/v9/projects/$PROJ/domains/nikita-mygirl.com?teamId=$TEAM"
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"redirect":"nikita-mygirl.com","redirectStatusCode":308}' \
+  "https://api.vercel.com/v9/projects/$PROJ/domains/www.nikita-mygirl.com?teamId=$TEAM"
+```
+
+**CORS verification** (run after any domain or backend change):
+```bash
+curl -sI -H "Origin: https://nikita-mygirl.com" -X OPTIONS \
+  https://nikita-api-1040094048579.us-central1.run.app/api/v1/health \
+  | grep -iE "(http/|access-control-allow-origin)"
+# Expect: 2xx + access-control-allow-origin: https://nikita-mygirl.com
+```
+
 ## Supabase (Database)
 
 | Resource | Value |


### PR DESCRIPTION
## Summary
Captures durable lessons from the domain-migration session (PR #294) into permanent project rules + memory artifacts.

**Two near-incidents resolved**:
1. Apex was in CORS allowlist but Vercel redirected apex→www — would have broken every authenticated API call from production. Fixed by flipping Vercel canonical via REST API.
2. First QA-review subagent dispatched without caps ran 87 tool calls / 40 min then crashed. Re-dispatched with HARD CAP (5 tool calls / 3 files) — converged in seconds.

## Changes
- **NEW** `.claude/rules/vercel-cors-canonical.md` (60 lines, path-scoped) — 3-step pre-CORS check + Vercel CLI catalog
- **NEW** `.claude/rules/vercel-rest-api.md` (54 lines) — REST API auth recipe + endpoint matrix + apex-canonical worked example
- **UPDATE** `.claude/rules/parallel-agents.md` — Subagent Dispatch Caps section (mandatory)
- **UPDATE** `.claude/rules/pr-workflow.md` — caps requirement embedded in /qa-review dispatch step
- **UPDATE** `.claude/CLAUDE.md` — 3 gotcha bullets pointing to new rules
- **UPDATE** `docs/deployment.md` — Custom Domain Management subsection

Plus 3 local memory entries.

## Test plan
- [x] All file sizes within caps (≤80 lines rules, ≤200 CLAUDE.md)
- [x] Live verification: apex still 200 (canonical preserved)
- [x] No production code changed; pure docs/rules/knowledge artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)