### PR TITLE
chore(rules): pre-push local-test HARD GATE in pr-workflow + CLAUDE.md

### DIFF
--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -14,12 +14,29 @@ globs: ["**"]
 ## Per-Change Workflow
 1. `git checkout -b {type}/{issue}-{description}`
 2. Implement with TDD (tests first)
-3. `gh pr create --title "..." --body "..."`
-4. `/qa-review --pr N` — auto-dispatch via Agent (subagent). Fix all findings, then dispatch a NEW review agent (fresh context). Repeat until the fresh review returns **0 findings across ALL severities** (0 blocking + 0 important + 0 nitpick). Never self-certify a fix — the fresh reviewer is the authority. Never prompt user for permission — this loop is mandatory. **Every dispatch MUST include `HARD CAP: 5 tool calls` + explicit changed-files list** (per `.claude/rules/parallel-agents.md` Subagent Dispatch Caps). PR #294 precedent: uncapped first dispatch ran 40 min and crashed with `API ConnectionRefused`; capped re-dispatch converged in seconds.
-5. Squash merge ONLY after a fresh QA review returns absolute zero findings + CI green
-6. `gh issue close N --comment "Fixed in PR #M"`
-7. Post-merge verification (auto-dispatched subagent): smoke test the deployed change (curl probe, log sweep, or dogfood scenario as appropriate). Do not skip. Do not ask permission.
-8. **Commit-hash verification** (mandatory after merge): run `git log origin/master --oneline -3` and confirm the PR's merge commit appears at the top. If the PR's GH status is "merged" but the commit is NOT on `origin/master`, STOP. Force-push wipes are silent and recoverable only via commit-hash audit. See PR #273 precedent (force-push wiped merged PR, recovered via #277). Also applicable to task-close operations: before `TaskUpdate(status=completed)` on any task referencing GH #NNN, verify `gh issue view NNN --json state` returns `"CLOSED"` OR `git log origin/master | rg "#NNN"` returns the merge commit. See `.claude/rules/task-verification.md`.
+3. **Pre-push local-test gate (HARD GATE)** — before `git push` or `gh pr create`, run the full suite for every area the diff touches. Not "the tests for the new code." THE FULL SUITE — regressions in other files via shared imports/config/types/build are exactly what this gate catches. Minimum commands, union across touched areas:
+   - `nikita/**`, `tests/**`, `supabase/migrations/**`, `scripts/**` → `uv run pytest -q` (or narrower `uv run pytest tests/<module>/ -q` if you are certain the diff is truly local; when in doubt, full suite)
+   - `portal/**` → `(cd portal && npm run test -- --run && npm run lint && npm run build)`
+   - CI-equivalent, not a subset. CI runs the full suite on every push; running it locally first is the cheap version of the round-trip.
+   - Skip only if: (a) the change is docs-only (`*.md` outside `portal/src/`, `docs/**`, `specs/**` without spec.md touching implementation), (b) config-only files (`.github/**`, `.claude/**`, hooks) that have no test coverage. "No test file exists for my new file" is NOT a valid skip — see anti-rationalization table below.
+   - Record pass/fail in the PR body under a `## Local tests` section.
+4. `gh pr create --title "..." --body "..."`
+5. `/qa-review --pr N` — auto-dispatch via Agent (subagent). Fix all findings, then dispatch a NEW review agent (fresh context). Repeat until the fresh review returns **0 findings across ALL severities** (0 blocking + 0 important + 0 nitpick). Never self-certify a fix — the fresh reviewer is the authority. Never prompt user for permission — this loop is mandatory. **Every dispatch MUST include `HARD CAP: 5 tool calls` + explicit changed-files list** (per `.claude/rules/parallel-agents.md` Subagent Dispatch Caps). PR #294 precedent: uncapped first dispatch ran 40 min and crashed with `API ConnectionRefused`; capped re-dispatch converged in seconds.
+6. Squash merge ONLY after a fresh QA review returns absolute zero findings + CI green
+7. `gh issue close N --comment "Fixed in PR #M"`
+8. Post-merge verification (auto-dispatched subagent): smoke test the deployed change (curl probe, log sweep, or dogfood scenario as appropriate). Do not skip. Do not ask permission.
+9. **Commit-hash verification** (mandatory after merge): run `git log origin/master --oneline -3` and confirm the PR's merge commit appears at the top. If the PR's GH status is "merged" but the commit is NOT on `origin/master`, STOP. Force-push wipes are silent and recoverable only via commit-hash audit. See PR #273 precedent (force-push wiped merged PR, recovered via #277). Also applicable to task-close operations: before `TaskUpdate(status=completed)` on any task referencing GH #NNN, verify `gh issue view NNN --json state` returns `"CLOSED"` OR `git log origin/master | rg "#NNN"` returns the merge commit. See `.claude/rules/task-verification.md`.
+
+## Anti-Rationalization — Pre-Push Test Gate
+
+| Rationalization | Response |
+|---|---|
+| "There's no test file for my new code, so there's nothing to run" | Wrong — run the *full suite* for the touched area. Regressions often land in OTHER files (shared types, build config, imports, globals). PR #329 (2026-04-18) shipped a new 1907-line page; author ran lint+build but skipped vitest; user had to prompt. Would have silently passed a stricter TS/import change that broke unrelated tests. |
+| "Lint passed + build passed, same signal as tests" | No. Build catches type + parse errors. Unit tests catch behavioral regressions in shared modules. Both are required. |
+| "The change is confined to one file" | Then the test run is fast — no reason to skip. `uv run pytest -q` runs the nikita suite in ~90 s. |
+| "CI will catch it" | CI catches it but costs a round-trip, user-facing noise, and GH Actions minutes. User rule (feedback_compact_and_local_tests.md): run locally before push to not waste Actions. |
+| "I'm in a worktree, tests might behave differently" | Worktree tests are identical; pytest/vitest resolve from the worktree root. If it fails locally it would fail on CI. |
+| "`uv run pytest` is slow" | `-q` + scoped path is fast enough. Even a 2-min local run beats a failed CI round-trip. |
 
 ## Orchestrator Grep-Verify Gate (critical, before dispatching QA reviewer)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,10 @@ AI girlfriend simulation game. Players interact with Nikita via text (Telegram) 
 ## Commands
 
 ```bash
-pytest tests/ -x -q                          # Run all tests
-pytest tests/{module}/ -v                    # Run module tests
+uv run pytest -q                             # Full nikita suite (pre-push gate; ~90 s)
+uv run pytest tests/{module}/ -v             # Module-scoped tests
+(cd portal && npm run test -- --run)         # Portal vitest (pre-push gate)
+(cd portal && npm run lint && npm run build) # Portal lint + build (pre-push gate)
 gcloud run deploy nikita-api --source . --region us-central1 --project gcp-transcribe-test --allow-unauthenticated
 cd portal && npm run build && vercel --prod  # Deploy portal
 ```
@@ -46,7 +48,7 @@ See `docs/deployment.md` for full deployment reference (URLs, project IDs, comma
 
 1. **Verify before implementing**: Use MCP Ref tool to check official docs for ANY external library/API before writing code. Training data is outdated.
 2. **Search before writing**: `rg "class.*Client" --type py` — if it exists, use it. One source of truth per utility.
-3. **Zero failing tests**: Fix, track (GitHub issue), or delete — never ignore. Run tests before ending any task.
+3. **Zero failing tests**: Fix, track (GitHub issue), or delete — never ignore. Run tests before ending any task. **Pre-push HARD GATE**: before `git push` or `gh pr create`, run the FULL suite for every touched area (nikita → `uv run pytest -q`, portal → `(cd portal && npm run test -- --run)`). "No test file exists for my new code" is NOT a valid skip — see `.claude/rules/pr-workflow.md` "Anti-Rationalization — Pre-Push Test Gate" + PR #329 (2026-04-18) precedent.
 4. **External service config**: Document BOTH code-side AND dashboard-side settings (ElevenLabs, Supabase, etc.).
 5. **No over-engineering**: Implement ONLY what was requested. No invented features.
 6. **Event logging**: Log all significant actions in `event-stream.md` — format: `[TIMESTAMP] TYPE: description`


### PR DESCRIPTION
## Summary

Adds explicit pre-push test gate as step 3 of `.claude/rules/pr-workflow.md`, naming exact commands per touched area. Includes 6-row anti-rationalization table.

## Why

PR #329 (2026-04-18, heartbeat/page.tsx) shipped a new 1907-line file after running only `npm run lint` + `npm run build`, **skipping vitest** because "no tests exist for research-lab pages." User caught it post-push: *"Did you run the tests locally?"*

Root cause: existing rule text was loose (*"always run tests locally before github so as to not waste actions"*). Read as "the affected tests" not "the full suite that could regress in OTHER files via shared imports/config/types/build."

## Changes

- `.claude/rules/pr-workflow.md`: insert step 3 (pre-push HARD GATE) between TDD and `gh pr create`. Renumber steps 4-9. Add 6-row anti-rationalization table covering "no test file for new code", "lint+build same as tests", "single-file change", "CI will catch it", "worktree differs", "pytest is slow".
- `CLAUDE.md`: tighten Critical Rule #3 with HARD GATE language + cross-ref to anti-rationalization table. Replace bare \`pytest tests/ -x -q\` with \`uv run pytest -q\` + portal vitest/lint/build commands.

Per-area commands now explicit:
- \`nikita/**\`, \`tests/**\`, \`supabase/migrations/**\`, \`scripts/**\` → \`uv run pytest -q\`
- \`portal/**\` → \`(cd portal && npm run test -- --run && npm run lint && npm run build)\`

## Local tests

Skipped per the new rule itself (config-only, \`.claude/**\` + repo-root \`CLAUDE.md\`, no test coverage for these markdown files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)