### PR TITLE
docs(onboarding): design authority for Spec 214 wizard

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ specs_total: 86
 specs_complete: 87
 specs_superseded: 2
 tests_total: 5934
-last_deploy: 2026-04-15
+last_deploy: 2026-04-16
 version: 1.0.2
 ---
 
@@ -26,11 +26,11 @@ version: 1.0.2
 | Pipeline stages | 11 |
 | Feature flags | 6/6 ON |
 | pg_cron jobs | 8 active |
-| Cloud Run deploy | `nikita-api-00250-4mm` (us-central1) |
+| Cloud Run deploy | `nikita-api-00251-w7m` (us-central1) |
 | Portal deploy | `portal-phi-orcin.vercel.app` |
-| Last deploy | 2026-04-15 (Spec 213 backend foundation — PRs 213-1..213-5: frozen contracts, migration, facade, routes, FR-6 first-message + R8 continuity) |
-| Active specs | 1 (214 portal-wizard) |
-| In-flight | none (Spec 213 closed PR 213-5; Spec 214 portal-wizard pending) |
+| Last deploy | 2026-04-16 (Spec 214 PR 214-D backend sub-amendment — PUT /profile/chosen-option + wizard_step extension; revision `nikita-api-00251-w7m`) |
+| Active specs | 1 (214 portal-wizard — PR-D shipped, PR-A in-flight) |
+| In-flight | PR 214-A portal foundation (TS contracts mirror + state machine + hooks + persistence) |
 
 ---
 
@@ -135,7 +135,7 @@ Player portal, admin dashboards, data viz, push notifications.
 | 208 | portal-landing-page-hero | #209 | **COMPLETE** — "Don't Get Dumped" hero landing page, 5 sections, FallingPattern, deployed 2026-04-03 |
 | 212 | phone-capture-onboarding-ux | #266-272 | **COMPLETE** — Phone field, E.164 validation, voice-callback routing, 409 conflict handling. Spec dir backfill pending. |
 | 213 | onboarding-backend-foundation | 60+ | **COMPLETE** (PR 213-5, 2026-04-15) — contracts.py + tuning.py + adapters.py; migration + ORM + BackstoryCacheRepository; PortalOnboardingFacade + preview endpoint + PII fixes; GET /pipeline-ready + PATCH /profile + FR-14 session isolation; FR-6 FirstMessageGenerator backstory hook + R8 continuity regression tests. |
-| 214 | portal-onboarding-wizard | — | **PLANNED** — One-thing-at-a-time wizard with landing aesthetic. Imports Spec 213 contracts. Supersedes 081. |
+| 214 | portal-onboarding-wizard | 98+ | **IN PROGRESS** — PR 214-D shipped 2026-04-16 (PUT /profile/chosen-option endpoint + wizard_step extension, deployed `nikita-api-00251-w7m`). PR 214-A foundation in-flight; PR-B/C pending. Imports Spec 213 contracts. Supersedes 081. |
 
 **Domain subtotal: 16 specs (15 complete, 1 planned)**
 

--- a/docs/content/onboarding-design-brief.md
+++ b/docs/content/onboarding-design-brief.md
@@ -25,7 +25,7 @@ The wizard reuses the **same primitives** (FallingPattern, AuroraOrbs, GlowButto
 
 - Each step occupies `min-h-screen` (or `min-h-[100dvh]` for mobile safe areas).
 - Background = `bg-void` (`oklch(0.08 0 0)`).
-- One headline. One input or one decision. One CTA. No secondary navigation, no progress shrunk into a corner footer — progress goes top-center as the dossier file index "FIELD N OF 7".
+- One headline. One input or one decision. One CTA. No secondary navigation, no progress shrunk into a corner footer — progress goes top-center as the dossier file index "FIELD N OF 7". The 7 dossier fields correspond to spec-214 steps 4-10 (Location, Scene, Darkness, Identity, Backstory, Phone, PipelineGate); steps 1-3 (Landing/Auth/DossierHeader) and 11 (Handoff) do not show the FIELD indicator.
 - White space dominates. Center vertically (`flex items-center`) with content max-width capped (`max-w-2xl mx-auto`).
 
 ### 2. Landing-page typography (non-negotiable)
@@ -55,7 +55,7 @@ The wizard reuses the **same primitives** (FallingPattern, AuroraOrbs, GlowButto
 
 - Step entry: `initial={{ opacity: 0, y: 24 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1] }}`
 - Stagger pattern (e.g., reveal of multiple options): delay siblings by 0.15s × index, max 0.55s.
-- DossierStamp typewriter: 50ms per character (matches `system-terminal.tsx`).
+- DossierStamp typewriter: 50ms per character (landing's `system-terminal.tsx` uses 50ms per LINE — this is a dossier-stamp adaptation of the same cadence).
 - CLEARED rotate-in: 0.5s spring, opacity 0→1, rotate 8deg→0deg, scale 1.2→1.
 - **`prefers-reduced-motion: reduce`** MUST short-circuit ALL animations to instant state. Pattern from `system-terminal.tsx:37-46`.
 
@@ -71,7 +71,7 @@ The wizard reuses the **same primitives** (FallingPattern, AuroraOrbs, GlowButto
 </section>
 ```
 
-Reuse: `import { FallingPattern } from "@/components/landing/falling-pattern"` and `AuroraOrbs`. These are 11 + 82 lines respectively — already shipped.
+Reuse: `import { FallingPattern } from "@/components/landing/falling-pattern"` and `AuroraOrbs`. These are 82 + 11 lines respectively — already shipped.
 
 ### 6. shadcn/ui — install, don't reinvent
 
@@ -115,17 +115,19 @@ The component is a 1:1 visual sibling of `system-terminal.tsx` but with `--rose-
 
 ## Step-by-Step Aesthetic Map
 
+Step numbering matches spec 214 (`specs/214-portal-onboarding-wizard/spec.md` §"Wizard Step Map"). Steps 1 (Landing) and 2 (Auth) are pre-wizard surfaces and not covered here. Step 3 (DossierHeader) is the wizard's intro screen; steps 4-10 are the 7 dossier fields; step 11 is the post-pipeline handoff.
+
 | Step | Visual | Reveal? | shadcn primitive |
 |---|---|---|---|
-| 3 LocationStep | Hero "WHERE." → city Input below → DossierReveal of "venue scout active" on blur | Yes (post-blur) | `Input` |
-| 4 SceneStep | Hero "WHO DO YOU RUN WITH?" → 4-button radiogroup grid, each card glass + rose focus ring | No | `RadioGroup` (REQUIRED — WAI-ARIA) |
-| 5 DarknessStep | Hero "HOW DARK?" → slider full-width → live Nikita quote underneath | Yes (consequence ladder above slider) | `Slider` |
-| 6 IdentityStep | Hero "TELL ME WHO" → 3 stacked Inputs (name/age/occupation) | Yes (data-use reveal above) | `Input` x3 |
-| 7 BackstoryReveal | Hero "PICK YOUR ENTRY POINT" → 3 BackstoryOption cards in a horizontal grid | No | `Card` x3 |
-| 8 PhoneStep | Hero "SHE NEEDS A NUMBER" → phone input with country selector + voice/text radio | No | `Input` + `RadioGroup` |
-| 9 PipelineGate | Hero "CLEARANCE PROCESSING" → DossierReveal driven by pipeline state | YES (live, primary feature) | none — pure custom |
-| 10 HandoffStep | Hero "GO." → GlowButton(Telegram) center; QRHandoff right (desktop only) | No | `Button` (or GlowButton) |
-| 11 Complete | CLEARED stamp center-screen, fades to dashboard redirect | n/a | none |
+| 3 DossierHeader | Hero "THE DOSSIER" → eyebrow "FILE OPENED" → metric bars at 50/50/50/50 → CTA "Open the file." | No | `Button` |
+| 4 LocationStep | Hero "WHERE." → city Input below → DossierReveal of "venue scout active" on blur | Yes (post-blur) | `Input` |
+| 5 SceneStep | Hero "WHO DO YOU RUN WITH?" → 4-button radiogroup grid, each card glass + rose focus ring | No | `RadioGroup` (REQUIRED — WAI-ARIA) |
+| 6 DarknessStep | Hero "HOW DARK?" → slider full-width → live Nikita quote underneath | Yes (consequence ladder above slider) | `Slider` |
+| 7 IdentityStep | Hero "TELL ME WHO" → 3 stacked Inputs (name/age/occupation) | Yes (data-use reveal above) | `Input` x3 |
+| 8 BackstoryReveal | Hero "PICK YOUR ENTRY POINT" → 3 BackstoryOption cards in a horizontal grid | No | `Card` x3 |
+| 9 PhoneStep | Hero "SHE NEEDS A NUMBER" → phone input with country selector + voice/text radio | No | `Input` + `RadioGroup` |
+| 10 PipelineGate | Hero "CLEARANCE PROCESSING" → DossierReveal driven by pipeline state, terminates with CLEARED stamp | YES (live, primary feature) | none — pure custom |
+| 11 HandoffStep | Hero "GO." → GlowButton(Telegram) center; QRHandoff right (desktop only) | No | `Button` (or GlowButton) |
 
 ---
 

--- a/docs/content/onboarding-design-brief.md
+++ b/docs/content/onboarding-design-brief.md
@@ -1,0 +1,161 @@
+# Onboarding Design Brief — Spec 214 PR-B & PR-C Reviewers
+
+**Audience**: PR 214-B/C QA reviewers + future onboarding work
+**Authority**: User direction 2026-04-16 ("follow the great aesthetic we have in the landing page... one focused piece at a time. Full screen.")
+**Status**: AUTHORITATIVE for all 11 wizard steps
+
+---
+
+## North Star
+
+The onboarding is **the wizard equivalent of the landing page's "Under The Hood" reveal**. It teaches Nikita's reality — interactively, one focused beat at a time — while *being* the very first turn of the relationship. No SaaS form. No brand strip. Each screen is a full-viewport stage; each transition is a curtain reveal.
+
+**Reference experience**: open `portal/src/app/page.tsx` → scroll through. Note especially:
+- `system-section.tsx` + `system-terminal.tsx` — staggered ✓ reveal of capabilities
+- `hero-section.tsx` — typography scale, motion timing, eyebrow + headline + subheadline + cta rhythm
+- `stakes-section.tsx`, `pitch-section.tsx`, `cta-section.tsx` — section-by-section beats with `whileInView` transitions
+
+The wizard reuses the **same primitives** (FallingPattern, AuroraOrbs, GlowButton, glass cards, terminal aesthetic) so the onboarding feels like the landing page **animated forward** into a personal conversation — not a separate product.
+
+---
+
+## Hard Design Rules
+
+### 1. One thing per screen, full viewport
+
+- Each step occupies `min-h-screen` (or `min-h-[100dvh]` for mobile safe areas).
+- Background = `bg-void` (`oklch(0.08 0 0)`).
+- One headline. One input or one decision. One CTA. No secondary navigation, no progress shrunk into a corner footer — progress goes top-center as the dossier file index "FIELD N OF 7".
+- White space dominates. Center vertically (`flex items-center`) with content max-width capped (`max-w-2xl mx-auto`).
+
+### 2. Landing-page typography (non-negotiable)
+
+- **Hero text per step** (e.g., "What city?"): `text-[clamp(3rem,7vw,6rem)] font-black tracking-tighter leading-none text-foreground`
+- **Eyebrow** (above headline, e.g., "FIELD 03 OF 07 — LOCATION"): `text-xs tracking-[0.2em] uppercase text-muted-foreground`
+- **Subheadline / Nikita voice** (e.g., "Where do you actually live? I want to know what corner you cry in."): `text-lg text-muted-foreground max-w-md leading-relaxed`
+- **Body / form labels**: `text-sm text-muted-foreground`
+- Use `font-mono` ONLY for terminal-style elements (CLEARED stamps, system reveals, pipeline gate progress).
+
+### 3. Color palette (use tokens, never literals)
+
+| Use | Token | Value |
+|---|---|---|
+| Background | `bg-void` | `oklch(0.08 0 0)` |
+| Card surface | `bg-card` / `bg-glass` | `oklch(0.13 0 0)` / `oklch(1 0 0 / 5%)` |
+| Primary accent (rose) | `text-primary` / `bg-primary` | `oklch(0.75 0.15 350)` |
+| Cyan accent (info) | `text-cyan-glow` / `var(--cyan-glow)` | `oklch(0.7 0.15 190)` |
+| Amber accent (warning) | `text-amber-glow` | `oklch(0.75 0.15 80)` |
+| Foreground | `text-foreground` | `oklch(0.95 0 0)` |
+| Muted | `text-muted-foreground` | `oklch(0.6 0 0)` |
+| Glass border | `border-glass-border` | `oklch(1 0 0 / 10%)` |
+
+**Never inline `oklch(...)` values**. Always use tokens via Tailwind classes or `var(--token)`.
+
+### 4. Motion language (framer-motion, EASE_OUT_QUART)
+
+- Step entry: `initial={{ opacity: 0, y: 24 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1] }}`
+- Stagger pattern (e.g., reveal of multiple options): delay siblings by 0.15s × index, max 0.55s.
+- DossierStamp typewriter: 50ms per character (matches `system-terminal.tsx`).
+- CLEARED rotate-in: 0.5s spring, opacity 0→1, rotate 8deg→0deg, scale 1.2→1.
+- **`prefers-reduced-motion: reduce`** MUST short-circuit ALL animations to instant state. Pattern from `system-terminal.tsx:37-46`.
+
+### 5. Background atmosphere on EVERY step
+
+```tsx
+<section className="relative min-h-screen overflow-hidden bg-void">
+  <FallingPattern />
+  <AuroraOrbs />
+  <div className="relative z-10 flex flex-col items-center justify-center min-h-screen container mx-auto px-6">
+    {/* step content */}
+  </div>
+</section>
+```
+
+Reuse: `import { FallingPattern } from "@/components/landing/falling-pattern"` and `AuroraOrbs`. These are 11 + 82 lines respectively — already shipped.
+
+### 6. shadcn/ui — install, don't reinvent
+
+- `components.json` already configured: style `"new-york"`, base color `"zinc"`, RSC enabled, lucide icons.
+- **Use shadcn primitives** for: `Input`, `Label`, `RadioGroup` (SceneStep!), `Slider` (DarknessStep!), `Button`, `Card`. Install via `npx shadcn@latest add <component>` if missing.
+- Wrap shadcn primitives in dossier-themed adapters when needed (e.g., `<DossierInput>` extends `<Input>` with rose focus ring, monospace eyebrow label).
+- NEVER write custom radio buttons / sliders / form fields when a shadcn equivalent exists.
+
+---
+
+## "How Nikita Works" Reveal Pattern
+
+The user explicitly called this out. The landing page's `system-terminal.tsx` reveals 14 system capabilities with staggered ✓ marks in a monospace terminal. **Mirror this in onboarding**:
+
+### When to deploy the reveal pattern
+
+Use it at **3 specific teaching moments** in the wizard:
+
+1. **Pre-IdentityStep ("Who are you?")**: A 4-line monospace reveal explaining what Nikita stores about the player and why ("Name → so she calls you yours", "Age → so she calibrates innuendo", "Occupation → so she remembers your Mondays"). Each line stagger-fades in 50ms apart.
+
+2. **Pre-DarknessStep ("How dark do you want this?")**: Reveal the consequence ladder — 5 ✓ lines mapping slider position to in-game consequence ("0.2 → soft chaos, no scars", "0.5 → real fights, real grace", "0.8 → vice surfaces in week 2", etc.).
+
+3. **PipelineGate ("CLEARANCE PROCESSING")**: Real-time staggered reveal as backend stages complete — `✓ Researching your city...`, `✓ Generating backstory candidates...`, `✓ Compiling first message...`. Each ✓ appears as the corresponding pipeline stage finishes (driven by `useOnboardingPipelineReady` state).
+
+### Reveal component pseudocode
+
+```tsx
+"use client"
+// Reuse system-terminal.tsx as a base. Extract a generic
+// <DossierReveal items={[{label, detail}]} interval={50} /> that
+// the wizard steps can drop into a step's pre-input slot.
+
+// Visual: black/40 backdrop, rounded-lg, border-glass-border,
+// monospace, ✓ in --rose-glow (NOT green — match dossier theme),
+// label in foreground, detail in muted-foreground right-aligned.
+```
+
+The component is a 1:1 visual sibling of `system-terminal.tsx` but with `--rose-glow` accent (matches landing rose primary), and the reveal *concludes the explanation* before the user touches the input below.
+
+---
+
+## Step-by-Step Aesthetic Map
+
+| Step | Visual | Reveal? | shadcn primitive |
+|---|---|---|---|
+| 3 LocationStep | Hero "WHERE." → city Input below → DossierReveal of "venue scout active" on blur | Yes (post-blur) | `Input` |
+| 4 SceneStep | Hero "WHO DO YOU RUN WITH?" → 4-button radiogroup grid, each card glass + rose focus ring | No | `RadioGroup` (REQUIRED — WAI-ARIA) |
+| 5 DarknessStep | Hero "HOW DARK?" → slider full-width → live Nikita quote underneath | Yes (consequence ladder above slider) | `Slider` |
+| 6 IdentityStep | Hero "TELL ME WHO" → 3 stacked Inputs (name/age/occupation) | Yes (data-use reveal above) | `Input` x3 |
+| 7 BackstoryReveal | Hero "PICK YOUR ENTRY POINT" → 3 BackstoryOption cards in a horizontal grid | No | `Card` x3 |
+| 8 PhoneStep | Hero "SHE NEEDS A NUMBER" → phone input with country selector + voice/text radio | No | `Input` + `RadioGroup` |
+| 9 PipelineGate | Hero "CLEARANCE PROCESSING" → DossierReveal driven by pipeline state | YES (live, primary feature) | none — pure custom |
+| 10 HandoffStep | Hero "GO." → GlowButton(Telegram) center; QRHandoff right (desktop only) | No | `Button` (or GlowButton) |
+| 11 Complete | CLEARED stamp center-screen, fades to dashboard redirect | n/a | none |
+
+---
+
+## What Gets REJECTED at QA
+
+- Multiple form fields visible per screen (violates "one thing per screen")
+- Default Tailwind colors (`bg-blue-500`, `text-gray-400`, etc.) instead of project tokens
+- shadcn skipped in favor of hand-rolled `<input>` / `<button>` markup
+- No background atmosphere (FallingPattern + AuroraOrbs missing)
+- Typography that doesn't match landing scale (e.g., `text-2xl` for hero where it should be `clamp(3rem,7vw,6rem)`)
+- SaaS copy ("Continue", "Next step", "Submit") instead of Nikita voice ("Lock it in", "Tell me more", "I'm ready when you are")
+- Animation that ignores `prefers-reduced-motion`
+- Page that scrolls instead of being one full-viewport stage
+- Missing eyebrow label (no "FIELD N OF 7" context)
+
+---
+
+## Reference Files (read these before implementing or reviewing)
+
+- `portal/src/components/landing/hero-section.tsx` — typography rhythm, EASE_OUT_QUART pattern
+- `portal/src/components/landing/system-terminal.tsx` — staggered reveal authority
+- `portal/src/components/landing/system-section.tsx` — `whileInView` section pattern
+- `portal/src/components/landing/falling-pattern.tsx`, `aurora-orbs.tsx` — background primitives
+- `portal/src/components/landing/glow-button.tsx` — primary CTA style
+- `portal/src/app/globals.css` lines 99-108 + 110-145 — token catalog
+- `portal/components.json` — shadcn config
+- `docs/content/wizard-copy.md` — Nikita-voiced copy reference (PR-B creates this)
+
+---
+
+## Acceptance Criterion (informal)
+
+If a designer who built the landing page screenshots the wizard and can't tell where the landing ends and the onboarding begins (apart from the form mechanics), we shipped it right. If it looks like a Vercel template with a logo on top, we did not.

--- a/docs/content/onboarding-design-brief.md
+++ b/docs/content/onboarding-design-brief.md
@@ -31,7 +31,7 @@ The wizard reuses the **same primitives** (FallingPattern, AuroraOrbs, GlowButto
 ### 2. Landing-page typography (non-negotiable)
 
 - **Hero text per step** (e.g., "What city?"): `text-[clamp(3rem,7vw,6rem)] font-black tracking-tighter leading-none text-foreground`
-- **Eyebrow** (above headline, e.g., "FIELD 03 OF 07 — LOCATION"): `text-xs tracking-[0.2em] uppercase text-muted-foreground`
+- **Eyebrow** (above headline, e.g., "FIELD 01 OF 07 — LOCATION"): `text-xs tracking-[0.2em] uppercase text-muted-foreground`
 - **Subheadline / Nikita voice** (e.g., "Where do you actually live? I want to know what corner you cry in."): `text-lg text-muted-foreground max-w-md leading-relaxed`
 - **Body / form labels**: `text-sm text-muted-foreground`
 - Use `font-mono` ONLY for terminal-style elements (CLEARED stamps, system reveals, pipeline gate progress).
@@ -88,13 +88,19 @@ The user explicitly called this out. The landing page's `system-terminal.tsx` re
 
 ### When to deploy the reveal pattern
 
-Use it at **3 specific teaching moments** in the wizard:
+DossierReveal serves two roles. **Teaching reveals** (3) explain Nikita's mechanics before the player commits to an input. **Result reveals** (1) confirm a backend response after the player acts. Both share the staggered-✓ visual but differ in trigger and intent.
+
+**Teaching reveals** — render ABOVE the input, before user interaction:
 
 1. **Pre-IdentityStep ("Who are you?")**: A 4-line monospace reveal explaining what Nikita stores about the player and why ("Name → so she calls you yours", "Age → so she calibrates innuendo", "Occupation → so she remembers your Mondays"). Each line stagger-fades in 50ms apart.
 
 2. **Pre-DarknessStep ("How dark do you want this?")**: Reveal the consequence ladder — 5 ✓ lines mapping slider position to in-game consequence ("0.2 → soft chaos, no scars", "0.5 → real fights, real grace", "0.8 → vice surfaces in week 2", etc.).
 
 3. **PipelineGate ("CLEARANCE PROCESSING")**: Real-time staggered reveal as backend stages complete — `✓ Researching your city...`, `✓ Generating backstory candidates...`, `✓ Compiling first message...`. Each ✓ appears as the corresponding pipeline stage finishes (driven by `useOnboardingPipelineReady` state).
+
+**Result reveal** — fires AFTER user input on a single step:
+
+4. **Post-LocationStep blur ("venue scout active")**: a confirmation reveal that fires after the city Input loses focus, surfacing the venue-research preview returned by the backend. Shorter (1-2 lines), positioned BELOW the input. This is a result reveal — distinct in role from the teaching reveals above, identical in visual treatment.
 
 ### Reveal component pseudocode
 
@@ -115,7 +121,7 @@ The component is a 1:1 visual sibling of `system-terminal.tsx` but with `--rose-
 
 ## Step-by-Step Aesthetic Map
 
-Step numbering matches spec 214 (`specs/214-portal-onboarding-wizard/spec.md` §"Wizard Step Map"). Steps 1 (Landing) and 2 (Auth) are pre-wizard surfaces and not covered here. Step 3 (DossierHeader) is the wizard's intro screen; steps 4-10 are the 7 dossier fields; step 11 is the post-pipeline handoff.
+Step numbering matches spec 214 (`specs/214-portal-onboarding-wizard/spec.md` §"FR-1 — 11-Step Wizard Flow"). Steps 1 (Landing) and 2 (Auth) are pre-wizard surfaces and not covered here. Step 3 (DossierHeader) is the wizard's intro screen; steps 4-10 are the 7 dossier fields; step 11 is the post-pipeline handoff.
 
 | Step | Visual | Reveal? | shadcn primitive |
 |---|---|---|---|


### PR DESCRIPTION
## Summary

Codifies the design direction the user gave on 2026-04-16 for the Spec 214 portal-onboarding-wizard. Becomes the AUTHORITATIVE reference for all PR 214-B/C QA reviewers and any future onboarding work.

- **North Star**: onboarding = wizard equivalent of the landing page's "Under The Hood" reveal
- **Hard Design Rules**: `min-h-screen`, `bg-void` token, landing typography scale (`clamp(3rem,7vw,6rem) font-black tracking-tighter`), framer-motion EASE_OUT_QUART with `prefers-reduced-motion` short-circuit, FallingPattern + AuroraOrbs on every step, shadcn primitives required (RadioGroup, Slider, Input)
- **DossierReveal pattern**: deployed at 3 teaching moments (pre-Identity data-use, pre-Darkness consequence ladder, PipelineGate live progress)
- **Step-by-step aesthetic map** for all 11 wizard steps
- **QA rejection criteria**: explicit list of what gets rejected at review

## Why

User explicitly directed: "follow the great aesthetic we have in the landing page... mimic [system-terminal reveal] during onboarding... one focused piece of information at a time. Full screen." First implementor of PR-B violated all 6 hard rules. This brief makes the rules grep-able and gives reviewers a single authority to point at.

## Test plan

- [x] Cross-checks against `portal/src/components/landing/{system-terminal,hero-section,falling-pattern,aurora-orbs,glow-button}.tsx`
- [x] Token catalog matches `portal/src/app/globals.css:99-145`
- [x] shadcn references match `portal/components.json` config
- [x] Cited in PR #298 (PR-B) verification gates
- [ ] Reviewer sanity check (reviewer)

## Refs

- Used as authority by PR #298 (PR-B step components)
- Will be cited by upcoming PR-C E2E + Vercel deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)