### PR TITLE
feat(215-F): heartbeat live parity validator

### DIFF
--- a/.github/workflows/heartbeat-parity-nightly.yml
+++ b/.github/workflows/heartbeat-parity-nightly.yml
@@ -1,0 +1,121 @@
+# Nightly heartbeat live-vs-offline parity validator (Spec 215 FR-016).
+#
+# Runs the KS-test parity script every night at 03:30 UTC. On non-zero exit
+# (drift detected in any chapter, p ≤ 0.01), files a GH issue tagged
+# severity:high so the next on-call sees it. Phase 1: prod has no heartbeat
+# events yet, so this will report status=no_data and exit 0 until PR 215-D
+# wires the dispatcher.
+#
+# Manual trigger via workflow_dispatch is supported for ad-hoc validation
+# (e.g., after tuning ACTIVITY_PARAMS or chapter modulators).
+
+name: heartbeat-parity-nightly
+
+on:
+  schedule:
+    - cron: "30 3 * * *"  # 03:30 UTC daily
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write  # required to file an alert issue on drift
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: latest
+
+      - name: Set up Python via uv
+        run: uv python install 3.12
+
+      - name: Sync project deps
+        run: uv sync --frozen || uv sync
+
+      - name: Run parity validator
+        id: parity
+        env:
+          # Wired in PR 215-D; safe to be empty in Phase 1 (the validator
+          # falls back to no_data and exits 0).
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          set +e
+          uv run python scripts/models/heartbeat_live_parity.py > parity-result.json
+          rc=$?
+          echo "exit_code=${rc}" >> "$GITHUB_OUTPUT"
+          # Always print the JSON to step summary for human review
+          {
+            echo '## Heartbeat parity result'
+            echo ''
+            echo '```json'
+            cat parity-result.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit ${rc}
+        continue-on-error: true
+
+      - name: Upload parity result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: parity-result
+          path: parity-result.json
+          retention-days: 30
+
+      - name: File GH issue on drift
+        if: steps.parity.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Build issue body from parity-result.json (truncated for safety)
+          BODY=$(cat <<EOF
+          The nightly heartbeat parity validator detected drift between live
+          \`scheduled_events\` and the offline Monte Carlo distribution.
+
+          **Workflow run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger**: ${{ github.event_name }}
+          **Commit**: ${{ github.sha }}
+
+          ## Parity result
+
+          \`\`\`json
+          $(cat parity-result.json)
+          \`\`\`
+
+          ## Next steps
+
+          1. Inspect the per-chapter \`p_value\` and \`ks_statistic\` above
+             to localize which chapter(s) drifted.
+          2. Pull the production \`scheduled_events\` slice for that chapter
+             and inspect inter-wake distribution shape.
+          3. If drift is real (not a transient cohort artefact), open a
+             follow-up to re-tune \`ACTIVITY_PARAMS\` /
+             \`NU_PER_ACTIVITY\` / \`CHAPTER_MULT\` in
+             \`nikita/heartbeat/intensity.py\`.
+          4. After fix, re-run this workflow via \`workflow_dispatch\` to
+             confirm parity restored.
+
+          See \`specs/215-heartbeat-engine/spec.md\` FR-016 for the design
+          contract.
+          EOF
+          )
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "[heartbeat-parity] Drift detected $(date -u +%Y-%m-%d)" \
+            --label "severity:high" \
+            --label "spec-215" \
+            --body "${BODY}"
+
+      - name: Surface parity exit code
+        if: steps.parity.outputs.exit_code != '0'
+        run: |
+          echo "::error::heartbeat parity validator exited with code ${{ steps.parity.outputs.exit_code }}"
+          exit 1

--- a/scripts/models/heartbeat_live_parity.py
+++ b/scripts/models/heartbeat_live_parity.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Live-vs-offline heartbeat parity validator (Spec 215 PR 215-F, FR-016).
+
+Compares production-observed heartbeat inter-wake distributions (last 7 days,
+``scheduled_events WHERE event_type='heartbeat'``) against the offline Monte
+Carlo distribution from :mod:`nikita.heartbeat.intensity`. Performs a
+Kolmogorov-Smirnov two-sample test per chapter and exits 0/1.
+
+**Why KS?** The two-sample KS statistic measures the maximum vertical gap
+between two empirical CDFs without assuming a specific parametric form.
+Inter-wake gaps from the Hawkes-modulated intensity are NOT exponentially
+distributed (excitation makes them sub-exponential at short lags), so a
+parametric test would mis-specify the null. KS is distribution-free.
+
+**Why exit code policy "any chapter p ≤ 0.01 → exit 1"?** A single failing
+chapter is a real signal — the model and reality diverge for at least one
+relationship phase. The threshold 0.01 is intentionally strict (Type I error
+~1%) because we run nightly and the "alert if EVER fails" cost over a year
+is non-trivial; we want false-positive rate ≤ 365 × 0.01 ≈ 3.6 alerts/year
+per chapter. The CI workflow files a GH issue with severity:high on exit 1.
+
+**Why mock at SQL-result level in tests?** Production has zero heartbeat
+events at PR write time (PR 215-F is the first to ship the validator).
+Tests inject synthetic numpy arrays directly through the
+``fetch_observed_inter_wake`` boundary; the live SQL is exercised only in
+CI cron after Phase 2 of Spec 215 ships.
+
+**KS implementation**: We re-implement the two-sample KS p-value via the
+Smirnov asymptotic series (Numerical Recipes 14.3.4) instead of importing
+SciPy. SciPy is not in pyproject.toml and adding a heavy native dep just
+for one statistic is poor cost/benefit. The Smirnov series converges fast
+(<1e-8 after ~10 terms for typical effective N).
+
+Usage::
+
+    uv run python scripts/models/heartbeat_live_parity.py
+    uv run python scripts/models/heartbeat_live_parity.py --window-days 14
+    uv run python scripts/models/heartbeat_live_parity.py --mc-samples 5000
+
+Exit codes:
+    0  All chapters pass parity OR no observed data yet (no alert)
+    1  At least one chapter has p ≤ P_VALUE_THRESHOLD (drift detected)
+
+Output: JSON document on stdout with per-chapter breakdown
+(``ks_statistic``, ``p_value``, ``n_observed``, ``n_mc``, ``passed``).
+
+See also:
+    - scripts/models/heartbeat_intensity_mc.py — offline MC validator
+    - .github/workflows/heartbeat-parity-nightly.yml — CI cron
+    - specs/215-heartbeat-engine/spec.md FR-016
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import sys
+from typing import Any, Final
+
+import numpy as np
+
+from nikita.heartbeat.intensity import sample_next_wakeup
+
+# --------------------------------------------------------------------------- #
+# Tunable thresholds (kept here, not in nikita/, since this is a validator)   #
+# --------------------------------------------------------------------------- #
+
+# A chapter PASSES parity iff KS p-value > P_VALUE_THRESHOLD. 0.01 chosen
+# to bound nightly false-positive rate to ~3.6 alerts/chapter/year. Tighter
+# than the typical 0.05 because we run on a fixed schedule.
+P_VALUE_THRESHOLD: Final[float] = 0.01
+
+# Default rolling window of production data to consider.
+DEFAULT_WINDOW_DAYS: Final[int] = 7
+
+# Default MC sample count per chapter. Larger → tighter KS p-values + slower.
+# 2000 gives KS standard error ~0.02 — adequate for chapter-level decisions.
+DEFAULT_MC_SAMPLES: Final[int] = 2000
+
+# Engagement state used for MC reference. We compare against the modal
+# engagement state ('in_zone') because per-event engagement isn't currently
+# stored on scheduled_events; treat divergence per chapter as the lever.
+MC_REFERENCE_ENGAGEMENT: Final[str] = "in_zone"
+
+# Deterministic seed for the MC reference distribution so nightly runs are
+# reproducible (the only stochasticity should be the production data).
+MC_SEED: Final[int] = 0xDEADBEEF
+
+
+# --------------------------------------------------------------------------- #
+# Two-sample Kolmogorov-Smirnov                                               #
+# --------------------------------------------------------------------------- #
+
+
+def _kolmogorov_p(d: float, n_eff: float) -> float:
+    """Asymptotic two-sided KS p-value via Smirnov series.
+
+    Returns Pr(D >= d) under the null where ``n_eff`` is the harmonic-mean
+    sample size. Numerical Recipes 14.3.4. Series converges in ~10 terms for
+    en >= 4. Returns 1.0 for degenerate inputs (n_eff <= 0 or d == 0).
+    """
+    if n_eff <= 0 or d <= 0:
+        return 1.0
+    en = math.sqrt(n_eff)
+    # Stevens 1970 small-sample correction
+    lam = (en + 0.12 + 0.11 / en) * d
+    lam2 = -2.0 * lam * lam
+    total = 0.0
+    fac = 2.0
+    prev = 0.0
+    for j in range(1, 101):
+        term = fac * math.exp(lam2 * j * j)
+        total += term
+        if abs(term) <= 0.001 * abs(prev) or abs(term) <= 1.0e-10 * total:
+            return min(max(total, 0.0), 1.0)
+        fac = -fac
+        prev = term
+    return 1.0  # series failed to converge → conservative (no rejection)
+
+
+def ks_two_sample(a: np.ndarray, b: np.ndarray) -> tuple[float, float]:
+    """Two-sample Kolmogorov-Smirnov test (D statistic + asymptotic p-value).
+
+    Returns (D, p) where D = max |F_a(x) - F_b(x)| over the pooled support
+    and p ≈ Pr(D >= observed | both samples drawn from same distribution).
+
+    Both arrays must be 1-D and have at least 1 element each. Behaviour with
+    empty arrays is undefined (caller must guard).
+    """
+    a_sorted = np.sort(np.asarray(a, dtype=float))
+    b_sorted = np.sort(np.asarray(b, dtype=float))
+    n_a = a_sorted.size
+    n_b = b_sorted.size
+    if n_a == 0 or n_b == 0:
+        return 0.0, 1.0
+    # Pool, then compute step-CDF differences via searchsorted
+    pooled = np.concatenate([a_sorted, b_sorted])
+    cdf_a = np.searchsorted(a_sorted, pooled, side="right") / n_a
+    cdf_b = np.searchsorted(b_sorted, pooled, side="right") / n_b
+    d = float(np.max(np.abs(cdf_a - cdf_b)))
+    n_eff = n_a * n_b / (n_a + n_b)
+    p = _kolmogorov_p(d, n_eff)
+    return d, p
+
+
+# --------------------------------------------------------------------------- #
+# I/O boundary — mockable in tests                                            #
+# --------------------------------------------------------------------------- #
+
+
+def fetch_observed_inter_wake(
+    window_days: int = DEFAULT_WINDOW_DAYS,
+) -> dict[int, np.ndarray]:
+    """Pull observed heartbeat inter-wake gaps (hours) per chapter from Supabase.
+
+    Live implementation queries scheduled_events:
+
+        SELECT user_id, chapter, scheduled_at
+        FROM scheduled_events
+        WHERE event_type = 'heartbeat'
+          AND scheduled_at > now() - interval '{window_days} days'
+        ORDER BY user_id, scheduled_at;
+
+    For each user, computes inter-wake = diff(scheduled_at) in hours, groups
+    by chapter, returns ``{chapter: ndarray}``.
+
+    Wired against the production Supabase MCP at runtime. In CI/nightly the
+    MCP isn't available from a GitHub Actions runner, so the cron uses the
+    REST API or a service-role JWT against the Supabase HTTP endpoint
+    (configured via SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY env vars in the
+    workflow). Since prod has zero heartbeat events at PR-F write time,
+    this function is a no-op stub returning empty arrays — the validator
+    correctly reports ``no_data`` and exits 0. It will be wired up in PR
+    215-D once the heartbeat dispatcher starts emitting rows.
+
+    Tests patch this function directly to inject synthetic distributions.
+    """
+    # Phase 1 stub: no observed data exists yet. Return empty arrays per
+    # chapter so the validator reports 'no_data' rather than crashing.
+    # PR 215-D wires the real query.
+    return {chapter: np.array([]) for chapter in range(1, 6)}
+
+
+def generate_mc_samples(
+    n_samples: int = DEFAULT_MC_SAMPLES,
+    seed: int = MC_SEED,
+) -> dict[int, np.ndarray]:
+    """Generate per-chapter MC inter-wake samples via Ogata thinning.
+
+    For each chapter 1-5, runs ``sample_next_wakeup`` repeatedly from a
+    cold-start state (R=0, randomized t_now ∈ [0, 24)) and collects
+    inter-wake gaps in hours. Reuses production sampler so MC <> live
+    comparison cannot drift from a divergent implementation.
+    """
+    rng = random.Random(seed)
+    out: dict[int, np.ndarray] = {}
+    for chapter in range(1, 6):
+        gaps: list[float] = []
+        # Start at an arbitrary phase to mix circadian, then chain wakes
+        t_now = rng.uniform(0.0, 24.0)
+        R = 0.0
+        for _ in range(n_samples):
+            t_next, R_next = sample_next_wakeup(
+                t_now=t_now,
+                R_now=R,
+                chapter=chapter,
+                engagement=MC_REFERENCE_ENGAGEMENT,
+                rng=rng,
+            )
+            gap = t_next - t_now
+            # Skip horizon-truncated gaps (degenerate "no event in 24h")
+            if gap < 24.0 - 1e-6:
+                gaps.append(gap)
+            t_now = t_next
+            R = R_next
+        out[chapter] = np.asarray(gaps, dtype=float)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Core validator                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def run_parity(
+    observed: dict[int, np.ndarray],
+    mc_samples: dict[int, np.ndarray],
+    *,
+    p_threshold: float = P_VALUE_THRESHOLD,
+) -> dict[str, Any]:
+    """Compare observed vs MC per chapter; return structured result.
+
+    Per chapter:
+        - If observed is empty → ``passed=True``, p_value/ks_statistic=None,
+          contributes ``no_data`` flavor to overall status.
+        - Else KS-test against MC; ``passed = p_value > p_threshold``.
+
+    Overall status:
+        - "pass" if all chapters have observed data and all pass
+        - "fail" if ANY chapter has observed data and fails
+        - "no_data" if NO chapter has observed data
+    """
+    chapters: dict[int, dict[str, Any]] = {}
+    any_data = False
+    any_failed = False
+
+    for chapter in range(1, 6):
+        obs = observed.get(chapter, np.array([]))
+        mc = mc_samples.get(chapter, np.array([]))
+        n_obs = int(obs.size)
+        n_mc = int(mc.size)
+
+        if n_obs == 0:
+            chapters[chapter] = {
+                "passed": True,
+                "p_value": None,
+                "ks_statistic": None,
+                "n_observed": 0,
+                "n_mc": n_mc,
+                "reason": "no_observed_data",
+            }
+            continue
+
+        any_data = True
+        if n_mc == 0:
+            # Defensive — MC should never be empty, but don't crash if it is
+            chapters[chapter] = {
+                "passed": True,
+                "p_value": None,
+                "ks_statistic": None,
+                "n_observed": n_obs,
+                "n_mc": 0,
+                "reason": "no_mc_reference",
+            }
+            continue
+
+        d, p = ks_two_sample(obs, mc)
+        passed = p > p_threshold
+        if not passed:
+            any_failed = True
+        chapters[chapter] = {
+            "passed": passed,
+            "p_value": float(p),
+            "ks_statistic": float(d),
+            "n_observed": n_obs,
+            "n_mc": n_mc,
+        }
+
+    if not any_data:
+        status = "no_data"
+        exit_code = 0
+    elif any_failed:
+        status = "fail"
+        exit_code = 1
+    else:
+        status = "pass"
+        exit_code = 0
+
+    return {
+        "status": status,
+        "exit_code": exit_code,
+        "p_threshold": p_threshold,
+        "chapters": chapters,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# CLI entry                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--window-days", type=int, default=DEFAULT_WINDOW_DAYS)
+    p.add_argument("--mc-samples", type=int, default=DEFAULT_MC_SAMPLES)
+    p.add_argument("--mc-seed", type=int, default=MC_SEED)
+    p.add_argument(
+        "--p-threshold", type=float, default=P_VALUE_THRESHOLD,
+        help="A chapter passes iff KS p-value > threshold (default 0.01)",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: fetch live data + MC samples, run parity, emit JSON, return exit code."""
+    args = _build_arg_parser().parse_args(argv)
+    observed = fetch_observed_inter_wake(window_days=args.window_days)
+    mc_samples = generate_mc_samples(n_samples=args.mc_samples, seed=args.mc_seed)
+    result = run_parity(
+        observed=observed,
+        mc_samples=mc_samples,
+        p_threshold=args.p_threshold,
+    )
+    # Emit JSON on stdout (the GH Actions step pipes this into a comment + log)
+    print(json.dumps(result, indent=2, default=str))
+    return int(result["exit_code"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -1,0 +1,26 @@
+"""Make the repo-root ``scripts/`` package importable from tests.
+
+The repo's ``scripts/`` directory is intentionally NOT a package (no
+``__init__.py``); pytest still resolves ``from scripts.models import X``
+inside test bodies because rootdir gets added to ``sys.path`` lazily.
+However, module-level imports during collection see a snapshot of
+``sys.path`` BEFORE that lazy injection, so collection fails when this
+file is reached as part of the full suite (works in isolation).
+
+Adding the repo root to ``sys.path`` here, at conftest load (which fires
+before any test module in this directory is imported), guarantees
+``import scripts.models.heartbeat_live_parity`` resolves at collection
+time. Mirrors the same pattern used in tests/heartbeat/test_intensity.py
+where the import is deferred to function body — we can't defer here
+because the module-level ``patch(...)`` decorators need the symbol
+present at import.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))

--- a/tests/scripts/test_heartbeat_live_parity.py
+++ b/tests/scripts/test_heartbeat_live_parity.py
@@ -1,0 +1,220 @@
+"""Tests for the live-vs-offline heartbeat parity validator (Spec 215 PR 215-F).
+
+These tests mock the SQL-result level (production has no heartbeat events at PR
+write time). They cover four scenarios:
+
+    1. PASS — observed inter-wake distribution matches MC samples (no drift).
+    2. FAIL — observed diverges from MC (synthetic drift).
+    3. Per-chapter breakdown is in the JSON output for ALL chapters 1-5.
+    4. Empty observed data is handled gracefully (warning, exit 0 — not crash).
+
+Coverage strategy: bypass the real Supabase MCP client by patching
+``fetch_observed_inter_wake`` (the validator's I/O boundary). Every test
+provides synthetic numpy arrays directly, so the code paths under test are
+the KS computation, exit-code policy, and JSON shape.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from scripts.models.heartbeat_live_parity import (
+    P_VALUE_THRESHOLD,
+    ks_two_sample,
+    main,
+    run_parity,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _matched_observed(rng_seed: int = 7) -> dict[int, np.ndarray]:
+    """Synthetic 'observed' that mirrors the MC distribution (should PASS).
+
+    Use a fixed seed so the test is deterministic. We sample directly from
+    the same exponential family the MC uses so KS p-values are high.
+    """
+    rng = np.random.default_rng(rng_seed)
+    return {ch: rng.exponential(scale=1.0 / (1.0 + 0.1 * ch), size=200)
+            for ch in range(1, 6)}
+
+
+def _drifted_observed(rng_seed: int = 7) -> dict[int, np.ndarray]:
+    """Synthetic 'observed' with heavy drift (should FAIL KS).
+
+    Multiplies inter-wake gaps by 5 — the empirical distribution is
+    stochastically dominated by the MC, so KS rejects with very small p.
+    """
+    rng = np.random.default_rng(rng_seed)
+    return {ch: rng.exponential(scale=5.0, size=200) for ch in range(1, 6)}
+
+
+def _matched_mc(rng_seed: int = 13) -> dict[int, np.ndarray]:
+    """MC reference samples drawn from the same family as ``_matched_observed``."""
+    rng = np.random.default_rng(rng_seed)
+    return {ch: rng.exponential(scale=1.0 / (1.0 + 0.1 * ch), size=2000)
+            for ch in range(1, 6)}
+
+
+# --------------------------------------------------------------------------- #
+# KS primitive sanity                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_ks_two_sample_returns_high_p_for_same_distribution():
+    rng = np.random.default_rng(0)
+    a = rng.exponential(scale=1.0, size=500)
+    b = rng.exponential(scale=1.0, size=500)
+    stat, p = ks_two_sample(a, b)
+    assert 0 <= stat <= 1
+    assert p > 0.05  # cannot reject same-distribution hypothesis
+
+
+def test_ks_two_sample_returns_low_p_for_different_distribution():
+    rng = np.random.default_rng(0)
+    a = rng.exponential(scale=1.0, size=500)
+    b = rng.exponential(scale=5.0, size=500)
+    _, p = ks_two_sample(a, b)
+    assert p < 0.001  # decisively rejects same-distribution hypothesis
+
+
+# --------------------------------------------------------------------------- #
+# Main scenarios                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_passes_when_observed_matches_mc():
+    """AC: validator exits 0 + no failed chapters when distributions match."""
+    observed = _matched_observed()
+    mc = _matched_mc()
+
+    result = run_parity(observed=observed, mc_samples=mc)
+
+    assert result["status"] == "pass"
+    assert result["exit_code"] == 0
+    assert all(ch["passed"] for ch in result["chapters"].values()), \
+        f"Expected all chapters to pass, got: {result['chapters']}"
+
+
+def test_fails_when_observed_diverges_from_mc():
+    """AC: validator exits 1 + flags failing chapters when distributions diverge."""
+    observed = _drifted_observed()
+    mc = _matched_mc()
+
+    result = run_parity(observed=observed, mc_samples=mc)
+
+    assert result["status"] == "fail"
+    assert result["exit_code"] == 1
+    failing = [ch for ch, data in result["chapters"].items() if not data["passed"]]
+    assert len(failing) == 5, \
+        f"Expected all 5 chapters to fail under heavy drift, got failing={failing}"
+    # Each failing chapter must report p ≤ threshold
+    for ch_data in result["chapters"].values():
+        if not ch_data["passed"]:
+            assert ch_data["p_value"] <= P_VALUE_THRESHOLD
+
+
+def test_per_chapter_breakdown_in_output():
+    """AC: JSON output contains per-chapter p-value, ks_statistic, sample sizes for chapters 1-5."""
+    observed = _matched_observed()
+    mc = _matched_mc()
+
+    result = run_parity(observed=observed, mc_samples=mc)
+
+    for chapter in range(1, 6):
+        assert chapter in result["chapters"], f"Missing chapter {chapter}"
+        ch_data = result["chapters"][chapter]
+        assert "p_value" in ch_data
+        assert "ks_statistic" in ch_data
+        assert "n_observed" in ch_data
+        assert "n_mc" in ch_data
+        assert "passed" in ch_data
+        assert ch_data["n_observed"] == 200
+        assert ch_data["n_mc"] == 2000
+
+
+def test_handles_empty_observed_data_gracefully():
+    """AC: empty observed data produces structured 'no_data' status, exit 0 (no spurious alert)."""
+    observed: dict[int, np.ndarray] = {ch: np.array([]) for ch in range(1, 6)}
+    mc = _matched_mc()
+
+    result = run_parity(observed=observed, mc_samples=mc)
+
+    assert result["status"] == "no_data"
+    assert result["exit_code"] == 0
+    for chapter in range(1, 6):
+        ch_data = result["chapters"][chapter]
+        assert ch_data["passed"] is True  # not actively failing
+        assert ch_data["n_observed"] == 0
+        assert ch_data["p_value"] is None
+        assert ch_data["ks_statistic"] is None
+
+
+def test_partial_data_still_evaluates_present_chapters():
+    """If only some chapters have observed data, those are KS-tested; others marked no_data."""
+    observed = {1: _matched_observed()[1], 3: _matched_observed()[3]}
+    # Chapters 2, 4, 5 absent
+    mc = _matched_mc()
+
+    result = run_parity(observed=observed, mc_samples=mc)
+
+    assert result["chapters"][1]["n_observed"] == 200
+    assert result["chapters"][1]["p_value"] is not None
+    assert result["chapters"][2]["n_observed"] == 0
+    assert result["chapters"][2]["p_value"] is None
+    assert result["chapters"][3]["n_observed"] == 200
+    assert result["chapters"][3]["p_value"] is not None
+
+
+# --------------------------------------------------------------------------- #
+# Main entry point — exit code + JSON to stdout                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_main_emits_json_to_stdout_and_returns_exit_code():
+    """main() emits a single JSON document to stdout and returns int exit code."""
+    observed = _matched_observed()
+
+    with patch(
+        "scripts.models.heartbeat_live_parity.fetch_observed_inter_wake",
+        return_value=observed,
+    ), patch(
+        "scripts.models.heartbeat_live_parity.generate_mc_samples",
+        return_value=_matched_mc(),
+    ):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            exit_code = main([])
+
+    assert exit_code == 0
+    payload = json.loads(buf.getvalue())
+    assert payload["status"] == "pass"
+    assert "chapters" in payload
+
+
+def test_main_returns_1_on_drift():
+    observed = _drifted_observed()
+
+    with patch(
+        "scripts.models.heartbeat_live_parity.fetch_observed_inter_wake",
+        return_value=observed,
+    ), patch(
+        "scripts.models.heartbeat_live_parity.generate_mc_samples",
+        return_value=_matched_mc(),
+    ):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            exit_code = main([])
+
+    assert exit_code == 1
+    payload = json.loads(buf.getvalue())
+    assert payload["status"] == "fail"


### PR DESCRIPTION
Closes T7.1, T7.2, T7.3 of specs/215-heartbeat-engine/tasks.md US-7. Implements FR-016.

## What
- **scripts/models/heartbeat_live_parity.py** — Two-sample Kolmogorov-Smirnov test per chapter (1-5), compares production observed inter-wake gaps vs offline MC samples drawn from the production sampler (`nikita.heartbeat.intensity.sample_next_wakeup`). KS p-value computed via the Smirnov asymptotic series (Numerical Recipes 14.3.4, Stevens 1970 small-sample correction) — no scipy dependency added. Exit 0 if all chapters pass `p > 0.01` or no observed data yet; exit 1 if any chapter shows drift.
- **tests/scripts/test_heartbeat_live_parity.py** — 9 unit tests covering: KS primitive on same/different distributions, pass when matched, fail when drifted, per-chapter breakdown shape, empty-data graceful path, partial-data path, main() JSON-to-stdout + exit-code contract. Mocks at the SQL-result level (synthetic numpy arrays) since prod has zero heartbeat events at PR write time.
- **tests/scripts/conftest.py** — Adds repo root to `sys.path` so module-level `from scripts.models.heartbeat_live_parity import ...` resolves at collection time. Required because `scripts/` is intentionally not a package (no `__init__.py`); existing tests defer the import to function bodies, but mock-decorator patterns force module-level import here.
- **.github/workflows/heartbeat-parity-nightly.yml** — Nightly cron at 03:30 UTC, supports `workflow_dispatch`, uploads result JSON as a 30-day artifact, files a severity:high issue on drift via `gh issue create`. Phase 1 will report `status=no_data` and exit 0 until PR 215-D wires the dispatcher.

## Excludes
- Live Supabase reads in tests (mocked at SQL-result level — prod has no heartbeat events yet)
- Real Supabase HTTP query in `fetch_observed_inter_wake` (Phase 1 stub returns empty arrays per chapter; PR 215-D will replace the body with the real query against `scheduled_events WHERE event_type='heartbeat'`)

## Local tests
- `uv run pytest tests/scripts/test_heartbeat_live_parity.py -v` → 9 passed
- `uv run pytest -q` → 6298 passed, 184 deselected, 3 xpassed (full suite, 157s)

## Notes for QA
- KS threshold rationale: `P_VALUE_THRESHOLD = 0.01` chosen for nightly cadence (~3.6 expected false-positives per chapter per year at α=0.01); see module docstring.
- The MC reference uses `engagement="in_zone"` only because per-event engagement isn't currently stored on `scheduled_events`; the chapter is the divergence lever.
- Horizon-truncated MC gaps (sampler returns `t_now + 24h` when no event accepted) are filtered out so the KS comparison isn't biased by the safety-net fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)