### PR TITLE
fix(db): drop json.dumps, stop double-encoding JSONB with asyncpg (GH #318, CRITICAL)

### DIFF
--- a/nikita/db/repositories/user_repository.py
+++ b/nikita/db/repositories/user_repository.py
@@ -4,7 +4,6 @@ Handles User entity with eager-loaded metrics, score updates,
 decay application, and chapter advancement.
 """
 
-import json
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
@@ -662,17 +661,25 @@ class UserRepository(BaseRepository[User]):
     ) -> None:
         """Set a single key inside users.onboarding_profile JSONB via jsonb_set.
 
-        Uses ``jsonb_set(onboarding_profile, ARRAY[<key>]::TEXT[], cast(json.dumps(value), JSONB))``
+        Uses ``jsonb_set(onboarding_profile, ARRAY[<key>]::TEXT[], cast(value, JSONB))``
         to update exactly one key without loading the full profile into Python.
         Callers must pass ``key`` as a plain string; it is wrapped as a
         single-element ``text[]`` for the jsonb_set path automatically.
 
         CRITICAL implementation notes (two gotchas):
 
-        1. The JSONB value MUST be ``cast(json.dumps(value), JSONB)`` (a
-           JSON-encoded string cast to JSONB), NOT ``cast(value, JSONB)``.
-           Passing the raw Python value is invalid for string values
-           (documented gotcha from PR #279/#282).
+        1. The JSONB value MUST bind as the RAW Python object
+           (``cast(value, JSONB)``), NOT pre-encoded via ``json.dumps()``.
+           asyncpg's JSONB codec serializes Python objects to JSON exactly
+           once at the wire-protocol layer. Passing ``json.dumps(value)``
+           (a Python string) causes asyncpg to encode AGAIN, producing
+           double-encoded JSONB: e.g. ``json.dumps(28) -> "28"`` then
+           codec -> stored as JSON string ``"28"`` instead of JSON number
+           28. Downstream ``_age_bucket`` then TypeErrors comparing str to
+           int. This was the GH #318 bug, surfaced by Agent H-3 dogfood
+           on 2026-04-17. Earlier PR #279/#282 docstring advised the
+           opposite; that guidance was psycopg2-specific and wrong for
+           asyncpg.
 
         2. The path MUST be a Postgres ``text[]``, constructed via
            ``sqlalchemy.dialects.postgresql.array([key])``. Passing a plain
@@ -688,8 +695,9 @@ class UserRepository(BaseRepository[User]):
         Args:
             user_id: The user's UUID.
             key: Top-level JSONB key to set (e.g. ``"pipeline_state"``).
-            value: Python value to store.  Will be JSON-serialized via
-                ``json.dumps``.
+            value: Python value to store. Any JSON-serializable type
+                (str, int, float, bool, None, list, dict). asyncpg's
+                JSONB codec handles serialization at execute time.
         """
         stmt = (
             update(User)
@@ -700,7 +708,9 @@ class UserRepository(BaseRepository[User]):
                     # Emits `ARRAY[$N]::TEXT[]`. See docstring note #2 for
                     # the asyncpg VARCHAR inference bug this guards against.
                     array([key]),
-                    cast(json.dumps(value), JSONB),
+                    # Bind raw value, NOT json.dumps. asyncpg's JSONB codec
+                    # serializes once. See docstring note #1 for GH #318.
+                    cast(value, JSONB),
                 )
             )
         )

--- a/nikita/db/repositories/user_repository.py
+++ b/nikita/db/repositories/user_repository.py
@@ -678,8 +678,9 @@ class UserRepository(BaseRepository[User]):
            28. Downstream ``_age_bucket`` then TypeErrors comparing str to
            int. This was the GH #318 bug, surfaced by Agent H-3 dogfood
            on 2026-04-17. Earlier PR #279/#282 docstring advised the
-           opposite; that guidance was psycopg2-specific and wrong for
-           asyncpg.
+           opposite; that guidance was incorrect for our asyncpg stack
+           and was never exercised against a live DB until PR #315 wired
+           the wizard's first real PATCH call.
 
         2. The path MUST be a Postgres ``text[]``, constructed via
            ``sqlalchemy.dialects.postgresql.array([key])``. Passing a plain

--- a/tests/db/integration/test_repositories_integration.py
+++ b/tests/db/integration/test_repositories_integration.py
@@ -107,6 +107,87 @@ class TestUserRepositoryIntegration:
         assert history is not None
         assert history.event_type == "conversation"
 
+    @pytest.mark.asyncio
+    async def test_update_onboarding_profile_key_stores_native_json_types(
+        self, user_repo: UserRepository, test_telegram_id: int
+    ):
+        """GH #318 real-DB regression guard.
+
+        Verifies `update_onboarding_profile_key` stores Python values as their
+        native JSON types (number, string, object), NOT as JSON strings.
+
+        Pre-fix (GH #318): stored `{"age":"28"}` (string) instead of
+        `{"age":28}` (number), because `cast(json.dumps(value), JSONB)`
+        double-encoded through asyncpg's JSONB codec. Downstream
+        `_age_bucket(profile["age"])` then TypeError'd comparing str to int.
+        All three prior bugs in the #313 -> #316 -> #318 chain evaded
+        mock-only tests; this test hits asyncpg end-to-end.
+        """
+        user_id = uuid4()
+        user = await user_repo.create_with_metrics(
+            user_id=user_id,
+            telegram_id=test_telegram_id,
+        )
+
+        # Integer value: must store as JSON number, not JSON string.
+        await user_repo.update_onboarding_profile_key(user.id, "age", 28)
+        await user_repo.session.commit()
+
+        result = await user_repo.session.execute(
+            text(
+                "SELECT jsonb_typeof(onboarding_profile->'age') AS age_type, "
+                "(onboarding_profile->>'age')::int AS age_int "
+                "FROM users WHERE id = :uid"
+            ),
+            {"uid": user.id},
+        )
+        row = result.mappings().first()
+        assert row is not None
+        assert row["age_type"] == "number", (
+            f"age should be JSON number, got {row['age_type']!r} "
+            "(pre-fix bug stored as string)"
+        )
+        assert row["age_int"] == 28
+
+        # String value: must store as JSON string (unescaped), not double-quoted.
+        await user_repo.update_onboarding_profile_key(user.id, "name", "Simon")
+        await user_repo.session.commit()
+
+        result = await user_repo.session.execute(
+            text(
+                "SELECT jsonb_typeof(onboarding_profile->'name') AS name_type, "
+                "onboarding_profile->>'name' AS name_val "
+                "FROM users WHERE id = :uid"
+            ),
+            {"uid": user.id},
+        )
+        row = result.mappings().first()
+        assert row is not None
+        assert row["name_type"] == "string"
+        assert row["name_val"] == "Simon", (
+            f"name should be 'Simon', got {row['name_val']!r} "
+            "(pre-fix bug stored as double-quoted JSON-encoded form)"
+        )
+
+        # Dict value: must store as JSON object, not JSON string blob.
+        await user_repo.update_onboarding_profile_key(
+            user.id, "meta", {"venues": ["Berghain"], "count": 3}
+        )
+        await user_repo.session.commit()
+
+        result = await user_repo.session.execute(
+            text(
+                "SELECT jsonb_typeof(onboarding_profile->'meta') AS meta_type, "
+                "(onboarding_profile->'meta'->>'count')::int AS meta_count "
+                "FROM users WHERE id = :uid"
+            ),
+            {"uid": user.id},
+        )
+        row = result.mappings().first()
+        assert row is not None
+        assert row["meta_type"] == "object"
+        assert row["meta_count"] == 3
+
 
 class TestConversationRepositoryIntegration:
     """Integration tests for ConversationRepository."""

--- a/tests/db/repositories/test_user_repository_update_key.py
+++ b/tests/db/repositories/test_user_repository_update_key.py
@@ -1,14 +1,22 @@
 """Tests for UserRepository.update_onboarding_profile_key (Spec 213, F-01).
 
-Verifies:
-- jsonb_set SQL function is used (not a Python-level merge)
-- cast(json.dumps(value), JSONB) is used — NOT cast(value, JSONB) (PR #279/#282 gotcha)
-- Method executes without error when user doesn't exist (silent no-op)
+Verifies (post-GH #318):
+- jsonb_set SQL function is used (not a Python-level merge).
+- The path argument compiles to a `text[]` ARRAY via
+  `sqlalchemy.dialects.postgresql.array([key])` (GH #316 guard).
+- The value argument is the raw Python object via `cast(value, JSONB)`,
+  NOT pre-encoded with `json.dumps`. asyncpg's JSONB codec serializes once
+  at the wire protocol; pre-encoding causes double-encoding (GH #318).
+- Method executes without error when user doesn't exist (silent no-op).
+
+NOTE: these are compile-time unit tests. For end-to-end asyncpg behavior
+(including the exact failure mode of GH #318), see
+`tests/db/integration/test_repositories_integration.py::TestUserRepositoryIntegration::test_update_onboarding_profile_key_stores_native_json_types`.
 
 Per .claude/rules/testing.md:
-- Non-empty fixtures for all paths
-- Every async def test_* has at least one assert
-- Patch source module, NOT importer
+- Non-empty fixtures for all paths.
+- Every async def test_* has at least one assert.
+- Patch source module, NOT importer.
 """
 
 from __future__ import annotations

--- a/tests/db/repositories/test_user_repository_update_key.py
+++ b/tests/db/repositories/test_user_repository_update_key.py
@@ -72,15 +72,26 @@ class TestUpdateOnboardingProfileKey:
         )
 
     @pytest.mark.asyncio
-    async def test_uses_json_dumps_not_raw_value(self, mock_session: AsyncMock):
-        """The JSONB cast wraps json.dumps(value) — NOT the raw Python value.
+    async def test_binds_raw_python_value_not_json_dumps(self, mock_session: AsyncMock):
+        """GH #318 regression guard: the value bind must be the RAW Python
+        object, not json.dumps(value).
 
-        This is a regression guard for PR #279/#282 gotcha: cast(value, JSONB)
-        is INVALID for strings; cast(json.dumps(value), JSONB) is correct.
+        asyncpg's JSONB codec JSON-encodes bind values at the wire protocol
+        layer. If we pre-encode with json.dumps(), asyncpg encodes AGAIN,
+        double-serializing: `json.dumps(28) -> "28"` (Python str) -> asyncpg
+        JSONB codec -> stored as JSON string `"28"` instead of JSON number 28.
+        Downstream callers (`_age_bucket`) then fail with TypeError comparing
+        str to int.
 
-        We verify via compiled.params: the bind value should be '"pending"'
-        (JSON-encoded string with surrounding quotes), not 'pending' (bare string).
-        json.dumps("pending") == '"pending"'.
+        The fix is to pass the Python value directly through `cast(value, JSONB)`
+        and let asyncpg's codec serialize exactly once. This test asserts the
+        raw Python value (28) appears in compiled params, NOT the pre-encoded
+        string '"28"' that the pre-fix code produced.
+
+        Prior test (`test_uses_json_dumps_not_raw_value`, removed) asserted the
+        opposite based on the PR #279/#282 docstring guidance. That guidance
+        was driver-specific for psycopg2 and wrong for asyncpg; Agent H-3
+        dogfood confirmed the actual prod behavior.
         """
         from nikita.db.repositories.user_repository import UserRepository
         from sqlalchemy.dialects import postgresql
@@ -95,17 +106,20 @@ class TestUpdateOnboardingProfileKey:
         mock_session.execute = capture_execute
 
         repo = UserRepository(mock_session)
-        await repo.update_onboarding_profile_key(TEST_USER_ID, "pipeline_state", "pending")
+        await repo.update_onboarding_profile_key(TEST_USER_ID, "age", 28)
 
         assert captured_stmt is not None
         compiled = captured_stmt.compile(dialect=postgresql.dialect())
         params = compiled.params
-        # json.dumps("pending") == '"pending"' — the value in params must be JSON-encoded
-        expected_json = json.dumps("pending")  # '"pending"'
-        # Look for the param value that matches the JSON-encoded string
-        assert expected_json in params.values(), (
-            f"Expected JSON-encoded value '{expected_json}' in compiled params, "
+        # Post-fix: raw int 28 must appear, NOT json.dumps(28) == "28" (string).
+        assert 28 in params.values(), (
+            f"Expected raw int 28 in compiled params (GH #318 fix), "
             f"got: {dict(params)}"
+        )
+        assert "28" not in params.values(), (
+            f"Pre-fix form json.dumps(28)=='28' must NOT appear (GH #318). "
+            f"That form double-encodes through asyncpg's JSONB codec. "
+            f"Got: {dict(params)}"
         )
 
     @pytest.mark.asyncio
@@ -219,11 +233,17 @@ class TestUpdateOnboardingProfileKey:
         mock_session.execute.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_non_string_value_json_serialized(self, mock_session: AsyncMock):
-        """Non-string values (dict, int, list) are also JSON-serialized correctly.
+    async def test_dict_value_bound_as_native_dict_not_json_dumps(
+        self, mock_session: AsyncMock
+    ):
+        """GH #318 regression guard: dict values bind as the native Python
+        dict, letting asyncpg's JSONB codec serialize once.
 
-        json.dumps({"venues": [...], "count": 3}) should appear in compiled params,
-        not the raw Python dict.
+        Pre-fix code passed `json.dumps({"venues": [...], "count": 3})` (a
+        string), which asyncpg then JSON-encoded again as a JSON string.
+        The stored value became the string `"{\"venues\":...}"` instead of
+        the parsed JSON object. This test asserts the native dict reaches
+        the bind layer so asyncpg's codec can serialize it correctly.
         """
         from nikita.db.repositories.user_repository import UserRepository
         from sqlalchemy.dialects import postgresql
@@ -244,8 +264,13 @@ class TestUpdateOnboardingProfileKey:
         assert captured_stmt is not None
         compiled = captured_stmt.compile(dialect=postgresql.dialect())
         params = compiled.params
-        expected_json = json.dumps(value)
-        assert expected_json in params.values(), (
-            f"Expected JSON-encoded dict '{expected_json}' in compiled params, "
+        # Post-fix: the raw dict object must be in params, not its JSON string.
+        assert value in params.values(), (
+            f"Expected raw dict {value} in compiled params (GH #318 fix), "
             f"got: {dict(params)}"
+        )
+        # Pre-fix form must NOT appear.
+        assert json.dumps(value) not in params.values(), (
+            f"Pre-fix json.dumps form must NOT appear (GH #318). "
+            f"Got: {dict(params)}"
         )


### PR DESCRIPTION
## Summary

**Fixes GH #318** (CRITICAL; third latent bug in the GH #313 → #316 → #318 chain).

The wizard finally PATCHes JSONB (thanks to PR #315) and the path binds as text[] (thanks to PR #317). But the value bind double-encodes JSON, so integers land as JSON strings and strings land with escaped quotes inside JSONB. Downstream `_age_bucket(age)` TypeErrors comparing str to int. 100% of onboarding past step 8 returns 500 on \`PUT /profile/chosen-option\`.

## Root cause

`user_repository.py:update_onboarding_profile_key` passed `cast(json.dumps(value), JSONB)`. The original PR #279/#282 docstring advised this form explicitly. That guidance was driver-specific for psycopg2 (which treats bind values as text and defers JSONB parsing to Postgres). asyncpg's JSONB codec serializes Python objects to JSON at the wire-protocol layer, so `json.dumps(value)` gets encoded AGAIN:

  - `json.dumps(28) -> "28"` (Python string) -> asyncpg codec -> stored JSONB = JSON string `"28"`
  - `json.dumps("DogfoodWalker3") -> '"DogfoodWalker3"'` -> codec -> stored JSONB = JSON string `'"DogfoodWalker3"'` (note the escaped quotes)

## Fix

  - `cast(value, JSONB)` (no `json.dumps`).
  - Drop the now-unused `import json`.
  - Docstring rewritten: gotcha #1 now documents the correct form + PR #279/#282 misguidance note.

## Surfaced by
Agent H-3 post-GH#316 dogfood walk, 2026-04-17. Full report at `docs-to-process/20260417-adv-e2e/J-post-fix2-dogfood.md`. Cloud Run logs show the full traceback from `_age_bucket(age: str "28")`.

## TDD

- RED commit (f8ff273): two failing tests (`test_binds_raw_python_value_not_json_dumps`, `test_dict_value_bound_as_native_dict_not_json_dumps`) replace the prior `test_uses_json_dumps_not_raw_value` + `test_non_string_value_json_serialized`. New tests assert the raw Python value (int 28 or dict) appears in compiled params, and the pre-fix `json.dumps` form does NOT.
- GREEN commit (1f01178): 1-line code change plus docstring rewrite.

## Test plan

- [x] `uv run pytest tests/db/repositories/test_user_repository_update_key.py` → 7 pass
- [x] `uv run pytest tests/db/repositories/ tests/services/test_portal_onboarding.py tests/api/routes/test_portal_onboarding.py` → 333 pass
- [ ] Post-merge: Cloud Run redeploy + H-4 dogfood to confirm wizard completes step 8-11 and Telegram deep-link is generated.

## Note on mock-test blind spots

All 3 bugs in the #313 → #316 → #318 chain were invisible to mock-only tests. Fixing this class of bug requires real-DB integration tests, or alternatively, accepting that live dogfood walks are the primary regression guard. Recommend filing a follow-up to add a Postgres-container integration test for `update_onboarding_profile_key` covering:

  1. `jsonb_typeof(value->'age') = 'number'` for int inputs.
  2. `value->>'name' = 'Simon'` (not `'"Simon"'`) for string inputs.
  3. `value->'meta'->'count' = '3'::jsonb` for dict inputs.

Out of scope for this hotfix PR.

## Post-merge follow-through (auto-dispatched)

1. `gcloud run deploy nikita-api` (backend not auto-deployed).
2. Agent H-4 re-dogfood (simon.yang.ch+dogfood4@gmail.com).
3. DB cleanup of dogfood3 orphan rows.
4. Close GH #318.
5. If H-4 passes: dispatch Agent I Telegram handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)