### PR TITLE
fix(hooks): session-start emits real newlines, not literal \n

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -17,15 +17,20 @@ if [ -f "$CLAUDE_PROJECT_DIR/PROJECT_INDEX.json" ]; then
         high_coupling: [.deps | to_entries | map({f: .key, n: (.value | length)}) | sort_by(-.n)[:5] | .[] | "\(.f | split("/")[-1]):\(.n)"]
     }' PROJECT_INDEX.json 2>/dev/null || echo "{}")
 
-    CONTEXT_MESSAGE="$(printf '## Project Index\n%s\n**Changed files**: %s\n\n' "$DIGEST" "$(echo "$CHANGED" | tr '\n' ', ')")"
+    CHANGED_CSV=$(echo "$CHANGED" | grep -v '^$' | paste -sd, -)
+    CONTEXT_MESSAGE=$(printf '## Project Index\n%s\n**Changed files**: %s\n' "$DIGEST" "$CHANGED_CSV")
 fi
 
 # --- ROADMAP Summary ---
+# Convention: each section prepends its own blank-line separator to the
+# accumulator so trailing-newline stripping by $(...) command substitution
+# can't collapse the gap between blocks. Add new sections the same way.
 if [ -f "$CLAUDE_PROJECT_DIR/ROADMAP.md" ]; then
     TOTAL_SPECS=$(grep -oE '^\| [0-9]{3}' "$CLAUDE_PROJECT_DIR/ROADMAP.md" 2>/dev/null | sort -u | wc -l | tr -d ' ')
     ACTIVE_SPECS=$(grep -c 'ACTIVE\|IN_PROGRESS' "$CLAUDE_PROJECT_DIR/ROADMAP.md" 2>/dev/null | tr -d '\n' || echo "0")
     PLANNED_SPECS=$(grep -c 'PLANNED\|BACKLOG' "$CLAUDE_PROJECT_DIR/ROADMAP.md" 2>/dev/null | tr -d '\n' || echo "0")
-    CONTEXT_MESSAGE="${CONTEXT_MESSAGE}$(printf '## ROADMAP\nSpecs: %s total, %s active, %s planned. See ROADMAP.md for details.\n\n' "$TOTAL_SPECS" "$ACTIVE_SPECS" "$PLANNED_SPECS")"
+    ROADMAP_BLOCK=$(printf '\n\n## ROADMAP\nSpecs: %s total, %s active, %s planned. See ROADMAP.md for details.' "$TOTAL_SPECS" "$ACTIVE_SPECS" "$PLANNED_SPECS")
+    CONTEXT_MESSAGE="${CONTEXT_MESSAGE}${ROADMAP_BLOCK}"
 fi
 
 # --- SDD Workflow Detection ---

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -17,7 +17,7 @@ if [ -f "$CLAUDE_PROJECT_DIR/PROJECT_INDEX.json" ]; then
         high_coupling: [.deps | to_entries | map({f: .key, n: (.value | length)}) | sort_by(-.n)[:5] | .[] | "\(.f | split("/")[-1]):\(.n)"]
     }' PROJECT_INDEX.json 2>/dev/null || echo "{}")
 
-    CONTEXT_MESSAGE="## Project Index\n$DIGEST\n**Changed files**: $(echo "$CHANGED" | tr '\n' ', ')\n\n"
+    CONTEXT_MESSAGE="$(printf '## Project Index\n%s\n**Changed files**: %s\n\n' "$DIGEST" "$(echo "$CHANGED" | tr '\n' ', ')")"
 fi
 
 # --- ROADMAP Summary ---
@@ -25,7 +25,7 @@ if [ -f "$CLAUDE_PROJECT_DIR/ROADMAP.md" ]; then
     TOTAL_SPECS=$(grep -oE '^\| [0-9]{3}' "$CLAUDE_PROJECT_DIR/ROADMAP.md" 2>/dev/null | sort -u | wc -l | tr -d ' ')
     ACTIVE_SPECS=$(grep -c 'ACTIVE\|IN_PROGRESS' "$CLAUDE_PROJECT_DIR/ROADMAP.md" 2>/dev/null | tr -d '\n' || echo "0")
     PLANNED_SPECS=$(grep -c 'PLANNED\|BACKLOG' "$CLAUDE_PROJECT_DIR/ROADMAP.md" 2>/dev/null | tr -d '\n' || echo "0")
-    CONTEXT_MESSAGE="${CONTEXT_MESSAGE}## ROADMAP\nSpecs: ${TOTAL_SPECS} total, ${ACTIVE_SPECS} active, ${PLANNED_SPECS} planned. See ROADMAP.md for details.\n\n"
+    CONTEXT_MESSAGE="${CONTEXT_MESSAGE}$(printf '## ROADMAP\nSpecs: %s total, %s active, %s planned. See ROADMAP.md for details.\n\n' "$TOTAL_SPECS" "$ACTIVE_SPECS" "$PLANNED_SPECS")"
 fi
 
 # --- SDD Workflow Detection ---


### PR DESCRIPTION
## Summary

The SessionStart hook script built `CONTEXT_MESSAGE` via bash double-quoted string concatenation `"## Project Index\n..."`. Bash does not interpret `\n` outside `$'...'` or `printf`, so two literal characters (`\` + `n`) ended up inside the string. After jq's `--arg` JSON-quoting, that became `\\n` in the rendered hook output, turning the entire injected session-start digest into one unreadable line:

```
## Project Index\\n{stats:...}\\n**Changed files**: a,b,c,\\n\\n## ROADMAP\\nSpecs: 94 total...
```

Fix: switch both blocks to `printf`-piped command substitution so real LF bytes land in `CONTEXT_MESSAGE` before jq quotes it. After the fix, `jq -r '.hookSpecificOutput.additionalContext'` renders each section on its own line.

## Verification

```bash
CLAUDE_PROJECT_DIR=$(pwd) bash .claude/hooks/session-start.sh | jq -r '.hookSpecificOutput.additionalContext' | head -10
```

Before: `## Project Index\n{...}\n**Changed files**: ...\n\n## ROADMAP\n...` (single line, literal `\n`)
After: real multi-line digest with `## Project Index` / `## ROADMAP` headings on separate lines.

## Test plan
- [x] Run hook locally — exit 0, output formatted correctly
- [x] Verified `jq -r` renders real newlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)