### PR TITLE
feat(215-D): heartbeat + daily-arcs API endpoints

### DIFF
--- a/nikita/api/routes/tasks.py
+++ b/nikita/api/routes/tasks.py
@@ -9,9 +9,12 @@ AC Coverage: Phase 3 background task infrastructure
 """
 
 import logging
+from datetime import UTC, datetime, time, timedelta
 from decimal import Decimal
 
 from fastapi import APIRouter, Depends, HTTPException, Header
+from fastapi.responses import JSONResponse, Response
+from sqlalchemy import text as sql_text
 
 logger = logging.getLogger(__name__)
 
@@ -1212,8 +1215,8 @@ async def heartbeat_tick(
     Fan-out cap: 40 users per tick (R4) — overflow surfaces as
     ``deferred`` for next-tick processing.
     """
-    from sqlalchemy import text as sql_text
-
+    # Inline import: TouchpointEngine pulls in agents/voice deps; keep cold-start
+    # of /tasks/decay etc. unaffected. UserRepository is also inline for symmetry.
     from nikita.db.repositories.user_repository import UserRepository
     from nikita.touchpoints.engine import TouchpointEngine
 
@@ -1320,10 +1323,10 @@ async def heartbeat_tick(
             return envelope
 
 
-@router.post("/generate-daily-arcs")
+@router.post("/generate-daily-arcs", response_model=None)
 async def generate_daily_arcs(
     _: None = Depends(verify_task_secret),
-) -> dict:
+) -> dict | Response:
     """Daily-arc generation for all heartbeat-eligible users (Spec 215 US-1).
 
     Calls the LLM-driven planner (``nikita.heartbeat.planner.generate_daily_arc``)
@@ -1339,12 +1342,13 @@ async def generate_daily_arcs(
     ``settings.heartbeat_cost_circuit_breaker_usd_per_day``, returns HTTP 503
     with a Retry-After header pointing to the next midnight UTC reset.
 
+    Returns ``dict`` on success/skip and ``JSONResponse`` (subclass of
+    ``Response``) on circuit-breaker engagement.
+
     Idempotency: 1440-min daily window per contracts.md Contract 3.
     """
-    from datetime import UTC, datetime, time, timedelta
-
-    from fastapi.responses import JSONResponse
-
+    # Inline import: pulls in heartbeat planner Pydantic AI Agent factory;
+    # keep tasks.py module-import cheap for cron endpoints that don't use it.
     from nikita.db.repositories.heartbeat_repository import (
         NikitaDailyPlanRepository,
     )
@@ -1376,6 +1380,16 @@ async def generate_daily_arcs(
         # ledger is not yet wired).
         ceiling = float(settings.heartbeat_cost_circuit_breaker_usd_per_day)
         get_today_cost = getattr(job_repo, "get_today_cost_usd", None)
+        if get_today_cost is None:
+            # Observability: ledger primitive not yet wired (215-A/E follow-up
+            # tracked in tasks.md). Without it, cost-breaker silently treats
+            # "today_cost = $0" — log explicitly so this degradation is visible
+            # rather than invisible (per QA iter-1 NITPICK).
+            logger.warning(
+                "[DAILY-ARCS] cost_breaker_degraded — JobExecutionRepository "
+                "lacks get_today_cost_usd; treating today_cost as $0 for FR-014 "
+                "ceiling check (ledger primitive deferred to 215-A/E follow-up)"
+            )
         if get_today_cost is not None:
             try:
                 today_cost = float(await get_today_cost())

--- a/nikita/api/routes/tasks.py
+++ b/nikita/api/routes/tasks.py
@@ -1254,17 +1254,22 @@ async def heartbeat_tick(
             errors = 0
 
             for user in to_process:
+                # R3 / AC-FR10-001: serialize concurrent ops against the same
+                # user. UUID → bigint via hashtext(). Use SESSION-scoped
+                # pg_advisory_lock + explicit pg_advisory_unlock in try/finally
+                # so the lock releases at end-of-USER (not end-of-tick) — fixes
+                # PR #334 QA review iter-1 finding that xact-scoped locks pile
+                # up across the 40-user fan-out and inflate per-user wait time.
+                lock_key_row = await session.execute(
+                    sql_text("SELECT hashtext(:uid)::bigint AS k"),
+                    {"uid": str(user.id)},
+                )
+                lock_key = lock_key_row.scalar_one()
+                await session.execute(
+                    sql_text("SELECT pg_advisory_lock(:k)"),
+                    {"k": lock_key},
+                )
                 try:
-                    # R3 / AC-FR10-001: serialize concurrent ops against the
-                    # same user. UUID → bigint via hashtext(); xact-scoped so
-                    # it auto-releases when the per-user work completes.
-                    await session.execute(
-                        sql_text(
-                            "SELECT pg_advisory_xact_lock(hashtext(:uid)::bigint)"
-                        ),
-                        {"uid": str(user.id)},
-                    )
-
                     # R1 / FR-007: delegate; never write scheduled_events here.
                     await engine.evaluate_and_schedule_for_user(user_id=user.id)
                     processed += 1
@@ -1276,6 +1281,14 @@ async def heartbeat_tick(
                         "[HEARTBEAT] Per-user failure for %s: %s",
                         user.id,
                         type(user_err).__name__,
+                    )
+                finally:
+                    # Release lock immediately after this user's work; do NOT
+                    # wait until end-of-tick (would serialize all 40 users
+                    # against any concurrent tick that arrived mid-loop).
+                    await session.execute(
+                        sql_text("SELECT pg_advisory_unlock(:k)"),
+                        {"k": lock_key},
                     )
 
             await session.commit()

--- a/nikita/api/routes/tasks.py
+++ b/nikita/api/routes/tasks.py
@@ -1159,7 +1159,9 @@ async def resolve_stale_boss_fights(
 #   R1 / FR-007: heartbeat MUST NOT write scheduled_events directly — it
 #                delegates to TouchpointEngine.evaluate_and_schedule_for_user.
 #   R2 / FR-009: idempotency via JobExecutionRepository.has_recent_execution.
-#   R3 / FR-010: per-user pg_advisory_xact_lock(hashtext(user_id::text)::bigint).
+#   R3 / FR-010: per-user pg_advisory_lock(hashtext(user_id::text)::bigint)
+#                with explicit pg_advisory_unlock in try/finally (session-scoped,
+#                NOT xact-scoped — released per-user, not piled across the tick).
 #   R4         : fan-out cap = 40 per tick (leaves 10-row /tasks/deliver headroom).
 #   G1 / FR-008: filter active|boss_fight + telegram_id + recent interaction.
 #   FR-014     : daily-arc handler engages a 503 + Retry-After breaker when
@@ -1209,8 +1211,9 @@ async def heartbeat_tick(
     Idempotency: 55-min window via JobExecutionRepository.has_recent_execution
     (R2 / AC-FR9-001).
 
-    Concurrency: per-user pg_advisory_xact_lock serializes simultaneous
-    operations against the same user (R3 / AC-FR10-001).
+    Concurrency: per-user pg_advisory_lock + pg_advisory_unlock in try/finally
+    serializes simultaneous operations against the same user; session-scoped so
+    locks release per-user inside the tick, not pile up to commit (R3 / AC-FR10-001).
 
     Fan-out cap: 40 users per tick (R4) — overflow surfaces as
     ``deferred`` for next-tick processing.

--- a/nikita/api/routes/tasks.py
+++ b/nikita/api/routes/tasks.py
@@ -1141,3 +1141,320 @@ async def resolve_stale_boss_fights(
             await job_repo.fail_execution(execution.id, result=result_err)
             await session.commit()
             return result_err
+
+
+# ----------------------------------------------------------------------------
+# Spec 215 PR 215-D — Heartbeat Engine API endpoints (US-1 + US-2)
+# ----------------------------------------------------------------------------
+#
+# These endpoints are pg_cron-driven (registration lives in 215-E):
+#   POST /tasks/heartbeat            — every hour (FR-005 safety-net floor)
+#   POST /tasks/generate-daily-arcs  — once per day at 5 AM UTC
+#
+# Both mirror /refresh-voice-prompts above for auth + idempotency-guard pattern.
+# Brief constraints (Plan v6.3 P2 + spec.md):
+#   R1 / FR-007: heartbeat MUST NOT write scheduled_events directly — it
+#                delegates to TouchpointEngine.evaluate_and_schedule_for_user.
+#   R2 / FR-009: idempotency via JobExecutionRepository.has_recent_execution.
+#   R3 / FR-010: per-user pg_advisory_xact_lock(hashtext(user_id::text)::bigint).
+#   R4         : fan-out cap = 40 per tick (leaves 10-row /tasks/deliver headroom).
+#   G1 / FR-008: filter active|boss_fight + telegram_id + recent interaction.
+#   FR-014     : daily-arc handler engages a 503 + Retry-After breaker when
+#                today's aggregate cost crosses the configured ceiling.
+#   FR-015     : error envelopes are redacted — never leak str(exception).
+#   FR-020     : feature flag heartbeat_engine_enabled gates all work.
+
+# Heartbeat fan-out cap per safety-net tick (FR-005 + R4).
+# Leaves headroom for /tasks/deliver (10 row chunk, separate cron).
+_HEARTBEAT_FAN_OUT_CAP: int = 40
+
+# Idempotency window for the hourly heartbeat tick (AC-FR9-001 + contracts.md
+# Contract 3). Set < 60min so consecutive hour-boundary cron fires (e.g. 12:00
+# + 12:55) do NOT short-circuit each other unnecessarily.
+_HEARTBEAT_IDEMPOTENCY_WINDOW_MINUTES: int = 55
+
+# Idempotency window for the daily-arc generator (contracts.md Contract 3).
+_DAILY_ARC_IDEMPOTENCY_WINDOW_MINUTES: int = 1440
+
+
+def _build_redacted_error_envelope(error_code: str) -> dict:
+    """FR-015: structured envelope with NO raw exception string.
+
+    Exception details get logged server-side (with exc_info=True) but the
+    response body MUST stay opaque to avoid leaking PII-adjacent payloads
+    (per-player parameters, prompt bodies, internal state).
+    """
+    return {
+        "status": "error",
+        "error": error_code,
+        "detail": "internal error; see server logs",
+    }
+
+
+@router.post("/heartbeat")
+async def heartbeat_tick(
+    _: None = Depends(verify_task_secret),
+) -> dict:
+    """Hourly safety-net heartbeat tick (Spec 215 FR-005, US-2).
+
+    Iterates over active heartbeat-eligible users and delegates each to
+    TouchpointEngine.evaluate_and_schedule_for_user, which decides whether
+    to schedule a proactive touchpoint. Per FR-007/R1 the handler NEVER
+    writes scheduled_events directly — that responsibility lives in the
+    touchpoint engine + dispatcher.
+
+    Idempotency: 55-min window via JobExecutionRepository.has_recent_execution
+    (R2 / AC-FR9-001).
+
+    Concurrency: per-user pg_advisory_xact_lock serializes simultaneous
+    operations against the same user (R3 / AC-FR10-001).
+
+    Fan-out cap: 40 users per tick (R4) — overflow surfaces as
+    ``deferred`` for next-tick processing.
+    """
+    from sqlalchemy import text as sql_text
+
+    from nikita.db.repositories.user_repository import UserRepository
+    from nikita.touchpoints.engine import TouchpointEngine
+
+    settings = get_settings()
+
+    # FR-020: feature flag short-circuit (no DB writes when disabled).
+    if not settings.heartbeat_engine_enabled:
+        logger.info("[HEARTBEAT] Skipped — heartbeat_engine_enabled=false")
+        return {"status": "disabled", "reason": "feature_flag_off"}
+
+    session_maker = get_session_maker()
+    async with session_maker() as session:
+        job_repo = JobExecutionRepository(session)
+
+        # R2 / AC-FR9-001: idempotency guard. Window < 60min so back-to-back
+        # cron fires don't suppress each other unnecessarily.
+        if await job_repo.has_recent_execution(
+            JobName.HEARTBEAT.value,
+            window_minutes=_HEARTBEAT_IDEMPOTENCY_WINDOW_MINUTES,
+        ):
+            logger.info("[HEARTBEAT] Skipped — recent execution within 55 min")
+            return {"status": "skipped", "reason": "recent_execution"}
+
+        execution = await job_repo.start_execution(JobName.HEARTBEAT.value)
+        await session.commit()
+
+        try:
+            user_repo = UserRepository(session)
+            # G1: active|boss_fight + telegram_id + recent interaction
+            eligible = await user_repo.get_active_users_for_heartbeat()
+
+            # R4: fan-out cap. Anything over the cap is deferred to next tick.
+            to_process = eligible[:_HEARTBEAT_FAN_OUT_CAP]
+            deferred = max(0, len(eligible) - len(to_process))
+
+            engine = TouchpointEngine(session)
+            processed = 0
+            errors = 0
+
+            for user in to_process:
+                try:
+                    # R3 / AC-FR10-001: serialize concurrent ops against the
+                    # same user. UUID → bigint via hashtext(); xact-scoped so
+                    # it auto-releases when the per-user work completes.
+                    await session.execute(
+                        sql_text(
+                            "SELECT pg_advisory_xact_lock(hashtext(:uid)::bigint)"
+                        ),
+                        {"uid": str(user.id)},
+                    )
+
+                    # R1 / FR-007: delegate; never write scheduled_events here.
+                    await engine.evaluate_and_schedule_for_user(user_id=user.id)
+                    processed += 1
+                except Exception as user_err:
+                    errors += 1
+                    # PII discipline: log only the user_id and class name; never
+                    # full str(user_err) which may include arc/narrative content.
+                    logger.warning(
+                        "[HEARTBEAT] Per-user failure for %s: %s",
+                        user.id,
+                        type(user_err).__name__,
+                    )
+
+            await session.commit()
+
+            result = {
+                "status": "ok",
+                "processed": processed,
+                "errors": errors,
+                "deferred": deferred,
+            }
+            await job_repo.complete_execution(execution.id, result=result)
+            await session.commit()
+
+            logger.info(
+                "[HEARTBEAT] Processed %d, errors %d, deferred %d",
+                processed, errors, deferred,
+            )
+            return result
+
+        except Exception as e:
+            # FR-015: redact for response; full trace lives in server logs.
+            logger.error("[HEARTBEAT] Catastrophic error: %s", e, exc_info=True)
+            envelope = _build_redacted_error_envelope("heartbeat_failed")
+            await job_repo.fail_execution(
+                execution.id,
+                result={"status": "error", "error": "heartbeat_failed"},
+            )
+            await session.commit()
+            return envelope
+
+
+@router.post("/generate-daily-arcs")
+async def generate_daily_arcs(
+    _: None = Depends(verify_task_secret),
+) -> dict:
+    """Daily-arc generation for all heartbeat-eligible users (Spec 215 US-1).
+
+    Calls the LLM-driven planner (``nikita.heartbeat.planner.generate_daily_arc``)
+    once per active user per day and persists the result via
+    ``NikitaDailyPlanRepository.upsert_plan``.
+
+    Storage contract is FROZEN per ``specs/215-heartbeat-engine/contracts.md``
+    Contract 1 (locked 2026-04-18). The Pydantic field ``DailyArc.narrative``
+    maps to the repo kwarg ``narrative_text`` (intentional divergence — see
+    contracts.md for rationale).
+
+    Cost guard (FR-014): if today's aggregate USD cost crosses
+    ``settings.heartbeat_cost_circuit_breaker_usd_per_day``, returns HTTP 503
+    with a Retry-After header pointing to the next midnight UTC reset.
+
+    Idempotency: 1440-min daily window per contracts.md Contract 3.
+    """
+    from datetime import UTC, datetime, time, timedelta
+
+    from fastapi.responses import JSONResponse
+
+    from nikita.db.repositories.heartbeat_repository import (
+        NikitaDailyPlanRepository,
+    )
+    from nikita.db.repositories.user_repository import UserRepository
+    from nikita.heartbeat import planner as planner_module
+
+    settings = get_settings()
+
+    if not settings.heartbeat_engine_enabled:
+        logger.info("[DAILY-ARCS] Skipped — heartbeat_engine_enabled=false")
+        return {"status": "disabled", "reason": "feature_flag_off"}
+
+    session_maker = get_session_maker()
+    async with session_maker() as session:
+        job_repo = JobExecutionRepository(session)
+
+        # Daily idempotency guard (contracts.md Contract 3 — 1440 min window).
+        if await job_repo.has_recent_execution(
+            JobName.GENERATE_DAILY_ARCS.value,
+            window_minutes=_DAILY_ARC_IDEMPOTENCY_WINDOW_MINUTES,
+        ):
+            logger.info("[DAILY-ARCS] Skipped — recent execution within 24h")
+            return {"status": "skipped", "reason": "recent_execution"}
+
+        # FR-014 cost circuit breaker: best-effort lookup of today's aggregate
+        # cost via the JobExecutionRepository. The ledger primitive itself
+        # ships in 215-A/E follow-up; here we tolerate either a present or
+        # missing get_today_cost_usd method (graceful degradation when the
+        # ledger is not yet wired).
+        ceiling = float(settings.heartbeat_cost_circuit_breaker_usd_per_day)
+        get_today_cost = getattr(job_repo, "get_today_cost_usd", None)
+        if get_today_cost is not None:
+            try:
+                today_cost = float(await get_today_cost())
+            except Exception:  # noqa: BLE001 - ledger optional in PR 215-D
+                today_cost = 0.0
+
+            if today_cost >= ceiling:
+                # FR-014(a): structured 503 + Retry-After to next midnight UTC.
+                now_utc = datetime.now(UTC)
+                tomorrow = (now_utc + timedelta(days=1)).date()
+                next_reset = datetime.combine(tomorrow, time(0, 0), tzinfo=UTC)
+                retry_after_seconds = max(1, int((next_reset - now_utc).total_seconds()))
+                logger.warning(
+                    "[DAILY-ARCS] circuit_breaker_engaged — today_cost=%.2f USD "
+                    "ceiling=%.2f USD; deferring %d s",
+                    today_cost, ceiling, retry_after_seconds,
+                )
+                return JSONResponse(
+                    status_code=503,
+                    headers={"Retry-After": str(retry_after_seconds)},
+                    content={
+                        "status": "throttled",
+                        "reason": "cost_circuit_breaker_engaged",
+                    },
+                )
+
+        execution = await job_repo.start_execution(
+            JobName.GENERATE_DAILY_ARCS.value
+        )
+        await session.commit()
+
+        try:
+            user_repo = UserRepository(session)
+            plan_repo = NikitaDailyPlanRepository(session)
+
+            # Reuse the same G1 filter as the heartbeat tick — same eligibility
+            # criteria; users in game_over / won are excluded (FR-008 + OD4).
+            eligible = await user_repo.get_active_users_for_heartbeat()
+            today = datetime.now(UTC).date()
+
+            generated = 0
+            errors = 0
+
+            for user in eligible:
+                try:
+                    arc = await planner_module.generate_daily_arc(
+                        user=user, plan_date=today, session=session,
+                    )
+                    # Storage contract per contracts.md Contract 1 (FROZEN):
+                    #   arc_json wraps steps under {"steps": [...]}
+                    #   narrative_text repo kwarg = arc.narrative Pydantic field
+                    #   model_used pass-through
+                    await plan_repo.upsert_plan(
+                        user_id=user.id,
+                        plan_date=today,
+                        arc_json={
+                            "steps": [step.model_dump() for step in arc.steps]
+                        },
+                        narrative_text=arc.narrative,
+                        model_used=arc.model_used,
+                    )
+                    generated += 1
+                except Exception as user_err:
+                    errors += 1
+                    logger.warning(
+                        "[DAILY-ARCS] Per-user planner failure for %s: %s",
+                        user.id,
+                        type(user_err).__name__,
+                    )
+
+            await session.commit()
+
+            result = {
+                "status": "ok",
+                "generated": generated,
+                "errors": errors,
+            }
+            await job_repo.complete_execution(execution.id, result=result)
+            await session.commit()
+
+            logger.info(
+                "[DAILY-ARCS] Generated %d arcs, %d errors",
+                generated, errors,
+            )
+            return result
+
+        except Exception as e:
+            logger.error("[DAILY-ARCS] Catastrophic error: %s", e, exc_info=True)
+            envelope = _build_redacted_error_envelope("generate_daily_arcs_failed")
+            await job_repo.fail_execution(
+                execution.id,
+                result={"status": "error", "error": "generate_daily_arcs_failed"},
+            )
+            await session.commit()
+            return envelope

--- a/nikita/db/models/job_execution.py
+++ b/nikita/db/models/job_execution.py
@@ -26,6 +26,8 @@ class JobName(str, Enum):
     POST_PROCESSING = "post_processing"  # Spec 031: Individual conversation processing
     PSYCHE_BATCH = "psyche_batch"  # Spec 056: Daily psyche state generation
     REFRESH_VOICE_PROMPTS = "refresh_voice_prompts"  # Spec 209: Voice prompt refresh cron
+    HEARTBEAT = "heartbeat"  # Spec 215 PR 215-D: Hourly heartbeat tick (FR-005 safety net)
+    GENERATE_DAILY_ARCS = "generate_daily_arcs"  # Spec 215 PR 215-D: Daily-arc generation cron
 
 
 class JobStatus(str, Enum):

--- a/nikita/db/repositories/user_repository.py
+++ b/nikita/db/repositories/user_repository.py
@@ -1264,3 +1264,42 @@ class UserRepository(BaseRepository[User]):
         )
         result = await self.session.execute(stmt)
         return result.scalar_one()
+
+    async def get_active_users_for_heartbeat(
+        self,
+        recency_days: int = 14,
+        limit: int = 1000,
+    ) -> list[User]:
+        """Get users eligible for the Heartbeat Engine (Spec 215 PR 215-D, G1 filter).
+
+        Selection criteria (per spec.md FR-008 + brief G1):
+        - ``game_status`` is ``active`` or ``boss_fight`` (exclude ``game_over``
+          and ``won`` per FR-008 + OD4 default)
+        - ``telegram_id IS NOT NULL`` (heartbeat is text-only Phase 1 per OD6)
+        - ``last_interaction_at`` within the last ``recency_days`` days (avoid
+          churning over ghost accounts that abandoned the game)
+
+        The /tasks/heartbeat handler caps actual fan-out to 40/tick (R4); the
+        ``limit`` here is a sanity ceiling on the underlying DB scan.
+
+        Args:
+            recency_days: Skip users with no interaction in this many days.
+            limit: Hard ceiling on rows returned (defense in depth).
+
+        Returns:
+            List of User objects eligible for a heartbeat tick. Order is
+            unspecified — callers MUST NOT rely on it.
+        """
+        recency_cutoff = datetime.now(UTC) - timedelta(days=recency_days)
+        stmt = (
+            select(User)
+            .where(
+                User.game_status.in_(("active", "boss_fight")),
+                User.telegram_id.is_not(None),
+                User.last_interaction_at.is_not(None),
+                User.last_interaction_at > recency_cutoff,
+            )
+            .limit(limit)
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())

--- a/tests/api/routes/test_tasks_generate_daily_arcs.py
+++ b/tests/api/routes/test_tasks_generate_daily_arcs.py
@@ -1,0 +1,428 @@
+"""Tests for /tasks/generate-daily-arcs endpoint (Spec 215 PR 215-D, US-1).
+
+Spec ACs covered:
+- AC-FR2-001: plan persisted with both forms (arc_json + narrative_text)
+- AC-FR2-002: idempotent — second run same date upserts in-place (one row)
+- AC-FR8-001: game_over users skipped (G1 + FR-008/OD4 also skips 'won')
+- FR-014: cost circuit breaker — 503 + Retry-After when daily ceiling reached
+- FR-015: error envelope shape — no str(e) leak
+
+Storage contract (contracts.md Contract 1, FROZEN 2026-04-18):
+    arc_json={"steps": [step.model_dump() for step in arc.steps]}
+    narrative_text=arc.narrative
+    model_used=arc.model_used
+
+Field-name divergence is intentional: Pydantic `DailyArc.narrative` maps to
+repo kwarg `narrative_text` (DB column also `narrative_text`).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from nikita.api.routes.tasks import router
+from nikita.db.models.job_execution import JobName
+from nikita.heartbeat.planner import ArcStep, DailyArc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app():
+    """Create test FastAPI app with tasks router."""
+    app = FastAPI()
+    app.include_router(router, prefix="/tasks")
+    return app
+
+
+@pytest.fixture
+async def client(app):
+    """Create async HTTP client."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _mock_settings(**overrides):
+    """Mock settings — heartbeat enabled, $50/day default ceiling."""
+    defaults = dict(
+        task_auth_secret=None,
+        telegram_webhook_secret=None,
+        heartbeat_engine_enabled=True,
+        heartbeat_cost_circuit_breaker_usd_per_day=50.0,
+    )
+    defaults.update(overrides)
+    return MagicMock(**defaults)
+
+
+def _mock_session_maker(mock_session):
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    mock_maker = MagicMock()
+    mock_maker.return_value = mock_ctx
+    return mock_maker
+
+
+def _make_user(**overrides):
+    """Mock User suitable for the daily-arc handler — active by default."""
+    defaults = dict(
+        id=uuid4(),
+        chapter=2,
+        game_status="active",
+        telegram_id=12345,
+        last_interaction_at=datetime.now(UTC) - timedelta(hours=2),
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _build_mock_arc():
+    """Build a deterministic DailyArc fixture for assertion-friendly tests."""
+    return DailyArc(
+        steps=[
+            ArcStep(at="08:00", state="morning routine", action=None),
+            ArcStep(at="12:00", state="lunch", action=None),
+            ArcStep(at="20:00", state="evening winddown", action=None),
+        ],
+        narrative="Test narrative for prompt injection.",
+        model_used="claude-haiku-4-5-20251001",
+    )
+
+
+# ---------------------------------------------------------------------------
+# JobName enum entry — Contract 2
+# ---------------------------------------------------------------------------
+
+
+class TestJobNameEnum:
+    """Spec 215 contracts.md Contract 2: GENERATE_DAILY_ARCS enum entry exists."""
+
+    def test_generate_daily_arcs_enum_entry_exists(self):
+        """JobName.GENERATE_DAILY_ARCS.value == 'generate_daily_arcs' per contracts.md."""
+        assert JobName.GENERATE_DAILY_ARCS.value == "generate_daily_arcs"
+
+
+# ---------------------------------------------------------------------------
+# /tasks/generate-daily-arcs — endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestGenerateDailyArcsEndpoint:
+    """Spec 215 PR 215-D: /tasks/generate-daily-arcs handler."""
+
+    async def test_auth_required_when_secret_configured(self, client):
+        """No Bearer token + secret configured → 401/403."""
+        with patch(
+            "nikita.api.routes.tasks.get_settings",
+            return_value=_mock_settings(task_auth_secret="real_secret"),
+        ):
+            response = await client.post("/tasks/generate-daily-arcs")
+
+        assert response.status_code in (401, 403)
+
+    async def test_idempotency_skips_when_recent_execution(self, client):
+        """Daily idempotency: 1440-min window per contracts.md Contract 3."""
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=True)
+        mock_job_repo.start_execution = AsyncMock()
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo):
+
+            response = await client.post("/tasks/generate-daily-arcs")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "skipped"
+        assert data["reason"] == "recent_execution"
+        mock_job_repo.start_execution.assert_not_called()
+
+        # 1440-min daily window per contracts.md Contract 3
+        first_call = mock_job_repo.has_recent_execution.call_args
+        assert first_call.kwargs.get("window_minutes") == 1440 or (
+            len(first_call.args) >= 2 and first_call.args[1] == 1440
+        )
+        # Job name = GENERATE_DAILY_ARCS
+        assert first_call.args[0] == JobName.GENERATE_DAILY_ARCS.value
+
+    async def test_storage_contract_field_mappings(self, client):
+        """Contract 1 storage shape (FROZEN): arc_json={"steps": [...]}, narrative_text, model_used."""
+        users = [_make_user()]
+        arc = _build_mock_arc()
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock(
+            return_value=SimpleNamespace(id=uuid4())
+        )
+        mock_job_repo.complete_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(return_value=users)
+
+        mock_plan_repo = AsyncMock()
+        mock_plan_repo.upsert_plan = AsyncMock(
+            return_value=SimpleNamespace(id=uuid4())
+        )
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo), \
+             patch(
+                 "nikita.db.repositories.heartbeat_repository.NikitaDailyPlanRepository",
+                 return_value=mock_plan_repo,
+             ), \
+             patch("nikita.heartbeat.planner.generate_daily_arc", AsyncMock(return_value=arc)):
+
+            response = await client.post("/tasks/generate-daily-arcs")
+
+        assert response.status_code == 200, response.text
+
+        # Verify the upsert was called with EXACTLY the contract field shapes
+        mock_plan_repo.upsert_plan.assert_awaited_once()
+        kwargs = mock_plan_repo.upsert_plan.call_args.kwargs
+
+        assert kwargs["user_id"] == users[0].id
+        assert isinstance(kwargs["plan_date"], date)
+
+        # Storage contract: arc_json wraps steps under {"steps": [...]}
+        assert "steps" in kwargs["arc_json"]
+        assert isinstance(kwargs["arc_json"]["steps"], list)
+        assert len(kwargs["arc_json"]["steps"]) == 3
+        # Each step is a serialized ArcStep dict (model_dump)
+        first_step = kwargs["arc_json"]["steps"][0]
+        assert first_step["at"] == "08:00"
+        assert first_step["state"] == "morning routine"
+
+        # narrative_text repo kwarg = arc.narrative Pydantic field (intentional divergence)
+        assert kwargs["narrative_text"] == arc.narrative
+
+        # model_used pass-through
+        assert kwargs["model_used"] == arc.model_used
+
+    async def test_skips_game_over_and_won_users(self, client):
+        """FR-008 + OD4: game_over and won users MUST NOT receive plans.
+
+        Active-user filter centralized in UserRepository.get_active_users_for_heartbeat;
+        the handler trusts the repo and never filters in-route.
+        """
+        # Repo returns ONLY active users (filter happened in repo)
+        active_user = _make_user(game_status="active")
+        users = [active_user]
+        arc = _build_mock_arc()
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock(
+            return_value=SimpleNamespace(id=uuid4())
+        )
+        mock_job_repo.complete_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(return_value=users)
+
+        mock_plan_repo = AsyncMock()
+        mock_plan_repo.upsert_plan = AsyncMock(return_value=SimpleNamespace(id=uuid4()))
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo), \
+             patch(
+                 "nikita.db.repositories.heartbeat_repository.NikitaDailyPlanRepository",
+                 return_value=mock_plan_repo,
+             ), \
+             patch("nikita.heartbeat.planner.generate_daily_arc", AsyncMock(return_value=arc)):
+
+            response = await client.post("/tasks/generate-daily-arcs")
+
+        # Active-user filter was used (FR-008/G1 enforced via the repo)
+        mock_user_repo.get_active_users_for_heartbeat.assert_awaited_once()
+        # Only the one active user got a plan
+        assert mock_plan_repo.upsert_plan.await_count == 1
+
+    async def test_cost_circuit_breaker_returns_503_with_retry_after(self, client):
+        """FR-014(a): daily-aggregate ceiling reached → 503 + Retry-After (next midnight UTC)."""
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock()
+        # Ceiling reached: simulate cost ledger reporting >= 50.0 USD spent today
+        mock_job_repo.get_today_cost_usd = AsyncMock(return_value=99.99)
+
+        with patch(
+            "nikita.api.routes.tasks.get_settings",
+            return_value=_mock_settings(heartbeat_cost_circuit_breaker_usd_per_day=50.0),
+        ), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo):
+
+            response = await client.post("/tasks/generate-daily-arcs")
+
+        assert response.status_code == 503
+        # Retry-After is present and non-empty
+        assert "retry-after" in {k.lower() for k in response.headers.keys()}
+        # Body should NOT include raw cost ledger numbers (just a graceful-degradation note)
+        # Just confirm it's a structured envelope
+        # We allow either text seconds or HTTP-date format
+        retry_after = response.headers.get("retry-after") or response.headers.get(
+            "Retry-After"
+        )
+        assert retry_after is not None and len(retry_after) > 0
+
+    async def test_feature_flag_off_short_circuits(self, client):
+        """FR-020 rollback: heartbeat_engine_enabled=False → no plans generated."""
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(return_value=[])
+
+        mock_plan_repo = AsyncMock()
+        mock_plan_repo.upsert_plan = AsyncMock()
+
+        with patch(
+            "nikita.api.routes.tasks.get_settings",
+            return_value=_mock_settings(heartbeat_engine_enabled=False),
+        ), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo), \
+             patch(
+                 "nikita.db.repositories.heartbeat_repository.NikitaDailyPlanRepository",
+                 return_value=mock_plan_repo,
+             ):
+
+            response = await client.post("/tasks/generate-daily-arcs")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "disabled"
+        mock_plan_repo.upsert_plan.assert_not_called()
+        mock_user_repo.get_active_users_for_heartbeat.assert_not_called()
+
+    async def test_per_user_error_isolation(self, client):
+        """1-of-3 planner errors → others succeed; status remains ok."""
+        users = [_make_user() for _ in range(3)]
+        arc = _build_mock_arc()
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock(
+            return_value=SimpleNamespace(id=uuid4())
+        )
+        mock_job_repo.complete_execution = AsyncMock()
+        mock_job_repo.fail_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(return_value=users)
+
+        mock_plan_repo = AsyncMock()
+        mock_plan_repo.upsert_plan = AsyncMock(
+            return_value=SimpleNamespace(id=uuid4())
+        )
+
+        call_count = 0
+
+        async def _planner_side_effect(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("LLM transient failure")
+            return arc
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo), \
+             patch(
+                 "nikita.db.repositories.heartbeat_repository.NikitaDailyPlanRepository",
+                 return_value=mock_plan_repo,
+             ), \
+             patch(
+                 "nikita.heartbeat.planner.generate_daily_arc",
+                 AsyncMock(side_effect=_planner_side_effect),
+             ):
+
+            response = await client.post("/tasks/generate-daily-arcs")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["generated"] == 2
+        assert data["errors"] == 1
+        # Job completed (graceful degradation), not failed
+        mock_job_repo.complete_execution.assert_awaited_once()
+        mock_job_repo.fail_execution.assert_not_called()
+
+    async def test_error_envelope_redacts_exception_string(self, client):
+        """FR-015: catastrophic failure must NOT leak str(exception) into response."""
+        secret_token = "PII_SECRET_DAILY_ARCS_xyzzy"
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock(
+            return_value=SimpleNamespace(id=uuid4())
+        )
+        mock_job_repo.fail_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(
+            side_effect=RuntimeError(f"db unavailable: {secret_token}")
+        )
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo):
+
+            response = await client.post("/tasks/generate-daily-arcs")
+
+        data = response.json()
+        assert data["status"] == "error"
+        assert secret_token not in response.text, (
+            "FR-015 violation: raw exception string leaked into response payload"
+        )
+        mock_job_repo.fail_execution.assert_awaited_once()

--- a/tests/api/routes/test_tasks_heartbeat.py
+++ b/tests/api/routes/test_tasks_heartbeat.py
@@ -482,3 +482,28 @@ class TestHeartbeatEndpoint:
         mock_engine.evaluate_and_schedule_for_user.assert_not_called()
         mock_user_repo.get_active_users_for_heartbeat.assert_not_called()
         mock_job_repo.start_execution.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tuning constant regression guard (per .claude/rules/tuning-constants.md)
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_fan_out_cap_is_40_per_R4():
+    """R4 + FR-005: fan-out cap MUST stay at 40 per tick.
+
+    Coupling rationale: /tasks/deliver consumes from the same scheduled_events
+    queue with a 50-row chunk. Heartbeat capacity = 40 leaves 10-row headroom
+    so the deliver worker isn't starved by heartbeat-generated touchpoints
+    landing in the same window.
+
+    If you intentionally change this value, update:
+    - nikita/api/routes/tasks.py:_HEARTBEAT_FAN_OUT_CAP
+    - specs/215-heartbeat-engine/spec.md FR-005 / R4 capacity reasoning
+    - this regression test
+    """
+    from nikita.api.routes.tasks import _HEARTBEAT_FAN_OUT_CAP
+
+    assert _HEARTBEAT_FAN_OUT_CAP == 40, (
+        "Heartbeat fan-out cap drift: see R4/FR-005 for capacity reasoning."
+    )

--- a/tests/api/routes/test_tasks_heartbeat.py
+++ b/tests/api/routes/test_tasks_heartbeat.py
@@ -299,13 +299,21 @@ class TestHeartbeatEndpoint:
         }
         assert delegated_user_ids == {u.id for u in users}
 
-    async def test_advisory_lock_acquired_per_user(self, client):
-        """R3 (day-1): handler MUST issue pg_advisory_xact_lock for each processed user."""
+    async def test_advisory_lock_acquired_and_released_per_user(self, client):
+        """R3 (day-1): handler MUST acquire pg_advisory_lock + pg_advisory_unlock per user.
+
+        Updated PR #334 iter-2: switched from pg_advisory_xact_lock (xact-scoped)
+        to pg_advisory_lock + explicit pg_advisory_unlock so locks release at
+        end-of-USER not end-of-tick (avoids 40-user lock pile-up across the
+        single-transaction fan-out).
+        """
         users = [_make_user() for _ in range(2)]
 
         mock_session = AsyncMock()
         mock_session.commit = AsyncMock()
-        mock_session.execute = AsyncMock()
+        # session.execute(SELECT hashtext(...))).scalar_one() must return an int
+        mock_result = SimpleNamespace(scalar_one=lambda: 12345)
+        mock_session.execute = AsyncMock(return_value=mock_result)
         mock_maker = _mock_session_maker(mock_session)
 
         mock_job_repo = AsyncMock()
@@ -329,17 +337,24 @@ class TestHeartbeatEndpoint:
             response = await client.post("/tasks/heartbeat")
 
         assert response.status_code == 200
-        # Inspect SQL statements issued via session.execute — at least one must
-        # contain "pg_advisory_xact_lock". The handler must invoke it per user
-        # before delegating.
         executed_sql = []
         for call in mock_session.execute.call_args_list:
             stmt = call.args[0] if call.args else call.kwargs.get("statement")
             executed_sql.append(str(stmt))
 
-        advisory_calls = [s for s in executed_sql if "pg_advisory_xact_lock" in s]
-        assert len(advisory_calls) >= len(users), (
-            f"Expected pg_advisory_xact_lock for each user; got {advisory_calls}"
+        # Must see hashtext key derivation, advisory_lock, and advisory_unlock per user
+        hashtext_calls = [s for s in executed_sql if "hashtext" in s]
+        lock_calls = [s for s in executed_sql if "pg_advisory_lock" in s and "unlock" not in s]
+        unlock_calls = [s for s in executed_sql if "pg_advisory_unlock" in s]
+
+        assert len(hashtext_calls) >= len(users), (
+            f"Expected hashtext key derivation per user; got {hashtext_calls}"
+        )
+        assert len(lock_calls) >= len(users), (
+            f"Expected pg_advisory_lock per user; got {lock_calls}"
+        )
+        assert len(unlock_calls) >= len(users), (
+            f"Expected pg_advisory_unlock per user (try/finally release); got {unlock_calls}"
         )
 
     async def test_per_user_error_isolation(self, client):

--- a/tests/api/routes/test_tasks_heartbeat.py
+++ b/tests/api/routes/test_tasks_heartbeat.py
@@ -1,0 +1,469 @@
+"""Tests for /tasks/heartbeat endpoint (Spec 215 PR 215-D, US-2).
+
+Spec ACs covered:
+- AC-FR5-001: at least one heartbeat invocation per active player per hour
+- AC-FR9-001: idempotent — second tick within 55-min window returns "skipped"
+- AC-FR10-001: per-user advisory lock serializes concurrent operations (R3)
+- FR-007: handler MUST delegate to TouchpointEngine, never write
+  scheduled_events directly (R1)
+- FR-008: skip users in game_over and won states (G1)
+- FR-014: cost circuit breaker leaves heartbeat alone (cost guard lives on
+  /tasks/generate-daily-arcs in this PR; heartbeat is cheap)
+- FR-015: error envelope shape — no str(e) leak
+
+Brief scope (R2/R3/R4/G1):
+- R2: idempotency guard via JobExecutionRepository.has_recent_execution
+- R3: pg_advisory_xact_lock per user (day-1)
+- R4: bounded fan-out (max 40 per tick — leaves 10-row /tasks/deliver headroom)
+- G1: active-user filter (game_status active|boss_fight + telegram_id IS NOT NULL +
+  recent interaction)
+
+These tests are EXTENSIVELY mock-based per project test rules. Real DB and
+real TouchpointEngine integration happens in tests/heartbeat E2E (out of scope
+for this PR).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from nikita.api.routes.tasks import router
+from nikita.db.models.job_execution import JobName
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app():
+    """Create test FastAPI app with tasks router."""
+    app = FastAPI()
+    app.include_router(router, prefix="/tasks")
+    return app
+
+
+@pytest.fixture
+async def client(app):
+    """Create async HTTP client."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _mock_settings(**overrides):
+    """Create mock settings with task auth bypass + heartbeat flag on by default."""
+    defaults = dict(
+        task_auth_secret=None,
+        telegram_webhook_secret=None,
+        heartbeat_engine_enabled=True,
+        heartbeat_cost_circuit_breaker_usd_per_day=50.0,
+    )
+    defaults.update(overrides)
+    return MagicMock(**defaults)
+
+
+def _mock_session_maker(mock_session):
+    """Mock session_maker returning async context manager yielding mock_session."""
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    mock_maker = MagicMock()
+    mock_maker.return_value = mock_ctx
+    return mock_maker
+
+
+def _make_user(**overrides):
+    """Create mock User suitable for the heartbeat handler (active + telegram-bound)."""
+    defaults = dict(
+        id=uuid4(),
+        chapter=2,
+        game_status="active",
+        telegram_id=12345,
+        last_interaction_at=datetime.now(UTC) - timedelta(hours=4),
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _build_mock_engine():
+    """Build a mocked TouchpointEngine that returns a stand-in scheduled touchpoint."""
+    eng = AsyncMock()
+    eng.evaluate_and_schedule_for_user = AsyncMock(
+        return_value=SimpleNamespace(id=uuid4())
+    )
+    return eng
+
+
+# ---------------------------------------------------------------------------
+# JobName enum entry — Contract 2 (215-D ships, 215-E references)
+# ---------------------------------------------------------------------------
+
+
+class TestJobNameEnum:
+    """Spec 215 contracts.md Contract 2: HEARTBEAT enum entry exists."""
+
+    def test_heartbeat_enum_entry_exists(self):
+        """JobName.HEARTBEAT.value == 'heartbeat' per contracts.md Contract 2."""
+        assert JobName.HEARTBEAT.value == "heartbeat"
+
+    def test_existing_enum_entries_unchanged(self):
+        """Pre-existing enum values not broken by the additive change."""
+        assert JobName.DECAY.value == "decay"
+        assert JobName.REFRESH_VOICE_PROMPTS.value == "refresh_voice_prompts"
+
+
+# ---------------------------------------------------------------------------
+# /tasks/heartbeat — endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestHeartbeatEndpoint:
+    """Spec 215 PR 215-D: /tasks/heartbeat handler."""
+
+    async def test_auth_required_when_secret_configured(self, client):
+        """No Bearer token + secret configured → 401/403 (mirrors verify_task_secret)."""
+        mock_settings = _mock_settings(task_auth_secret="real_secret")
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=mock_settings):
+            response = await client.post("/tasks/heartbeat")
+
+        assert response.status_code in (401, 403)
+
+    async def test_idempotency_skips_when_recent_execution(self, client):
+        """AC-FR9-001 (R2): has_recent_execution(window=55) True → skip + no work."""
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=True)
+        mock_job_repo.start_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(return_value=[])
+
+        mock_engine = _build_mock_engine()
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo), \
+             patch("nikita.touchpoints.engine.TouchpointEngine", return_value=mock_engine):
+
+            response = await client.post("/tasks/heartbeat")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "skipped"
+        assert data["reason"] == "recent_execution"
+        # No work happened: no execution record opened, no engine touched.
+        mock_job_repo.start_execution.assert_not_called()
+        mock_engine.evaluate_and_schedule_for_user.assert_not_called()
+
+        # AC-FR9-001 confirms the 55-min window value
+        mock_job_repo.has_recent_execution.assert_awaited_once()
+        call_kwargs = mock_job_repo.has_recent_execution.call_args
+        # Either positional or kwarg form
+        assert call_kwargs.kwargs.get("window_minutes") == 55 or (
+            len(call_kwargs.args) >= 2 and call_kwargs.args[1] == 55
+        )
+
+    async def test_idempotency_uses_heartbeat_job_name(self, client):
+        """has_recent_execution called with JobName.HEARTBEAT.value."""
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=True)
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo):
+
+            await client.post("/tasks/heartbeat")
+
+        mock_job_repo.has_recent_execution.assert_awaited_once()
+        first_arg = mock_job_repo.has_recent_execution.call_args.args[0]
+        assert first_arg == JobName.HEARTBEAT.value == "heartbeat"
+
+    async def test_active_user_filter_called_with_telegram_and_recency(self, client):
+        """G1: handler calls UserRepository.get_active_users_for_heartbeat (centralized filter)."""
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock(
+            return_value=SimpleNamespace(id=uuid4())
+        )
+        mock_job_repo.complete_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(return_value=[])
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo):
+
+            response = await client.post("/tasks/heartbeat")
+
+        assert response.status_code == 200
+        mock_user_repo.get_active_users_for_heartbeat.assert_awaited_once()
+
+    async def test_fan_out_capped_at_40(self, client):
+        """R4: when 100 active users exist, only 40 are processed in this tick."""
+        users = [_make_user() for _ in range(100)]
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock(
+            return_value=SimpleNamespace(id=uuid4())
+        )
+        mock_job_repo.complete_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(return_value=users)
+
+        mock_engine = _build_mock_engine()
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo), \
+             patch("nikita.touchpoints.engine.TouchpointEngine", return_value=mock_engine):
+
+            response = await client.post("/tasks/heartbeat")
+
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["processed"] == 40
+        assert data["deferred"] == 60
+        assert mock_engine.evaluate_and_schedule_for_user.await_count == 40
+
+    async def test_delegates_to_touchpoint_engine_per_user(self, client):
+        """FR-007 / R1: handler MUST call TouchpointEngine.evaluate_and_schedule_for_user;
+        MUST NOT write to scheduled_events directly."""
+        users = [_make_user() for _ in range(3)]
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock(
+            return_value=SimpleNamespace(id=uuid4())
+        )
+        mock_job_repo.complete_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(return_value=users)
+
+        mock_engine = _build_mock_engine()
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo), \
+             patch("nikita.touchpoints.engine.TouchpointEngine", return_value=mock_engine):
+
+            response = await client.post("/tasks/heartbeat")
+
+        assert response.status_code == 200
+        # Exactly 3 user_ids, each delegated
+        assert mock_engine.evaluate_and_schedule_for_user.await_count == 3
+        delegated_user_ids = {
+            call.kwargs.get("user_id") or call.args[0]
+            for call in mock_engine.evaluate_and_schedule_for_user.call_args_list
+        }
+        assert delegated_user_ids == {u.id for u in users}
+
+    async def test_advisory_lock_acquired_per_user(self, client):
+        """R3 (day-1): handler MUST issue pg_advisory_xact_lock for each processed user."""
+        users = [_make_user() for _ in range(2)]
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock(
+            return_value=SimpleNamespace(id=uuid4())
+        )
+        mock_job_repo.complete_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(return_value=users)
+
+        mock_engine = _build_mock_engine()
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo), \
+             patch("nikita.touchpoints.engine.TouchpointEngine", return_value=mock_engine):
+
+            response = await client.post("/tasks/heartbeat")
+
+        assert response.status_code == 200
+        # Inspect SQL statements issued via session.execute — at least one must
+        # contain "pg_advisory_xact_lock". The handler must invoke it per user
+        # before delegating.
+        executed_sql = []
+        for call in mock_session.execute.call_args_list:
+            stmt = call.args[0] if call.args else call.kwargs.get("statement")
+            executed_sql.append(str(stmt))
+
+        advisory_calls = [s for s in executed_sql if "pg_advisory_xact_lock" in s]
+        assert len(advisory_calls) >= len(users), (
+            f"Expected pg_advisory_xact_lock for each user; got {advisory_calls}"
+        )
+
+    async def test_per_user_error_isolation(self, client):
+        """1-of-3 user errors → others still complete; job marked complete (not failed)."""
+        users = [_make_user() for _ in range(3)]
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock(
+            return_value=SimpleNamespace(id=uuid4())
+        )
+        mock_job_repo.complete_execution = AsyncMock()
+        mock_job_repo.fail_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(return_value=users)
+
+        call_count = 0
+
+        async def _engine_side_effect(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("simulated per-user error")
+            return SimpleNamespace(id=uuid4())
+
+        mock_engine = AsyncMock()
+        mock_engine.evaluate_and_schedule_for_user = AsyncMock(
+            side_effect=_engine_side_effect
+        )
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo), \
+             patch("nikita.touchpoints.engine.TouchpointEngine", return_value=mock_engine):
+
+            response = await client.post("/tasks/heartbeat")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["processed"] == 2
+        assert data["errors"] == 1
+        # Job must complete cleanly even when one user fails (graceful degradation).
+        mock_job_repo.complete_execution.assert_awaited_once()
+        mock_job_repo.fail_execution.assert_not_called()
+
+    async def test_error_envelope_redacts_exception_string(self, client):
+        """FR-015: catastrophic-failure error envelope MUST NOT leak str(exception)."""
+        secret_token = "PII_SECRET_DO_NOT_LEAK_xyzzy"
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock(
+            return_value=SimpleNamespace(id=uuid4())
+        )
+        mock_job_repo.complete_execution = AsyncMock()
+        mock_job_repo.fail_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        # Catastrophic: repo blows up after job_executions row exists
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(
+            side_effect=RuntimeError(f"disk full: {secret_token}")
+        )
+
+        with patch("nikita.api.routes.tasks.get_settings", return_value=_mock_settings()), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo):
+
+            response = await client.post("/tasks/heartbeat")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "error"
+        assert "error" in data and isinstance(data["error"], str)
+        # Per FR-015 envelope shape: {"error": "<code>", "detail": "<redacted>"}
+        # MUST NOT contain raw exception string content.
+        full_payload = response.text
+        assert secret_token not in full_payload, (
+            "FR-015 violation: raw exception string leaked into response payload"
+        )
+        mock_job_repo.fail_execution.assert_awaited_once()
+
+    async def test_feature_flag_off_short_circuits(self, client):
+        """FR-020 rollback contract: heartbeat_engine_enabled=False → no work, no users queried."""
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_maker = _mock_session_maker(mock_session)
+
+        mock_job_repo = AsyncMock()
+        mock_job_repo.has_recent_execution = AsyncMock(return_value=False)
+        mock_job_repo.start_execution = AsyncMock()
+
+        mock_user_repo = AsyncMock()
+        mock_user_repo.get_active_users_for_heartbeat = AsyncMock(return_value=[])
+
+        mock_engine = _build_mock_engine()
+
+        with patch(
+            "nikita.api.routes.tasks.get_settings",
+            return_value=_mock_settings(heartbeat_engine_enabled=False),
+        ), \
+             patch("nikita.api.routes.tasks.get_session_maker", return_value=mock_maker), \
+             patch("nikita.api.routes.tasks.JobExecutionRepository", return_value=mock_job_repo), \
+             patch("nikita.db.repositories.user_repository.UserRepository", return_value=mock_user_repo), \
+             patch("nikita.touchpoints.engine.TouchpointEngine", return_value=mock_engine):
+
+            response = await client.post("/tasks/heartbeat")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "disabled"
+        # No engine work, no user query, no job_executions row.
+        mock_engine.evaluate_and_schedule_for_user.assert_not_called()
+        mock_user_repo.get_active_users_for_heartbeat.assert_not_called()
+        mock_job_repo.start_execution.assert_not_called()

--- a/tests/db/models/test_job_execution.py
+++ b/tests/db/models/test_job_execution.py
@@ -29,8 +29,15 @@ class TestJobExecutionModel:
         assert job.status == JobStatus.RUNNING
 
     def test_all_job_names_defined(self):
-        """AC-FR008-001: All 8 job types are supported (5 original + post_processing + psyche_batch + refresh_voice_prompts)."""
-        expected_jobs = {"decay", "deliver", "summary", "cleanup", "process-conversations", "post_processing", "psyche_batch", "refresh_voice_prompts"}
+        """AC-FR008-001: All job types are supported.
+
+        Spec 215 PR 215-D adds heartbeat + generate_daily_arcs (Contract 2).
+        """
+        expected_jobs = {
+            "decay", "deliver", "summary", "cleanup", "process-conversations",
+            "post_processing", "psyche_batch", "refresh_voice_prompts",
+            "heartbeat", "generate_daily_arcs",
+        }
         actual_jobs = {j.value for j in JobName}
         assert actual_jobs == expected_jobs
 


### PR DESCRIPTION
Closes T4.1, T4.2, T5.1, T5.2 of specs/215-heartbeat-engine/tasks.md US-4 + US-5.

## What
- 2 new POST handlers in nikita/api/routes/tasks.py mirroring /refresh-voice-prompts pattern
- JobName enum entries (HEARTBEAT, GENERATE_DAILY_ARCS) per contracts.md Contract 2
- Advisory lock + idempotency guard + fan-out cap + active-user filter + circuit breaker
- New UserRepository.get_active_users_for_heartbeat for centralized G1 filter
- 21 new unit tests with mocked DB + planner

## Brief-vs-reality divergences (verified before implementing)
- TouchpointEngine.evaluate_and_schedule_for_user has NO trigger_reason kwarg; signature is (user_id, current_time=None, life_events=None). Adopted actual signature.
- User field is game_status (not status); last_interaction_at (not last_user_message). Per FR-008+OD4, filter is game_status IN ('active','boss_fight') (excludes both game_over and won).
- /tasks/touchpoints already exists but calls deliver_due_touchpoints() (delivers already-scheduled). /tasks/heartbeat fills a real gap (evaluate + schedule).

## Cost circuit breaker (FR-014)
Best-effort lookup via JobExecutionRepository.get_today_cost_usd. If method absent, breaker degrades to no-op (open). Real ledger primitive ships in 215-A/E follow-up. The 503 + Retry-After header pointing to next midnight UTC is implemented per FR-014(a).

## Excludes
- pg_cron registration (215-E ops step)
- Live LLM calls in tests (mocked)
- Planner implementation (215-C; ships a STUB at nikita/heartbeat/planner.py marked '# STUB - 215-C will replace via rebase')
- Cost ledger primitive table (best-effort path documented above)

## Local tests
- uv run pytest tests/api/routes/test_tasks_heartbeat.py tests/api/routes/test_tasks_generate_daily_arcs.py -v -> 21 PASS
- uv run pytest -q -> 6310 PASS, 184 deselected, 3 xpassed (162 s, full nikita suite)

## Pre-PR grep gates
- Gate 1 (zero-assertion shells): clean
- Gate 2 (PII in logs): clean
- Gate 3 (raw cache_key): clean