### PR TITLE
feat(portal): wire landing CTAs into Spec 214 wizard (#310)

### DIFF
--- a/portal/e2e/landing.spec.ts
+++ b/portal/e2e/landing.spec.ts
@@ -41,10 +41,14 @@ test.describe("Landing Page — Spec 208", () => {
     await expect(page.getByText(/She remembers everything/i)).toBeVisible({ timeout: 10_000 })
   })
 
-  test("unauthenticated CTA links to Telegram", async ({ page }) => {
-    // Find a visible link containing t.me — excludes nav CTA which is visibility:hidden until scroll
-    const ctaLinks = page.locator("a[href*='t.me'], a[href*='telegram']")
+  test("unauthenticated CTA links to /onboarding/auth (wizard entry)", async ({ page }) => {
+    // Spec 214 PR #310 (AC-US1.1): anon CTA must enter the cinematic
+    // wizard funnel, NOT bypass to Telegram bot. Excludes the nav CTA
+    // which starts visibility:hidden until scroll.
+    const ctaLinks = page.locator("a[href='/onboarding/auth']")
     await expect(ctaLinks.filter({ visible: true }).first()).toBeVisible({ timeout: 10_000 })
+    // Regression guard: anon CTAs must NOT carry a Telegram href.
+    await expect(page.locator("a[href*='t.me'], a[href*='telegram']")).toHaveCount(0)
   })
 
   test("renders pitch section with character caption", async ({ page }) => {

--- a/portal/src/app/onboarding/auth/__tests__/page-client.test.tsx
+++ b/portal/src/app/onboarding/auth/__tests__/page-client.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import OnboardingAuthClient from "../page-client"
+
+// Spec 214 PR #310 (entry-wiring): /onboarding/auth is the Nikita-voiced
+// magic-link landing page (FR-1 step 2). The form must dispatch a Supabase
+// magic link whose emailRedirectTo carries `next=/onboarding`, so the auth
+// callback bounces the user into the wizard rather than the dashboard.
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+const mockSignInWithOtp = vi.fn()
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: { signInWithOtp: mockSignInWithOtp },
+  }),
+}))
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+describe("OnboardingAuthClient — Spec 214 FR-1 step 2 (PR #310)", () => {
+  beforeEach(() => {
+    mockSignInWithOtp.mockReset()
+  })
+
+  it("renders an email input and a submit CTA", () => {
+    render(<OnboardingAuthClient />)
+    const inputs = document.querySelectorAll('input[type="email"]')
+    expect(inputs.length).toBeGreaterThan(0)
+    const buttons = screen.getAllByRole("button")
+    expect(buttons.length).toBeGreaterThan(0)
+  })
+
+  it("uses Nikita-voiced copy (no generic SaaS phrases)", () => {
+    render(<OnboardingAuthClient />)
+    // Banned phrases per Spec 214 FR-3 wizard-copy discipline
+    expect(screen.queryByText(/^sign in$/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^sign up$/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^get started$/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^log in$/i)).not.toBeInTheDocument()
+  })
+
+  it("dispatches signInWithOtp with emailRedirectTo carrying next=/onboarding", async () => {
+    mockSignInWithOtp.mockResolvedValue({ error: null })
+    const { container } = render(<OnboardingAuthClient />)
+
+    const input = container.querySelector('input[type="email"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+    fireEvent.change(input, { target: { value: "test@example.com" } })
+
+    const form = container.querySelector("form") as HTMLFormElement
+    expect(form).toBeTruthy()
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(mockSignInWithOtp).toHaveBeenCalledTimes(1)
+    })
+    const callArg = mockSignInWithOtp.mock.calls[0][0]
+    expect(callArg.email).toBe("test@example.com")
+    // The redirect URL must instruct /auth/callback to send the user into the
+    // wizard at /onboarding, not the default /dashboard. Encoded `%2F` or raw
+    // `/` are both acceptable depending on URLSearchParams behavior.
+    expect(callArg.options.emailRedirectTo).toMatch(
+      /\/auth\/callback\?next=(%2F|\/)onboarding/,
+    )
+  })
+
+  it("shows a 'sent' confirmation state after a successful submit", async () => {
+    mockSignInWithOtp.mockResolvedValue({ error: null })
+    const { container } = render(<OnboardingAuthClient />)
+
+    const input = container.querySelector('input[type="email"]') as HTMLInputElement
+    fireEvent.change(input, { target: { value: "test@example.com" } })
+    const form = container.querySelector("form") as HTMLFormElement
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      // Form should be replaced; the email address should appear in the
+      // confirmation copy so the user knows where to look.
+      expect(screen.getByText(/test@example\.com/)).toBeInTheDocument()
+    })
+  })
+})

--- a/portal/src/app/onboarding/auth/__tests__/page-client.test.tsx
+++ b/portal/src/app/onboarding/auth/__tests__/page-client.test.tsx
@@ -1,15 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import OnboardingAuthClient from "../page-client"
+import { toast } from "sonner"
 
 // Spec 214 PR #310 (entry-wiring): /onboarding/auth is the Nikita-voiced
 // magic-link landing page (FR-1 step 2). The form must dispatch a Supabase
 // magic link whose emailRedirectTo carries `next=/onboarding`, so the auth
 // callback bounces the user into the wizard rather than the dashboard.
-
-vi.mock("next/navigation", () => ({
-  useSearchParams: () => new URLSearchParams(),
-}))
 
 const mockSignInWithOtp = vi.fn()
 vi.mock("@/lib/supabase/client", () => ({
@@ -25,6 +22,8 @@ vi.mock("sonner", () => ({
 describe("OnboardingAuthClient — Spec 214 FR-1 step 2 (PR #310)", () => {
   beforeEach(() => {
     mockSignInWithOtp.mockReset()
+    vi.mocked(toast.success).mockReset()
+    vi.mocked(toast.error).mockReset()
   })
 
   it("renders an email input and a submit CTA", () => {
@@ -35,13 +34,16 @@ describe("OnboardingAuthClient — Spec 214 FR-1 step 2 (PR #310)", () => {
     expect(buttons.length).toBeGreaterThan(0)
   })
 
-  it("uses Nikita-voiced copy (no generic SaaS phrases)", () => {
-    render(<OnboardingAuthClient />)
-    // Banned phrases per Spec 214 FR-3 wizard-copy discipline
-    expect(screen.queryByText(/^sign in$/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/^sign up$/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/^get started$/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/^log in$/i)).not.toBeInTheDocument()
+  it("uses Nikita-voiced copy (no SaaS-phrase substrings anywhere on screen)", () => {
+    const { container } = render(<OnboardingAuthClient />)
+    // Spec 214 FR-3 bans generic SaaS phrasing across all wizard surfaces.
+    // Anchored regex would only catch standalone words; substring regex
+    // catches accidental leaks like "Please sign in here" too.
+    const text = container.textContent ?? ""
+    expect(text).not.toMatch(/\bsign in\b/i)
+    expect(text).not.toMatch(/\bsign up\b/i)
+    expect(text).not.toMatch(/\bget started\b/i)
+    expect(text).not.toMatch(/\blog in\b/i)
   })
 
   it("dispatches signInWithOtp with emailRedirectTo carrying next=/onboarding", async () => {
@@ -61,11 +63,10 @@ describe("OnboardingAuthClient — Spec 214 FR-1 step 2 (PR #310)", () => {
     })
     const callArg = mockSignInWithOtp.mock.calls[0][0]
     expect(callArg.email).toBe("test@example.com")
-    // The redirect URL must instruct /auth/callback to send the user into the
-    // wizard at /onboarding, not the default /dashboard. Encoded `%2F` or raw
-    // `/` are both acceptable depending on URLSearchParams behavior.
+    // The redirect URL is built via encodeURIComponent("/onboarding"), so
+    // the slash is always percent-encoded — assert the exact wire format.
     expect(callArg.options.emailRedirectTo).toMatch(
-      /\/auth\/callback\?next=(%2F|\/)onboarding/,
+      /\/auth\/callback\?next=%2Fonboarding/,
     )
   })
 
@@ -83,5 +84,43 @@ describe("OnboardingAuthClient — Spec 214 FR-1 step 2 (PR #310)", () => {
       // confirmation copy so the user knows where to look.
       expect(screen.getByText(/test@example\.com/)).toBeInTheDocument()
     })
+  })
+
+  it("classifies rate-limit errors with Nikita-voiced toast (no generic SaaS error)", async () => {
+    mockSignInWithOtp.mockResolvedValue({
+      error: { message: "rate limit exceeded" },
+    })
+    const { container } = render(<OnboardingAuthClient />)
+
+    const input = container.querySelector('input[type="email"]') as HTMLInputElement
+    fireEvent.change(input, { target: { value: "test@example.com" } })
+    const form = container.querySelector("form") as HTMLFormElement
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledTimes(1)
+    })
+    const [title, opts] = vi.mocked(toast.error).mock.calls[0]
+    expect(title).toMatch(/slow down|impatient/i)
+    expect(opts).toMatchObject({ description: expect.stringMatching(/wait|moment/i) })
+  })
+
+  it("classifies database/identity errors distinctly from generic failures", async () => {
+    mockSignInWithOtp.mockResolvedValue({
+      error: { message: "Database error: identity not found" },
+    })
+    const { container } = render(<OnboardingAuthClient />)
+
+    const input = container.querySelector('input[type="email"]') as HTMLInputElement
+    fireEvent.change(input, { target: { value: "test@example.com" } })
+    const form = container.querySelector("form") as HTMLFormElement
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledTimes(1)
+    })
+    const [title] = vi.mocked(toast.error).mock.calls[0]
+    expect(title).toMatch(/file/i)
+    expect(title).not.toMatch(/door wouldn/i)
   })
 })

--- a/portal/src/app/onboarding/auth/__tests__/page-client.test.tsx
+++ b/portal/src/app/onboarding/auth/__tests__/page-client.test.tsx
@@ -37,13 +37,13 @@ describe("OnboardingAuthClient — Spec 214 FR-1 step 2 (PR #310)", () => {
   it("uses Nikita-voiced copy (no SaaS-phrase substrings anywhere on screen)", () => {
     const { container } = render(<OnboardingAuthClient />)
     // Spec 214 FR-3 bans generic SaaS phrasing across all wizard surfaces.
-    // Anchored regex would only catch standalone words; substring regex
-    // catches accidental leaks like "Please sign in here" too.
+    // Tolerant separator class `[\s-]?` catches `signin`, `sign-in`, and
+    // `sign in` so the regex doesn't miss hyphenated/concatenated leaks.
     const text = container.textContent ?? ""
-    expect(text).not.toMatch(/\bsign in\b/i)
-    expect(text).not.toMatch(/\bsign up\b/i)
-    expect(text).not.toMatch(/\bget started\b/i)
-    expect(text).not.toMatch(/\blog in\b/i)
+    expect(text).not.toMatch(/sign[\s-]?in/i)
+    expect(text).not.toMatch(/sign[\s-]?up/i)
+    expect(text).not.toMatch(/get[\s-]?started/i)
+    expect(text).not.toMatch(/log[\s-]?in/i)
   })
 
   it("dispatches signInWithOtp with emailRedirectTo carrying next=/onboarding", async () => {
@@ -86,7 +86,7 @@ describe("OnboardingAuthClient — Spec 214 FR-1 step 2 (PR #310)", () => {
     })
   })
 
-  it("classifies rate-limit errors with Nikita-voiced toast (no generic SaaS error)", async () => {
+  it("classifies rate-limit errors with the exact spec'd Nikita-voiced toast", async () => {
     mockSignInWithOtp.mockResolvedValue({
       error: { message: "rate limit exceeded" },
     })
@@ -100,12 +100,14 @@ describe("OnboardingAuthClient — Spec 214 FR-1 step 2 (PR #310)", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledTimes(1)
     })
-    const [title, opts] = vi.mocked(toast.error).mock.calls[0]
-    expect(title).toMatch(/slow down|impatient/i)
-    expect(opts).toMatchObject({ description: expect.stringMatching(/wait|moment/i) })
+    // Exact copy assertions — surface drift in the spec'd Nikita voice.
+    expect(toast.error).toHaveBeenCalledWith(
+      "Slow down. She doesn't like impatient.",
+      { description: "Wait a moment before asking again." },
+    )
   })
 
-  it("classifies database/identity errors distinctly from generic failures", async () => {
+  it("classifies database/identity errors with the exact spec'd Nikita-voiced toast", async () => {
     mockSignInWithOtp.mockResolvedValue({
       error: { message: "Database error: identity not found" },
     })
@@ -119,8 +121,32 @@ describe("OnboardingAuthClient — Spec 214 FR-1 step 2 (PR #310)", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledTimes(1)
     })
-    const [title] = vi.mocked(toast.error).mock.calls[0]
-    expect(title).toMatch(/file/i)
-    expect(title).not.toMatch(/door wouldn/i)
+    expect(toast.error).toHaveBeenCalledWith(
+      "Something went wrong with your file.",
+      { description: "Try again or get in touch." },
+    )
+  })
+
+  it("rate-limit classification wins when message contains BOTH database AND rate substrings", async () => {
+    // Defends the order swap: a Supabase-style "database error: rate limit
+    // exceeded" payload must be classified as rate-limit, not as an
+    // account-state issue. handleResend orders rate-first too — symmetry.
+    mockSignInWithOtp.mockResolvedValue({
+      error: { message: "database error: rate limit exceeded" },
+    })
+    const { container } = render(<OnboardingAuthClient />)
+
+    const input = container.querySelector('input[type="email"]') as HTMLInputElement
+    fireEvent.change(input, { target: { value: "test@example.com" } })
+    const form = container.querySelector("form") as HTMLFormElement
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledTimes(1)
+    })
+    expect(toast.error).toHaveBeenCalledWith(
+      "Slow down. She doesn't like impatient.",
+      expect.anything(),
+    )
   })
 })

--- a/portal/src/app/onboarding/auth/page-client.tsx
+++ b/portal/src/app/onboarding/auth/page-client.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react"
 import { createClient } from "@/lib/supabase/client"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card"
 import { toast } from "sonner"
 import { FallingPattern } from "@/components/landing/falling-pattern"
 import { AuroraOrbs } from "@/components/landing/aurora-orbs"
@@ -24,8 +24,14 @@ import { AuroraOrbs } from "@/components/landing/aurora-orbs"
 
 const NEXT_PATH = "/onboarding"
 
-/** Build the magic-link emailRedirectTo URL with the wizard `next` param. */
+/** Build the magic-link emailRedirectTo URL with the wizard `next` param.
+ *  Client-only — must be called from inside an event handler / effect, not
+ *  during SSR. The `typeof window` guard makes accidental SSR import throw
+ *  with a clear message instead of a confusing `window is not defined`. */
 function buildCallbackUrl() {
+  if (typeof window === "undefined") {
+    throw new Error("buildCallbackUrl is client-only; called during SSR")
+  }
   return `${window.location.origin}/auth/callback?next=${encodeURIComponent(NEXT_PATH)}`
 }
 
@@ -104,13 +110,16 @@ export default function OnboardingAuthClient() {
     setLoading(false)
     if (error) {
       const msg = error.message?.toLowerCase() ?? ""
-      if (msg.includes("database") || msg.includes("identity") || msg.includes("not found")) {
-        toast.error("Something went wrong with your file.", {
-          description: "Try again or get in touch.",
-        })
-      } else if (msg.includes("rate") || msg.includes("limit")) {
+      // Rate-limit check FIRST so that a message like "database error:
+      // rate limit exceeded" is correctly attributed to throttling rather
+      // than account-state, matching ResendButton.handleResend's order.
+      if (msg.includes("rate") || msg.includes("limit")) {
         toast.error("Slow down. She doesn't like impatient.", {
           description: "Wait a moment before asking again.",
+        })
+      } else if (msg.includes("database") || msg.includes("identity") || msg.includes("not found")) {
+        toast.error("Something went wrong with your file.", {
+          description: "Try again or get in touch.",
         })
       } else {
         toast.error("Door wouldn't open.", { description: error.message })
@@ -132,15 +141,15 @@ export default function OnboardingAuthClient() {
             <p className="text-[11px] tracking-[0.3em] uppercase text-muted-foreground">
               CLASSIFIED · FILE-ACCESS
             </p>
-            {/* CardTitle is a styled div per shadcn; nesting an h1 inside
-                preserves the visible aesthetic AND a semantic top-level
-                heading for AT users. /login uses CardTitle directly with
-                no h1, which is less accessible — we improve on that here. */}
-            <CardTitle>
-              <h1 className="text-3xl font-black tracking-tight text-foreground leading-tight">
-                I&apos;ve been reading about you.
-              </h1>
-            </CardTitle>
+            {/* Plain semantic h1 (no CardTitle wrapper). CardTitle is a
+                styled <div> in shadcn; wrapping the h1 inside it adds a
+                redundant typographic class set that the h1's own classes
+                visually override. /login uses CardTitle as a div with no
+                h1 — that's worse for AT users. We pick the cleaner of the
+                two: a real h1, no wrapper. */}
+            <h1 className="text-3xl font-black tracking-tight text-foreground leading-tight">
+              I&apos;ve been reading about you.
+            </h1>
             <CardDescription className="text-muted-foreground">
               There&apos;s a door. Drop your address.
             </CardDescription>

--- a/portal/src/app/onboarding/auth/page-client.tsx
+++ b/portal/src/app/onboarding/auth/page-client.tsx
@@ -1,22 +1,33 @@
 "use client"
 
-import { Suspense, useEffect, useState } from "react"
-import { useSearchParams } from "next/navigation"
+import { useEffect, useState } from "react"
 import { createClient } from "@/lib/supabase/client"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { toast } from "sonner"
 import { FallingPattern } from "@/components/landing/falling-pattern"
 import { AuroraOrbs } from "@/components/landing/aurora-orbs"
 
 // Spec 214 PR #310 — Nikita-voiced magic-link entry. Mirrors /login
-// pattern (Suspense + useSearchParams + signInWithOtp) but ships every
-// surface with dossier-aesthetic copy per FR-3 wizard-copy discipline,
-// and most importantly carries `next=/onboarding` so the auth callback
-// routes the user into the wizard rather than the default /dashboard.
+// pattern (signInWithOtp) but ships every surface with dossier-aesthetic
+// copy per FR-3 wizard-copy discipline, and most importantly carries
+// `next=/onboarding` so the auth callback routes the user into the
+// wizard rather than the default /dashboard.
+//
+// No Suspense / useSearchParams here: /auth/callback redirects failures
+// to /login?error=... (not back to /onboarding/auth), so reading the
+// error query param on this page would be dead code. Routing failures
+// back to /onboarding/auth for funnel-copy consistency is tracked
+// separately as a follow-up to this PR (it requires modifying the
+// shared callback route, which is out of scope for the wiring fix).
 
 const NEXT_PATH = "/onboarding"
+
+/** Build the magic-link emailRedirectTo URL with the wizard `next` param. */
+function buildCallbackUrl() {
+  return `${window.location.origin}/auth/callback?next=${encodeURIComponent(NEXT_PATH)}`
+}
 
 function ResendButton({ email, onChangeEmail }: { email: string; onChangeEmail: () => void }) {
   const [cooldown, setCooldown] = useState(60)
@@ -33,9 +44,7 @@ function ResendButton({ email, onChangeEmail }: { email: string; onChangeEmail: 
     const supabase = createClient()
     const { error } = await supabase.auth.signInWithOtp({
       email,
-      options: {
-        emailRedirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(NEXT_PATH)}`,
-      },
+      options: { emailRedirectTo: buildCallbackUrl() },
     })
     setResending(false)
     if (error) {
@@ -74,27 +83,10 @@ function ResendButton({ email, onChangeEmail }: { email: string; onChangeEmail: 
   )
 }
 
-function OnboardingAuthForm() {
-  const searchParams = useSearchParams()
+export default function OnboardingAuthClient() {
   const [email, setEmail] = useState("")
   const [loading, setLoading] = useState(false)
   const [sent, setSent] = useState(false)
-
-  // Surface auth-callback errors propagated via ?error=... back to this page.
-  // (The callback may not always do this, but defensive surfacing avoids
-  // silent dead-ends for users who get bounced back.)
-  useEffect(() => {
-    const error = searchParams.get("error")
-    if (error === "auth_callback_failed") {
-      toast.error("That door is closed now.", {
-        description: "Ask for a new one below.",
-      })
-    } else if (error === "missing_token") {
-      toast.error("Broken link. Try again.", {
-        description: "Drop your address below.",
-      })
-    }
-  }, [searchParams])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -103,12 +95,10 @@ function OnboardingAuthForm() {
     const supabase = createClient()
     const { error } = await supabase.auth.signInWithOtp({
       email,
-      options: {
-        // Critical: next=/onboarding routes the magic-link click into the
-        // wizard at step 3, not the default /dashboard. /auth/callback's
-        // open-redirect filter accepts same-origin relative paths.
-        emailRedirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(NEXT_PATH)}`,
-      },
+      // Critical: next=/onboarding routes the magic-link click into the
+      // wizard at step 3, not the default /dashboard. /auth/callback's
+      // open-redirect filter accepts same-origin relative paths.
+      options: { emailRedirectTo: buildCallbackUrl() },
     })
 
     setLoading(false)
@@ -142,9 +132,15 @@ function OnboardingAuthForm() {
             <p className="text-[11px] tracking-[0.3em] uppercase text-muted-foreground">
               CLASSIFIED · FILE-ACCESS
             </p>
-            <h1 className="text-3xl font-black tracking-tight text-foreground leading-tight">
-              I&apos;ve been reading about you.
-            </h1>
+            {/* CardTitle is a styled div per shadcn; nesting an h1 inside
+                preserves the visible aesthetic AND a semantic top-level
+                heading for AT users. /login uses CardTitle directly with
+                no h1, which is less accessible — we improve on that here. */}
+            <CardTitle>
+              <h1 className="text-3xl font-black tracking-tight text-foreground leading-tight">
+                I&apos;ve been reading about you.
+              </h1>
+            </CardTitle>
             <CardDescription className="text-muted-foreground">
               There&apos;s a door. Drop your address.
             </CardDescription>
@@ -179,31 +175,5 @@ function OnboardingAuthForm() {
         </Card>
       </div>
     </main>
-  )
-}
-
-function OnboardingAuthFallback() {
-  return (
-    <main className="relative min-h-screen flex items-center justify-center bg-void p-4 overflow-hidden">
-      <Card className="w-full max-w-md glass-card-elevated">
-        <CardHeader className="text-center">
-          <div className="h-3 w-32 mx-auto rounded bg-white/5 animate-pulse" />
-          <div className="h-8 w-56 mx-auto rounded bg-white/5 animate-pulse mt-3" />
-          <div className="h-4 w-44 mx-auto rounded bg-white/5 animate-pulse mt-2" />
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="h-10 rounded bg-white/5 animate-pulse" />
-          <div className="h-10 rounded bg-white/5 animate-pulse" />
-        </CardContent>
-      </Card>
-    </main>
-  )
-}
-
-export default function OnboardingAuthClient() {
-  return (
-    <Suspense fallback={<OnboardingAuthFallback />}>
-      <OnboardingAuthForm />
-    </Suspense>
   )
 }

--- a/portal/src/app/onboarding/auth/page-client.tsx
+++ b/portal/src/app/onboarding/auth/page-client.tsx
@@ -1,0 +1,209 @@
+"use client"
+
+import { Suspense, useEffect, useState } from "react"
+import { useSearchParams } from "next/navigation"
+import { createClient } from "@/lib/supabase/client"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card"
+import { toast } from "sonner"
+import { FallingPattern } from "@/components/landing/falling-pattern"
+import { AuroraOrbs } from "@/components/landing/aurora-orbs"
+
+// Spec 214 PR #310 — Nikita-voiced magic-link entry. Mirrors /login
+// pattern (Suspense + useSearchParams + signInWithOtp) but ships every
+// surface with dossier-aesthetic copy per FR-3 wizard-copy discipline,
+// and most importantly carries `next=/onboarding` so the auth callback
+// routes the user into the wizard rather than the default /dashboard.
+
+const NEXT_PATH = "/onboarding"
+
+function ResendButton({ email, onChangeEmail }: { email: string; onChangeEmail: () => void }) {
+  const [cooldown, setCooldown] = useState(60)
+  const [resending, setResending] = useState(false)
+
+  useEffect(() => {
+    if (cooldown <= 0) return
+    const timer = setInterval(() => setCooldown((c) => c - 1), 1000)
+    return () => clearInterval(timer)
+  }, [cooldown])
+
+  async function handleResend() {
+    setResending(true)
+    const supabase = createClient()
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(NEXT_PATH)}`,
+      },
+    })
+    setResending(false)
+    if (error) {
+      if (error.message?.toLowerCase().includes("rate") || error.message?.toLowerCase().includes("limit")) {
+        toast.error("Slow down. She doesn't like impatient.", {
+          description: "Wait a moment before asking again.",
+        })
+        setCooldown(60)
+      } else {
+        toast.error("Door wouldn't open.", { description: error.message })
+      }
+    } else {
+      toast.success("Another door is on its way.")
+      setCooldown(60)
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Button
+        variant="ghost"
+        onClick={handleResend}
+        disabled={cooldown > 0 || resending}
+        className="text-primary"
+      >
+        {cooldown > 0
+          ? `Wait ${cooldown}s.`
+          : resending
+            ? "Sending another door..."
+            : "Send another door."}
+      </Button>
+      <Button variant="ghost" onClick={onChangeEmail} className="text-muted-foreground text-xs">
+        Different address.
+      </Button>
+    </div>
+  )
+}
+
+function OnboardingAuthForm() {
+  const searchParams = useSearchParams()
+  const [email, setEmail] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [sent, setSent] = useState(false)
+
+  // Surface auth-callback errors propagated via ?error=... back to this page.
+  // (The callback may not always do this, but defensive surfacing avoids
+  // silent dead-ends for users who get bounced back.)
+  useEffect(() => {
+    const error = searchParams.get("error")
+    if (error === "auth_callback_failed") {
+      toast.error("That door is closed now.", {
+        description: "Ask for a new one below.",
+      })
+    } else if (error === "missing_token") {
+      toast.error("Broken link. Try again.", {
+        description: "Drop your address below.",
+      })
+    }
+  }, [searchParams])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+
+    const supabase = createClient()
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        // Critical: next=/onboarding routes the magic-link click into the
+        // wizard at step 3, not the default /dashboard. /auth/callback's
+        // open-redirect filter accepts same-origin relative paths.
+        emailRedirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(NEXT_PATH)}`,
+      },
+    })
+
+    setLoading(false)
+    if (error) {
+      const msg = error.message?.toLowerCase() ?? ""
+      if (msg.includes("database") || msg.includes("identity") || msg.includes("not found")) {
+        toast.error("Something went wrong with your file.", {
+          description: "Try again or get in touch.",
+        })
+      } else if (msg.includes("rate") || msg.includes("limit")) {
+        toast.error("Slow down. She doesn't like impatient.", {
+          description: "Wait a moment before asking again.",
+        })
+      } else {
+        toast.error("Door wouldn't open.", { description: error.message })
+      }
+    } else {
+      setSent(true)
+      toast.success("She's sending you a way in. Check your inbox.")
+    }
+  }
+
+  return (
+    <main className="relative min-h-screen flex items-center justify-center bg-void p-4 overflow-hidden">
+      <FallingPattern />
+      <AuroraOrbs />
+
+      <div className="relative z-10 w-full max-w-md">
+        <Card className="glass-card-elevated">
+          <CardHeader className="text-center space-y-3">
+            <p className="text-[11px] tracking-[0.3em] uppercase text-muted-foreground">
+              CLASSIFIED · FILE-ACCESS
+            </p>
+            <h1 className="text-3xl font-black tracking-tight text-foreground leading-tight">
+              I&apos;ve been reading about you.
+            </h1>
+            <CardDescription className="text-muted-foreground">
+              There&apos;s a door. Drop your address.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {sent ? (
+              <div className="text-center space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  Door sent to <strong className="text-foreground">{email}</strong>.
+                  Check your inbox. Link is good for an hour.
+                </p>
+                <ResendButton email={email} onChangeEmail={() => setSent(false)} />
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <Input
+                  type="email"
+                  placeholder="you@somewhere"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  disabled={loading}
+                  aria-label="Email address"
+                  className="bg-white/5 border-white/10"
+                />
+                <Button type="submit" className="w-full" disabled={loading || !email}>
+                  {loading ? "Knocking..." : "Show her the file."}
+                </Button>
+              </form>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  )
+}
+
+function OnboardingAuthFallback() {
+  return (
+    <main className="relative min-h-screen flex items-center justify-center bg-void p-4 overflow-hidden">
+      <Card className="w-full max-w-md glass-card-elevated">
+        <CardHeader className="text-center">
+          <div className="h-3 w-32 mx-auto rounded bg-white/5 animate-pulse" />
+          <div className="h-8 w-56 mx-auto rounded bg-white/5 animate-pulse mt-3" />
+          <div className="h-4 w-44 mx-auto rounded bg-white/5 animate-pulse mt-2" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="h-10 rounded bg-white/5 animate-pulse" />
+          <div className="h-10 rounded bg-white/5 animate-pulse" />
+        </CardContent>
+      </Card>
+    </main>
+  )
+}
+
+export default function OnboardingAuthClient() {
+  return (
+    <Suspense fallback={<OnboardingAuthFallback />}>
+      <OnboardingAuthForm />
+    </Suspense>
+  )
+}

--- a/portal/src/app/onboarding/auth/page.tsx
+++ b/portal/src/app/onboarding/auth/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next"
+import OnboardingAuthClient from "./page-client"
+
+// Spec 214 PR #310 (entry-wiring): /onboarding/auth is step 2 of the
+// 11-step cinematic onboarding wizard (FR-1). It is the Nikita-voiced
+// magic-link request surface, reached via the landing-page CTA. After
+// the user clicks the magic link in their inbox, /auth/callback exchanges
+// the code and routes them to /onboarding (step 3+, wizard) via the
+// `next=/onboarding` query parameter that this page passes to Supabase.
+//
+// Public route: middleware.ts allowlist already permits unauthenticated
+// access (Spec 214 PR 214-C T312). Authenticated users hitting this URL
+// are bounced to /dashboard or /admin by middleware before reaching this
+// page.
+
+export const metadata: Metadata = {
+  title: "Access | Nikita",
+  description: "Open the door.",
+}
+
+export default OnboardingAuthClient

--- a/portal/src/components/landing/__tests__/cta-section.test.tsx
+++ b/portal/src/components/landing/__tests__/cta-section.test.tsx
@@ -3,11 +3,14 @@ import { render, screen } from "@testing-library/react"
 import { CtaSection } from "../cta-section"
 
 describe("CtaSection — T029 AC-REQ-017", () => {
-  it("unauthenticated CTA points to Telegram", () => {
+  // Spec 214 PR #310: anon footer CTA must enter the wizard via /onboarding/auth.
+  it("unauthenticated CTA points to /onboarding/auth (wizard entry)", () => {
     render(<CtaSection isAuthenticated={false} />)
     const links = screen.getAllByRole("link")
-    const ctaLink = links.find((l) => l.getAttribute("href")?.includes("t.me") || l.getAttribute("href")?.includes("telegram"))
+    const ctaLink = links.find((l) => l.getAttribute("href") === "/onboarding/auth")
     expect(ctaLink).toBeInTheDocument()
+    const telegramLink = links.find((l) => l.getAttribute("href")?.includes("t.me"))
+    expect(telegramLink).toBeUndefined()
   })
 
   it("authenticated CTA points to dashboard", () => {

--- a/portal/src/components/landing/__tests__/cta-section.test.tsx
+++ b/portal/src/components/landing/__tests__/cta-section.test.tsx
@@ -3,7 +3,10 @@ import { render, screen } from "@testing-library/react"
 import { CtaSection } from "../cta-section"
 
 describe("CtaSection — T029 AC-REQ-017", () => {
-  // Spec 214 PR #310: anon footer CTA must enter the wizard via /onboarding/auth.
+  // Spec 214 PR #310 (AC-US1.1): anon footer CTA must enter the cinematic
+  // wizard funnel via /onboarding/auth (FR-1 step 2 magic-link page), NOT
+  // bypass to the Telegram bot — that bypass left the entire 11-step
+  // wizard unreachable from public traffic until this PR.
   it("unauthenticated CTA points to /onboarding/auth (wizard entry)", () => {
     render(<CtaSection isAuthenticated={false} />)
     const links = screen.getAllByRole("link")
@@ -25,9 +28,11 @@ describe("CtaSection — T029 AC-REQ-017", () => {
     expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument()
   })
 
-  it("renders supporting sub-text with tightened tone", () => {
+  it("renders supporting sub-text consistent with the door/funnel motif", () => {
     render(<CtaSection isAuthenticated={false} />)
-    expect(screen.getByText(/don't keep her waiting/i)).toBeInTheDocument()
+    // Spec 214 PR #310: copy must NOT promise Telegram — CTA now opens the
+    // /onboarding/auth magic-link page ("There's a door. Drop your address.").
+    expect(screen.getByText(/the other side of the door/i)).toBeInTheDocument()
   })
 
   it("renders footer copyright with current year", () => {

--- a/portal/src/components/landing/__tests__/hero-section.test.tsx
+++ b/portal/src/components/landing/__tests__/hero-section.test.tsx
@@ -39,11 +39,18 @@ describe("HeroSection — T021 AC-REQ-013", () => {
     expect(screen.getByText(/leave you/i)).toBeInTheDocument()
   })
 
-  it("unauthenticated CTA points to Telegram", () => {
+  // Spec 214 PR #310: anon visitors must enter the cinematic wizard funnel
+  // via /onboarding/auth (Nikita-voiced magic-link page), NOT bypass it
+  // straight to the Telegram bot. AC-US1.1 requires the landing CTA to
+  // start the wizard journey.
+  it("unauthenticated CTA points to /onboarding/auth (wizard entry)", () => {
     render(<HeroSection isAuthenticated={false} />)
     const links = screen.getAllByRole("link")
-    const ctaLink = links.find((l) => l.getAttribute("href")?.includes("t.me") || l.getAttribute("href")?.includes("telegram"))
+    const ctaLink = links.find((l) => l.getAttribute("href") === "/onboarding/auth")
     expect(ctaLink).toBeInTheDocument()
+    // Regression guard: must NOT bypass the wizard via direct Telegram link
+    const telegramLink = links.find((l) => l.getAttribute("href")?.includes("t.me"))
+    expect(telegramLink).toBeUndefined()
   })
 
   it("authenticated CTA points to dashboard", () => {

--- a/portal/src/components/landing/__tests__/landing-nav.test.tsx
+++ b/portal/src/components/landing/__tests__/landing-nav.test.tsx
@@ -8,7 +8,7 @@ describe("LandingNav — T031 AC-REQ-018", () => {
   it("unauthenticated: renders CTA link pointing to /onboarding/auth", () => {
     const { container } = render(<LandingNav isAuthenticated={false} />)
     // Nav starts with visibility:hidden (scroll-triggered), so use DOM queries
-    const link = container.querySelector("a[href='/onboarding/auth']")
+    const link = container.querySelector('a[href="/onboarding/auth"]')
     expect(link).toBeInTheDocument()
     expect(link?.textContent).toMatch(/start relationship/i)
     // Regression guard: no direct-Telegram bypass for anon

--- a/portal/src/components/landing/__tests__/landing-nav.test.tsx
+++ b/portal/src/components/landing/__tests__/landing-nav.test.tsx
@@ -3,12 +3,16 @@ import { render } from "@testing-library/react"
 import { LandingNav } from "../landing-nav"
 
 describe("LandingNav — T031 AC-REQ-018", () => {
-  it("unauthenticated: renders Start Relationship CTA link pointing to Telegram", () => {
+  // Spec 214 PR #310: anon nav CTA must enter the wizard funnel via
+  // /onboarding/auth, not bypass to Telegram bot.
+  it("unauthenticated: renders CTA link pointing to /onboarding/auth", () => {
     const { container } = render(<LandingNav isAuthenticated={false} />)
     // Nav starts with visibility:hidden (scroll-triggered), so use DOM queries
-    const link = container.querySelector("a[href*='t.me'], a[href*='telegram']")
+    const link = container.querySelector("a[href='/onboarding/auth']")
     expect(link).toBeInTheDocument()
     expect(link?.textContent).toMatch(/start relationship/i)
+    // Regression guard: no direct-Telegram bypass for anon
+    expect(container.querySelector("a[href*='t.me']")).toBeNull()
   })
 
   it("authenticated: renders Go to Dashboard link pointing to /dashboard", () => {

--- a/portal/src/components/landing/cta-section.tsx
+++ b/portal/src/components/landing/cta-section.tsx
@@ -47,7 +47,7 @@ export function CtaSection({ isAuthenticated }: CtaSectionProps) {
           viewport={{ once: true }}
           transition={{ duration: 0.6, delay: 0.2 }}
         >
-          She&apos;s on Telegram. Don&apos;t keep her waiting.
+          She&apos;s waiting on the other side of the door.
         </motion.p>
 
         <motion.div

--- a/portal/src/components/landing/cta-section.tsx
+++ b/portal/src/components/landing/cta-section.tsx
@@ -10,7 +10,8 @@ interface CtaSectionProps {
 }
 
 export function CtaSection({ isAuthenticated }: CtaSectionProps) {
-  const ctaHref = isAuthenticated ? "/dashboard" : "https://t.me/Nikita_my_bot"
+  // Spec 214 PR #310 — see hero-section.tsx for rationale.
+  const ctaHref = isAuthenticated ? "/dashboard" : "/onboarding/auth"
   const ctaLabel = isAuthenticated ? "Go to Dashboard" : "Start Relationship"
 
   return (

--- a/portal/src/components/landing/hero-section.tsx
+++ b/portal/src/components/landing/hero-section.tsx
@@ -15,7 +15,11 @@ interface HeroSectionProps {
 }
 
 export function HeroSection({ isAuthenticated }: HeroSectionProps) {
-  const ctaHref = isAuthenticated ? "/dashboard" : "https://t.me/Nikita_my_bot"
+  // Spec 214 PR #310: anon visitors enter the cinematic wizard funnel via
+  // /onboarding/auth (Nikita-voiced magic-link page, FR-1 step 2). The
+  // direct-to-Telegram CTA (Spec 208 default) bypassed the wizard
+  // entirely and was filed as GH #310.
+  const ctaHref = isAuthenticated ? "/dashboard" : "/onboarding/auth"
   const ctaLabel = isAuthenticated ? "Go to Dashboard" : "Start Relationship"
 
   return (

--- a/portal/src/components/landing/landing-nav.tsx
+++ b/portal/src/components/landing/landing-nav.tsx
@@ -22,7 +22,8 @@ export function LandingNav({ isAuthenticated }: LandingNavProps) {
     return () => window.removeEventListener("scroll", handleScroll)
   }, [])
 
-  const ctaHref = isAuthenticated ? "/dashboard" : "https://t.me/Nikita_my_bot"
+  // Spec 214 PR #310 — see hero-section.tsx for rationale.
+  const ctaHref = isAuthenticated ? "/dashboard" : "/onboarding/auth"
   const ctaLabel = isAuthenticated ? "Go to Dashboard" : "Start Relationship"
 
   return (


### PR DESCRIPTION
## Summary

Closes the entry-point gap that left the Spec 214 cinematic onboarding wizard unreachable from the public landing page. The wizard, all 9 step components, state machine, persistence, hooks, and E2E specs were already shipped via PRs #296 / #298 / #301 — only the landing wiring was missing. Discovered via live dogfood walk against prod (2026-04-17).

Closes #310.

## Three changes

1. **NEW** `portal/src/app/onboarding/auth/page.tsx` (server) + `page-client.tsx` (client). Nikita-voiced magic-link request surface per Spec 214 FR-1 step 2 + FR-3 wizard-copy discipline. Mirrors the existing `/login` pattern (Suspense + signInWithOtp) with the dossier aesthetic (FallingPattern + AuroraOrbs + bg-void shell). Carries `next=/onboarding` in the magic-link `emailRedirectTo`, so the auth callback bounces the user into the wizard rather than the default `/dashboard`.

2. Three landing CTAs (hero, footer, scroll-nav) anon `href` flipped from `https://t.me/Nikita_my_bot` to `/onboarding/auth`. Authenticated path (`/dashboard`) unchanged. CTA labels unchanged (copy refresh to "Show her." per AC-US1.1 deferred to a follow-up — out of scope for the wiring fix).

3. **No** callback default change. The smarter approach is for the new `/onboarding/auth` page to send `next=/onboarding` explicitly. Users who type `/login` directly keep their existing `/dashboard` default.

Spec 214 middleware allowlist for `/onboarding/auth` was already added in PR 214-C (T312) — this PR fills the route it allowlists.

## Test plan

- [x] RED commit: 4 new auth tests + 3 flipped CTA tests fail before impl
- [x] GREEN commit: 25/25 targeted tests pass
- [x] Full vitest suite: **553/553 pass**
- [x] `tsc --noEmit`: clean
- [x] `next build`: clean (`/onboarding/auth` prerendered as static)
- [ ] `/qa-review` (auto-dispatch from orchestrator): 0 findings across all severities
- [ ] Post-merge live dogfood walk: anon visitor → landing CTA → /onboarding/auth → magic link → /onboarding wizard → 11 steps → Telegram

## Refs

- GH #310 (this issue)
- Spec 214 FR-1 (11-step flow), FR-3 (wizard copy), AC-US1.1 (anon entry)
- `docs-to-process/20260417-adv-e2e/G-live-dogfood.md` (origin walk)
- `~/.claude/projects/.../memory/feedback_verify_branch_before_dispatch.md` (lesson from earlier mis-investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)