### PR TITLE
fix(db): jsonb_set path as TEXT[] via pg.array (GH #316, CRITICAL)

### DIFF
--- a/nikita/db/repositories/user_repository.py
+++ b/nikita/db/repositories/user_repository.py
@@ -11,7 +11,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from sqlalchemy import cast, func, select, update
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, array
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -667,10 +667,21 @@ class UserRepository(BaseRepository[User]):
         Callers must pass ``key`` as a plain string — it is wrapped in braces
         for the jsonb_set path automatically.
 
-        CRITICAL implementation note: the second argument to ``cast`` MUST be
-        ``json.dumps(value)`` (a JSON-encoded string), NOT the raw Python value.
-        Passing ``cast(value, JSONB)`` is invalid for string values; always use
-        ``cast(json.dumps(value), JSONB)`` (documented gotcha from PR #279/#282).
+        CRITICAL implementation notes (two gotchas):
+
+        1. The JSONB value MUST be ``cast(json.dumps(value), JSONB)`` (a
+           JSON-encoded string cast to JSONB), NOT ``cast(value, JSONB)``.
+           Passing the raw Python value is invalid for string values
+           (documented gotcha from PR #279/#282).
+
+        2. The path MUST be a Postgres ``text[]``, constructed via
+           ``sqlalchemy.dialects.postgresql.array([key])``. Passing a plain
+           Python string like ``f"{{{key}}}"`` makes asyncpg infer the bind
+           as ``character varying`` at runtime, and Postgres rejects because
+           ``jsonb_set``'s real signature is
+           ``jsonb_set(jsonb, text[], jsonb)``. This was the GH #316 bug,
+           latent since PR #283 and surfaced by PR #315 when the wizard
+           first exercised this code path in prod.
 
         Silently no-ops if the user does not exist (UPDATE affects 0 rows).
 
@@ -686,7 +697,7 @@ class UserRepository(BaseRepository[User]):
             .values(
                 onboarding_profile=func.jsonb_set(
                     User.onboarding_profile,
-                    f"{{{key}}}",
+                    array([key]),  # emits ARRAY[...]::TEXT[] — see docstring #2
                     cast(json.dumps(value), JSONB),
                 )
             )

--- a/nikita/db/repositories/user_repository.py
+++ b/nikita/db/repositories/user_repository.py
@@ -662,10 +662,10 @@ class UserRepository(BaseRepository[User]):
     ) -> None:
         """Set a single key inside users.onboarding_profile JSONB via jsonb_set.
 
-        Uses ``jsonb_set(onboarding_profile, '{<key>}', cast(json.dumps(value), JSONB))``
+        Uses ``jsonb_set(onboarding_profile, ARRAY[<key>]::TEXT[], cast(json.dumps(value), JSONB))``
         to update exactly one key without loading the full profile into Python.
-        Callers must pass ``key`` as a plain string — it is wrapped in braces
-        for the jsonb_set path automatically.
+        Callers must pass ``key`` as a plain string; it is wrapped as a
+        single-element ``text[]`` for the jsonb_set path automatically.
 
         CRITICAL implementation notes (two gotchas):
 
@@ -697,7 +697,9 @@ class UserRepository(BaseRepository[User]):
             .values(
                 onboarding_profile=func.jsonb_set(
                     User.onboarding_profile,
-                    array([key]),  # emits ARRAY[...]::TEXT[] — see docstring #2
+                    # Emits `ARRAY[$N]::TEXT[]`. See docstring note #2 for
+                    # the asyncpg VARCHAR inference bug this guards against.
+                    array([key]),
                     cast(json.dumps(value), JSONB),
                 )
             )

--- a/tests/db/repositories/test_user_repository_update_key.py
+++ b/tests/db/repositories/test_user_repository_update_key.py
@@ -177,17 +177,32 @@ class TestUpdateOnboardingProfileKey:
         assert captured_stmt is not None
         compiled = captured_stmt.compile(dialect=postgresql.dialect())
         sql_upper = str(compiled).upper()
-        # Must NOT contain a VARCHAR-typed bind for the path. The old buggy
-        # code produced `jsonb_set(..., $2::VARCHAR, ...)`.
-        assert "::VARCHAR" not in sql_upper, (
-            "jsonb_set path must be TEXT[], not VARCHAR. Compiled SQL:\n"
-            f"{compiled}"
+        # Primary guard: compiled SQL must contain the distinctive `ARRAY[`
+        # opener that sqlalchemy.dialects.postgresql.array emits. Pre-fix
+        # code lacked this entirely; the absence-of-VARCHAR check alone is
+        # weaker because the pre-fix compiled SQL also had no explicit
+        # `::VARCHAR` cast (asyncpg inferred the type at execute time).
+        # `ARRAY[` is the positive signal that the fix landed.
+        assert "ARRAY[" in sql_upper, (
+            "jsonb_set path must compile to a TEXT[] ARRAY literal. "
+            f"Compiled SQL:\n{compiled}"
         )
-        # Must contain TEXT[] or ARRAY bracketing for the path. The fix is
-        # `array([key])` which emits `ARRAY[...]::TEXT[]` in pg dialect.
-        assert ("TEXT[]" in sql_upper) or ("ARRAY" in sql_upper), (
-            "jsonb_set path must compile to TEXT[] / ARRAY. Compiled SQL:\n"
-            f"{compiled}"
+        # Secondary guard: the path argument's SQLAlchemy type must be an
+        # ARRAY column type, so the wire protocol sends text[] not varchar.
+        # This introspects the expression tree directly and is the closest
+        # pre-execute approximation of what asyncpg will see at runtime.
+        from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
+        from sqlalchemy.types import ARRAY as SQL_ARRAY
+        from nikita.db.models.user import User as _User
+        jsonb_set_call = captured_stmt._values[_User.__table__.c.onboarding_profile]
+        path_arg = jsonb_set_call.clauses.clauses[1]
+        # The wrapping construct from `array([key])` is `postgresql.array`,
+        # whose `.type` is `ARRAY(inferred-element-type)`. Either the
+        # dialect-specific PG_ARRAY or the generic SQL_ARRAY is acceptable;
+        # both produce `text[]` on the wire for str elements.
+        assert isinstance(path_arg.type, (PG_ARRAY, SQL_ARRAY)), (
+            "jsonb_set path arg must be a SQLAlchemy ARRAY type to avoid "
+            f"the asyncpg VARCHAR inference bug. Got type: {type(path_arg.type)}"
         )
 
     @pytest.mark.asyncio

--- a/tests/db/repositories/test_user_repository_update_key.py
+++ b/tests/db/repositories/test_user_repository_update_key.py
@@ -110,7 +110,14 @@ class TestUpdateOnboardingProfileKey:
 
     @pytest.mark.asyncio
     async def test_key_appears_in_jsonb_path(self, mock_session: AsyncMock):
-        """The key is embedded in the jsonb_set path param as '{<key>}'."""
+        """The key is embedded in the jsonb_set path as a text[] element.
+
+        Post-GH #316 fix: path is now `ARRAY[<key>]::TEXT[]` rather than a
+        single-element VARCHAR literal `'{<key>}'` (the old form Postgres
+        rejected with `function jsonb_set(jsonb, character varying, jsonb)
+        does not exist` because the real signature is
+        `jsonb_set(jsonb, text[], jsonb)`).
+        """
         from nikita.db.repositories.user_repository import UserRepository
         from sqlalchemy.dialects import postgresql
 
@@ -129,9 +136,58 @@ class TestUpdateOnboardingProfileKey:
         assert captured_stmt is not None
         compiled = captured_stmt.compile(dialect=postgresql.dialect())
         params = compiled.params
-        # The jsonb_set path argument should be '{pipeline_state}'
-        assert "{pipeline_state}" in params.values(), (
-            f"Expected '{{pipeline_state}}' path in compiled params, got: {dict(params)}"
+        # The key must appear as a bare bind value (not wrapped in braces any
+        # more) because sqlalchemy.dialects.postgresql.array([key]) binds each
+        # element of the path as a standalone text. Old form was the string
+        # literal "{pipeline_state}"; that form is now forbidden because it
+        # was the VARCHAR vs TEXT[] mismatch.
+        assert "pipeline_state" in params.values(), (
+            f"Expected bare 'pipeline_state' key in compiled params, got: {dict(params)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_jsonb_set_path_bound_as_text_array_not_varchar(
+        self, mock_session: AsyncMock
+    ):
+        """GH #316 regression guard: the path arg must compile to TEXT[], not VARCHAR.
+
+        Postgres `jsonb_set` signature is `jsonb_set(jsonb, text[], jsonb)`.
+        Binding the path as a plain Python string produces `$N::VARCHAR`,
+        which Postgres rejects with `function jsonb_set(jsonb, character
+        varying, jsonb) does not exist`. This test compiles the statement
+        and asserts:
+          1. The compiled SQL does NOT bind the path as VARCHAR.
+          2. The compiled SQL uses TEXT[] / ARRAY for the path.
+        """
+        from nikita.db.repositories.user_repository import UserRepository
+        from sqlalchemy.dialects import postgresql
+
+        captured_stmt = None
+
+        async def capture_execute(stmt, *args, **kwargs):
+            nonlocal captured_stmt
+            captured_stmt = stmt
+            return MagicMock(rowcount=1)
+
+        mock_session.execute = capture_execute
+
+        repo = UserRepository(mock_session)
+        await repo.update_onboarding_profile_key(TEST_USER_ID, "wizard_step", 8)
+
+        assert captured_stmt is not None
+        compiled = captured_stmt.compile(dialect=postgresql.dialect())
+        sql_upper = str(compiled).upper()
+        # Must NOT contain a VARCHAR-typed bind for the path. The old buggy
+        # code produced `jsonb_set(..., $2::VARCHAR, ...)`.
+        assert "::VARCHAR" not in sql_upper, (
+            "jsonb_set path must be TEXT[], not VARCHAR. Compiled SQL:\n"
+            f"{compiled}"
+        )
+        # Must contain TEXT[] or ARRAY bracketing for the path. The fix is
+        # `array([key])` which emits `ARRAY[...]::TEXT[]` in pg dialect.
+        assert ("TEXT[]" in sql_upper) or ("ARRAY" in sql_upper), (
+            "jsonb_set path must compile to TEXT[] / ARRAY. Compiled SQL:\n"
+            f"{compiled}"
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Fixes GH #316** (CRITICAL, 100% of onboarding past step 8 broken). `UserRepository.update_onboarding_profile_key` now wraps the JSONB path key in `sqlalchemy.dialects.postgresql.array([key])` so the compiled SQL emits `ARRAY[...]::TEXT[]` (Postgres signature for `jsonb_set(jsonb, text[], jsonb)`).

## Root cause

Prior code passed \`f"{{{key}}}"\` as the path (a Python string like \`"{wizard_step}"\`). SQLAlchemy bound it as a plain string; asyncpg inferred the runtime type as \`VARCHAR\`; Postgres rejected:

\`\`\`
asyncpg.exceptions.UndefinedFunctionError:
function jsonb_set(jsonb, character varying, jsonb) does not exist
\`\`\`

Unit tests compiled SQL and asserted \`"{pipeline_state}"\` appeared in params, which passed regardless of runtime type. The integration path was never exercised because the wizard only wrote to localStorage until PR #315 wired the first real PATCH call.

## Surfaced by

Agent H-2 post-fix dogfood walk (2026-04-17). Full report:
\`docs-to-process/20260417-adv-e2e/I-post-fix-dogfood.md\`.

The report traces the complete network sequence: PR #315's fix correctly sent \`PATCH /onboarding/profile\` with the full collected profile, got HTTP 500 x 3, and the subsequent \`PUT /chosen-option\` never fired (so we're back to blocking onboarding, just at a different layer).

## TDD

- RED commit (\`0e7280c\`): 2 failing unit tests, including a new regression guard \`test_jsonb_set_path_bound_as_text_array_not_varchar\` that compiles SQL and asserts \`ARRAY\` appears and \`::VARCHAR\` does not.
- GREEN commit (\`29a96ea\`): one-line fix + docstring capturing both gotchas.

## Test plan

- [x] \`uv run pytest tests/db/repositories/test_user_repository_update_key.py\` → 7 pass
- [x] \`uv run pytest tests/db/repositories/ tests/services/test_portal_onboarding.py tests/api/routes/test_portal_onboarding.py\` → 333 pass
- [ ] Post-merge: Cloud Run redeploy + re-dogfood (Agent H-3) to confirm PATCH returns 200 end-to-end

## Out of scope

- HIGH-1 from the H-2 report: BackstoryReveal silently swallows PATCH failures with no toast (separate UX issue, file as GH follow-up after this lands)
- MEDIUM-1 from the H-2 report: DarknessStep button doesn't advance on default-3 click (framer-motion whileTap interception)

## Post-merge follow-through (auto-dispatched)

1. Cloud Run deploy via \`gcloud run deploy\` (backend not auto-deployed like Vercel)
2. Re-dogfood with fresh \`simon.yang.ch+dogfood3@gmail.com\` account
3. DB cleanup of dogfood2 test rows (left by Agent H-2)
4. Close GH #316 referencing this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)