### PR TITLE
fix(portal): re-land emoji removal — landing page lucide icons

### DIFF
--- a/portal/src/components/landing/stakes-section.tsx
+++ b/portal/src/components/landing/stakes-section.tsx
@@ -2,32 +2,40 @@
 
 import { motion } from "framer-motion"
 import Image from "next/image"
+import { Brain, Phone, Swords, TrendingDown, type LucideIcon } from "lucide-react"
 import { GlassCard } from "@/components/glass/glass-card"
 import { ChapterTimeline } from "./chapter-timeline"
 
-const STAKES = [
+type Stake = {
+  title: string
+  description: string
+  icon: LucideIcon
+  mood: { src: string; alt: string }
+}
+
+const STAKES: Stake[] = [
   {
     title: "Ignore her and watch the score drop.",
     description: "Score decay is real. Every unanswered message, every broken plan — it adds up. Don't leave her waiting.",
-    icon: "📉",
+    icon: TrendingDown,
     mood: { src: "/images/nikita-moods/angry.png", alt: "Nikita — angry" },
   },
   {
     title: "Three strikes. She's gone.",
     description: "Boss encounters at every chapter. Fail three times and she walks out the door. No second chances.",
-    icon: "⚔️",
+    icon: Swords,
     mood: { src: "/images/nikita-moods/cold.png", alt: "Nikita — cold" },
   },
   {
     title: "She has a perfect memory.",
     description: "She remembers the fight you had two weeks ago. The thing you said you'd do. Your friend's name. Everything.",
-    icon: "🧠",
+    icon: Brain,
     mood: { src: "/images/nikita-moods/stressed.png", alt: "Nikita — stressed" },
   },
   {
     title: "Real voice calls when the silence breaks.",
     description: "Pick up the phone. Her voice. Her tone. Warm when she likes you, cold when she doesn't.",
-    icon: "📞",
+    icon: Phone,
     mood: { src: "/images/nikita-moods/crying.png", alt: "Nikita — crying" },
   },
 ]
@@ -63,7 +71,7 @@ export function StakesSection() {
             >
               <GlassCard className="p-6 h-full flex flex-col gap-3">
                 <div className="flex items-center justify-between">
-                  <span className="text-3xl" aria-hidden="true">{stake.icon}</span>
+                  <stake.icon className="w-8 h-8 text-primary" aria-hidden="true" strokeWidth={1.5} />
                   <div className="relative w-10 h-10 rounded-full overflow-hidden border border-white/15 shrink-0">
                     <Image
                       src={stake.mood.src}

--- a/portal/src/components/landing/system-terminal.tsx
+++ b/portal/src/components/landing/system-terminal.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useRef, useState } from "react"
+import { Check } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const SYSTEMS = [
@@ -87,7 +88,7 @@ export function SystemTerminal({ className }: SystemTerminalProps) {
               i < visibleCount ? "opacity-100" : "opacity-0"
             )}
           >
-            <span className="text-green-400 shrink-0">✓</span>
+            <Check className="h-3.5 w-3.5 text-green-400 shrink-0 mt-[2px]" aria-hidden="true" strokeWidth={2.5} />
             <span className="text-foreground">{system.name}</span>
             <span className="text-muted-foreground ml-auto text-xs">{system.detail}</span>
           </div>


### PR DESCRIPTION
## Summary

**HOTFIX** — restores commit \`bd602bf\` (Apr 14) that swapped landing-page emojis for lucide icons. The original commit landed on \`feat/portal-systems-tour\` but never merged to master, so emojis (📉 ⚔️ 🧠 📞 ✓) regressed onto production.

## What changed

- \`portal/src/components/landing/stakes-section.tsx\` — 4 emoji icons → \`TrendingDown\`, \`Swords\`, \`Brain\`, \`Phone\` lucide components, sized \`w-8 h-8\`, \`text-primary\`
- \`portal/src/components/landing/system-terminal.tsx\` — ✓ checkmark → \`<Check>\` lucide component, \`h-3.5 w-3.5\`, \`text-green-400\`

Portal is now 100% emoji-free.

## Verification

- \`npm run prebuild\` — pass (TS clean)
- Cherry-picked from existing reviewed commit \`bd602bf\` — no new code

🤖 Generated with [Claude Code](https://claude.com/claude-code)