### PR TITLE
feat(215-E): heartbeat + daily-arcs + touchpoints pg_cron registration

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,12 +25,12 @@ version: 1.0.2
 | Portal routes | 25 (19 + admin) |
 | Pipeline stages | 11 |
 | Feature flags | 6/6 ON |
-| pg_cron jobs | 8 active |
-| Cloud Run deploy | `nikita-api-00251-w7m` (us-central1) |
+| pg_cron jobs | 9 active (post-215-E migration: 12 with heartbeat+arcs+touchpoints) |
+| Cloud Run deploy | `nikita-api-00258-62c` (us-central1) |
 | Portal deploy | `portal-phi-orcin.vercel.app` |
-| Last deploy | 2026-04-17 (PR #322, GH #321: portal->Telegram deep-link binding; merged a663af2) |
-| Active specs | 1 (214 portal-wizard — all FRs shipped incl. FR-11b; E2E live-walk verification partial, tooling-limited) |
-| In-flight | Spec 214 live E2E dogfood (Agent H-5 PARTIAL 2026-04-17; blocked on Gmail-MCP alias read + admin-Telegram already-bound) |
+| Last deploy | 2026-04-18 (PR #334, Spec 215-D: heartbeat + daily-arcs API endpoints; merged 02911f0) |
+| Active specs | 2 (214 portal-wizard — E2E partial; 215 heartbeat-engine — Phase 1 PARTIAL, flag-OFF, B1-B4 pre-flag-flip blockers) |
+| In-flight | Spec 215 PR 215-E (cron registration via migration + closes B1) + 3 parallel B2/B3/B4 fix PRs (#336/#337/#338) |
 
 ---
 
@@ -109,9 +109,9 @@ Context engineering, pipeline stages, memory system, processing.
 | 100 | cron-infrastructure-hardening | — | Idempotency, concurrency guards |
 | 102 | memory-data-integrity | — | Batch search, embedding dedup |
 | 104 | context-engineering-enrichment | — | Arcs, thought resolution |
-| 215 | heartbeat-engine | — | **PLANNED** — Activity-aware self-driven heartbeat (von Mises × Hawkes × Ogata thinning). 3 phases: P1 daily-plan + safety-net cron, P2 self-scheduling + circadian, P3 Bayesian per-user posteriors. Plan v4 brief at `.claude/plans/delightful-orbiting-ladybug.md`. |
+| 215 | heartbeat-engine | #330-334 + 215-E (in-flight) | **PARTIAL** (Phase 1, flag-OFF) — 5 PRs merged on master 02911f0: 215-A foundation (#330), 215-B intensity math (#331), 215-C planner (#332), 215-D endpoints (#334), 215-F parity validator (#333). PR 215-E in-flight: pg_cron registration via migration (closes B1 GH #335 — `nikita-touchpoints` cron MISSING in prod). Pre-flag-flip blockers tracked: B2 #336 cost circuit breaker disarmed, B3 #337 advisory_lock blocks tick, B4 #338 planner LLM no timeout. Phase 2 (Hawkes self-scheduling) + Phase 3 (Bayesian posteriors) pending separate spec cycles. Plan v6.14 at `.claude/plans/delightful-orbiting-ladybug.md`. |
 
-**Domain subtotal: 15 specs (1 superseded), 4,369 tests (215 PLANNED)**
+**Domain subtotal: 15 specs (1 superseded), 4,369 tests (215 PARTIAL Phase 1)**
 
 ---
 

--- a/docs/diagrams/11-heartbeat-engine.md
+++ b/docs/diagrams/11-heartbeat-engine.md
@@ -1,0 +1,209 @@
+# Diagram 11 — Heartbeat Engine (Spec 215, Phase 1 ship state)
+
+**Generated**: 2026-04-18 post-merge of 215-A/B/C/D/F (master `02911f0`).
+**Status**: Phase 1 — cron registered, flag OFF, planner output write-only, intensity math offline-only.
+**Companion**: `docs/models/heartbeat-intensity.md` (math), `docs/models/heartbeat-*.png` (7 distribution plots), `specs/215-heartbeat-engine/contracts.md` (frozen cross-PR shapes).
+
+---
+
+## A — Activation flow (cron tick → user-visible message)
+
+```
+ROOT pg_cron tick fires
+  │
+  ├── BRANCH 1 — Hourly heartbeat ("0 * * * *")  [pg_cron: nikita-heartbeat-hourly, registered by 215-E]
+  │   │
+  │   ├─ [⊙] supabase.cron → net.http_post → POST /api/v1/tasks/heartbeat
+  │   │      Bearer: hardcoded literal (matches Cloud Run TASK_AUTH_SECRET)
+  │   │
+  │   ├─ [⊙] FastAPI → tasks.py:1199-1326  heartbeat_tick()
+  │   │      ∘ verify_task_secret              [tasks.py:47-73]
+  │   │      ∘ if !heartbeat_engine_enabled    → 200 {"status":"disabled"}     [tasks.py:1228-1231]
+  │   │      ∘ has_recent_execution(55min)     → 200 {"status":"skipped"}      [tasks.py:1239-1244]
+  │   │      ∘ start_execution(JobName.HEARTBEAT) + commit
+  │   │      ∘ get_active_users_for_heartbeat() — game_status IN ('active','boss_fight')
+  │   │            AND telegram_id IS NOT NULL AND last_interaction_at > now()-14d
+  │   │            limit=1000                   [user_repository.py:1268-1305]
+  │   │      ∘ fan-out cap = min(eligible, 40) [tasks.py:1255-1256, _HEARTBEAT_FAN_OUT_CAP]
+  │   │
+  │   └─ for user in eligible[:40]:           [tasks.py:1262-1298]
+  │        ├─ [⊗] pg_advisory_lock(hashtext(user_id)::bigint)   ← BLOCKING (B3)
+  │        │      session-scoped + try/finally pg_advisory_unlock
+  │        │      slow user U serializes U+1..U+39
+  │        ├─ [⊙] TouchpointEngine.evaluate_and_schedule_for_user(user_id)
+  │        │      [touchpoints/engine.py:523-595]
+  │        │      ∘ store.get_recent_touchpoints(since=now-min_gap)  → dedup
+  │        │      ∘ user_repo.get_by_id(user_id) → chapter, tz, last_interaction_at
+  │        │      ∘ scheduler.evaluate_user(...)
+  │        │            ⊕ time-based, gap-based, event-based (Spec 071)
+  │        │      ∘ store.create(...)  → INSERT INTO touchpoints (NOT scheduled_events!)
+  │        └─ pg_advisory_unlock
+  │
+  │   ─── DELIVERY DECOUPLING [⊗ B1 — STANDING BUG] ───
+  │
+  │   ╔════════════════════════════════════════════════════════════╗
+  │   ║  touchpoints table written  ✓                              ║
+  │   ║  ↓                                                          ║
+  │   ║  /api/v1/tasks/touchpoints route exists  [tasks.py:992]    ║
+  │   ║  ↓                                                          ║
+  │   ║  TouchpointEngine.deliver_due_touchpoints()                ║
+  │   ║      → _send_telegram_message → bot.send_message            ║
+  │   ║      → store.mark_delivered                                 ║
+  │   ║  ↑                                                          ║
+  │   ║  CRON CALLER:    [⊗ MISSING IN PROD]                       ║
+  │   ║      cron.job query 2026-04-18 → no nikita-touchpoints      ║
+  │   ║      row. Heartbeat-fan-out + ALL other touchpoint          ║
+  │   ║      producers currently land in a queue with no consumer.  ║
+  │   ╚════════════════════════════════════════════════════════════╝
+  │
+  └── BRANCH 2 — Daily arc generator ("0 5 * * *") [pg_cron: nikita-generate-daily-arcs, registered by 215-E]
+      │
+      ├─ [⊙] supabase.cron → POST /api/v1/tasks/generate-daily-arcs
+      │
+      ├─ [⊙] FastAPI → tasks.py:1329-1490  generate_daily_arcs()
+      │      ∘ feature flag gate                              [tasks.py:1363-1365]
+      │      ∘ idempotency 1440-min                            [tasks.py:1372-1377]
+      │      ∘ FR-014 cost circuit-breaker
+      │            today_cost = job_repo.get_today_cost_usd()
+      │            [⊗ B2: method does NOT exist; fallback $0; breaker disarmed]
+      │            if today_cost ≥ ceiling → 503 + Retry-After-to-midnight
+      │      ∘ active-user filter (same as heartbeat, NO 40-cap)
+      │
+      └─ for user in eligible:                                [tasks.py:1439-1465]
+           ├─ [⊙] planner.generate_daily_arc(user, today, session) → DailyArc
+           │       [heartbeat/planner.py:161-207]
+           │       ∘ Pydantic AI Agent(model=Models.haiku())  ← claude-haiku-4-5-20251001
+           │       ∘ output_type=DailyArc (steps: 6-12, narrative, model_used)
+           │       ∘ system prompt: 6-12 chronologically ordered ArcStep entries
+           │       [⊗ B4: NO timeout on agent.run() — single hang blocks tick]
+           │
+           └─ [⊙] NikitaDailyPlanRepository.upsert_plan(...)
+                  [db/repositories/heartbeat_repository.py:79-148]
+                  INSERT … ON CONFLICT (user_id, plan_date) DO UPDATE
+                  arc_json passed as Python dict (NOT json.dumps — PR #319 burn)
+                  RETURNING * → row id + server-stamped generated_at
+                  [⊗ DOWNSTREAM CONSUMER GAP — Phase 2 wiring not yet shipped]
+```
+
+USER-VISIBLE OUTCOME (with current code, when flag flips ON):
+- Daily LLM cost burn writing `nikita_daily_plan` rows that nothing reads at runtime
+- Hourly TouchpointEngine fan-out writing `touchpoints` rows that no cron drains
+- Net: $$$/day spend, 0 user-visible behavior change
+- Once B1 cron is registered, hourly proactive Telegram messages start landing per existing Spec 071 trigger logic (NOT yet using planner arc data)
+
+---
+
+## B — Module dependency graph
+
+```
+nikita.heartbeat (Spec 215 surface)
+  │
+  ├─ intensity.py           [✓ 215-B]
+  │   ⇄ scripts/models/heartbeat_intensity_mc.py    [SOT seam, MC imports prod constants]
+  │   ⇄ scripts/models/heartbeat_live_parity.py     [215-F nightly KS-test]
+  │   → math, random, typing.Final
+  │   [⊗ NO RUNTIME CONSUMER — Phase 1 offline only]
+  │
+  ├─ planner.py             [✓ 215-C]
+  │   → pydantic_ai.Agent  ⇄  Anthropic API (HTTPS)
+  │   → nikita.config.models.Models.haiku()
+  │   exports: DailyArc, ArcStep, generate_daily_arc()
+  │   ↳ CONSUMER: tasks.generate_daily_arcs (215-D handler)
+  │
+  ├─ db.models.heartbeat.NikitaDailyPlan       [✓ 215-A]
+  │   ⇄ supabase.public.nikita_daily_plan
+  │       PK uuid, FK user_id ON DELETE CASCADE, plan_date date
+  │       UNIQUE(user_id, plan_date) — idempotency anchor
+  │       RLS: user-scoped read; service-role writes
+  │   [⊗ asyncpg JSONB invariant — never json.dumps()]
+  │
+  └─ db.repositories.heartbeat_repository.NikitaDailyPlanRepository  [✓ 215-A]
+      .get_plan_for_date()    [⊗ NO CONSUMER]
+      .upsert_plan()          ↳ CONSUMER: tasks.generate_daily_arcs
+
+nikita.api.routes.tasks (215-D handlers)
+  → verify_task_secret  [⊗ TASK_AUTH_SECRET coupling — 9 existing crons + 2 new = 11 hardcoded literals]
+  → settings.heartbeat_engine_enabled / heartbeat_cost_circuit_breaker_usd_per_day
+  → JobExecutionRepository  [⊗ B2: get_today_cost_usd missing]
+  → UserRepository.get_active_users_for_heartbeat
+  → TouchpointEngine.evaluate_and_schedule_for_user  ⊙ heartbeat-only call site
+  → planner.generate_daily_arc                       ⊙ daily-arcs-only call site
+  → NikitaDailyPlanRepository.upsert_plan            ⊙ daily-arcs-only call site
+
+nikita.touchpoints.engine.TouchpointEngine          [pre-existing Spec 025]
+  → store.{TouchpointStore, ScheduledTouchpoint}    ⇄ touchpoints table (NOT scheduled_events)
+  → scheduler.{TouchpointScheduler, TriggerContext, TriggerType}
+  → silence.StrategicSilence
+  → emotional_state.{models, store}
+  → platforms.telegram.bot.get_bot                  (used by deliver_due_touchpoints)
+  → db.repositories.{user, vice}                    (chat_id, vice prefs)
+
+pg_cron platform
+  ⇄ supabase.public.cron.job   (9 prod rows pre-215; +2 after 215-E lands)
+  ⇄ Cloud Run nikita-api  rev 00258 (HTTPS, app-layer Bearer auth)
+  [⊗ NO HTTP retry — fire-and-forget; cold-start caveats apply]
+```
+
+---
+
+## C — Failure-mode tree (Phase 1 ship + flag-flip risk)
+
+```
+Heartbeat engine fails to deliver value
+  │
+  ├─ B1 [CRITICAL] — touchpoints queue has no drain cron
+  │       Symptom: heartbeat tick succeeds, touchpoints rows accumulate, 0 messages sent
+  │       Detection: SELECT count(*) FROM touchpoints WHERE delivered_at IS NULL
+  │       Mitigation: register `nikita-touchpoints` cron (`*/5 * * * *` →
+  │                   POST /api/v1/tasks/touchpoints) BEFORE flag-flip
+  │       Pre-existing bug, surfaced by Spec 215 deployment intent
+  │
+  ├─ B2 [HIGH] — cost circuit breaker disarmed
+  │       Symptom: uncapped Anthropic spend on flag-flip; no 503 on overspend
+  │       Detection: GCP billing alert (out-of-band), or grep logs for
+  │                  `cost_breaker_degraded` warning
+  │       Mitigation: implement JobExecutionRepository.get_today_cost_usd OR
+  │                   add hard cap on len(eligible) in /generate-daily-arcs
+  │
+  ├─ B3 [HIGH] — pg_advisory_lock blocking serializes whole tick on slow user
+  │       Symptom: tick takes >60s, processed << to_process, fan-out stalls
+  │       Detection: log line `processed=N to_process=40` divergence
+  │       Mitigation: convert to pg_try_advisory_lock with skip semantics
+  │
+  ├─ B4 [MEDIUM] — planner LLM call has no timeout
+  │       Symptom: hung Anthropic request blocks daily-arc tick to 15min
+  │                Cloud Run timeout
+  │       Detection: tick latency p99 spike; `errors_pct` rises
+  │       Mitigation: asyncio.wait_for(agent.run, timeout=30s) in
+  │                   planner._run_planner_agent
+  │
+  ├─ Cold start [LOW] — first cron tick after idle = 2-5s extra latency
+  │       Mitigation: idempotency window 55min absorbs single missed tick
+  │
+  ├─ Schema drift [LOW] — planner output ↔ DailyArc Pydantic model
+  │       Mitigation: pydantic_ai validation enforces shape; defensive
+  │                   model_used backfill at planner.py:195-197
+  │
+  ├─ DB connection exhaustion [LOW] — fan-out shares one session
+  │       Mitigation: heartbeat_tick uses 1 session for whole tick;
+  │                   advisory locks are session-bound
+  │
+  └─ Schema-rotation pain [INFRA] — 11 hardcoded Bearer literals after 215-E
+        Mitigation: vault/templating cleanup tracked separately as hygiene work
+```
+
+---
+
+## D — Pre-flag-flip checklist
+
+Before setting `HEARTBEAT_ENGINE_ENABLED=true` in Cloud Run env:
+
+1. [ ] B1 fixed (nikita-touchpoints cron registered + verified delivering)
+2. [ ] B2 fixed (cost ledger primitive shipped OR fan-out hard cap added)
+3. [ ] B3 fixed (try-lock with skip semantics)
+4. [ ] B4 fixed (planner timeout)
+5. [ ] 24h baseline observation: cron.job_run_details for both 215-E jobs all green w/ `{"status":"disabled"}`
+6. [ ] log-based alert routed for `cost_breaker_degraded` warning + `errors_pct > 0.20`
+7. [ ] Staging dry-run: flip flag in staging, observe 24h, then production
+
+Phase 1 ship state (current target) = items 5-6 done, items 1-4 deferred to follow-up PRs. Flag stays OFF.

--- a/scripts/check_heartbeat_cron_jobs.py
+++ b/scripts/check_heartbeat_cron_jobs.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Verify that the 3 heartbeat-engine cron jobs are registered + healthy.
+
+Spec 215 PR 215-E (T6.2). Run via:
+
+    uv run python scripts/check_heartbeat_cron_jobs.py
+
+Exits 0 if all 3 jobs exist + recent runs are 'succeeded'. Exits 1 otherwise.
+Designed for both manual ops verification and CI smoke-checks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import Final
+
+import asyncpg
+
+EXPECTED_JOBS: Final[tuple[str, ...]] = (
+    "nikita-heartbeat-hourly",
+    "nikita-generate-daily-arcs",
+    "nikita-touchpoints",
+)
+
+DATABASE_URL_ENV: Final[str] = "DATABASE_URL"
+
+
+async def _check() -> int:
+    db_url = os.environ.get(DATABASE_URL_ENV)
+    if not db_url:
+        print(f"FAIL: {DATABASE_URL_ENV} not set", file=sys.stderr)
+        return 1
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        # 1) all expected jobs registered
+        rows = await conn.fetch(
+            "SELECT jobname, schedule FROM cron.job WHERE jobname = ANY($1::text[]) ORDER BY jobname",
+            list(EXPECTED_JOBS),
+        )
+        present = {r["jobname"] for r in rows}
+        missing = set(EXPECTED_JOBS) - present
+        if missing:
+            print(f"FAIL: missing cron jobs: {sorted(missing)}", file=sys.stderr)
+            return 1
+        print(f"OK: all {len(EXPECTED_JOBS)} cron jobs registered:")
+        for r in rows:
+            print(f"  - {r['jobname']:32s} {r['schedule']}")
+
+        # 2) most recent runs (within last 2h) are healthy
+        recent = await conn.fetch(
+            """
+            SELECT jobname, status, return_message, start_time
+            FROM cron.job_run_details
+            WHERE jobname = ANY($1::text[])
+              AND start_time > now() - interval '2 hours'
+            ORDER BY start_time DESC
+            """,
+            list(EXPECTED_JOBS),
+        )
+        if not recent:
+            print(
+                "WARN: no runs in last 2h (cron may not have ticked yet — "
+                "check again after the next scheduled minute)"
+            )
+            return 0
+        bad = [r for r in recent if r["status"] != "succeeded"]
+        if bad:
+            print(f"FAIL: {len(bad)} unhealthy run(s):", file=sys.stderr)
+            for r in bad:
+                print(
+                    f"  - {r['jobname']:32s} {r['status']:12s} {r['start_time']}",
+                    file=sys.stderr,
+                )
+                if r["return_message"]:
+                    print(f"      → {r['return_message']}", file=sys.stderr)
+            return 1
+        print(f"OK: {len(recent)} recent run(s), all 'succeeded'")
+        return 0
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_check()))

--- a/scripts/check_heartbeat_cron_jobs.py
+++ b/scripts/check_heartbeat_cron_jobs.py
@@ -24,6 +24,16 @@ EXPECTED_JOBS: Final[tuple[str, ...]] = (
     "nikita-touchpoints",
 )
 
+# Per-job freshness windows (minutes). Sized to cron cadence + safety buffer:
+#   touchpoints (every 5 min) → 15 min window  (3x cadence)
+#   heartbeat-hourly         → 90 min          (1.5x cadence)
+#   generate-daily-arcs      → 1500 min (~25h) (1x cadence + 1h slack)
+JOB_FRESHNESS_MINUTES: Final[dict[str, int]] = {
+    "nikita-touchpoints": 15,
+    "nikita-heartbeat-hourly": 90,
+    "nikita-generate-daily-arcs": 1500,
+}
+
 DATABASE_URL_ENV: Final[str] = "DATABASE_URL"
 
 
@@ -49,36 +59,40 @@ async def _check() -> int:
         for r in rows:
             print(f"  - {r['jobname']:32s} {r['schedule']}")
 
-        # 2) most recent runs (within last 2h) are healthy
-        recent = await conn.fetch(
-            """
-            SELECT jobname, status, return_message, start_time
-            FROM cron.job_run_details
-            WHERE jobname = ANY($1::text[])
-              AND start_time > now() - interval '2 hours'
-            ORDER BY start_time DESC
-            """,
-            list(EXPECTED_JOBS),
-        )
-        if not recent:
-            print(
-                "WARN: no runs in last 2h (cron may not have ticked yet — "
-                "check again after the next scheduled minute)"
+        # 2) most recent run per job is healthy, using per-job freshness
+        # windows so daily-arcs (24h cadence) is not falsely flagged as stale.
+        exit_code = 0
+        for jobname in EXPECTED_JOBS:
+            window_min = JOB_FRESHNESS_MINUTES[jobname]
+            row = await conn.fetchrow(
+                """
+                SELECT status, return_message, start_time
+                FROM cron.job_run_details
+                WHERE jobname = $1
+                  AND start_time > now() - make_interval(mins => $2)
+                ORDER BY start_time DESC
+                LIMIT 1
+                """,
+                jobname,
+                window_min,
             )
-            return 0
-        bad = [r for r in recent if r["status"] != "succeeded"]
-        if bad:
-            print(f"FAIL: {len(bad)} unhealthy run(s):", file=sys.stderr)
-            for r in bad:
+            if row is None:
                 print(
-                    f"  - {r['jobname']:32s} {r['status']:12s} {r['start_time']}",
+                    f"WARN: {jobname:32s} no runs in last {window_min} min "
+                    "(cron may not have ticked yet)"
+                )
+                continue
+            if row["status"] != "succeeded":
+                print(
+                    f"FAIL: {jobname:32s} {row['status']:12s} {row['start_time']}",
                     file=sys.stderr,
                 )
-                if r["return_message"]:
-                    print(f"      → {r['return_message']}", file=sys.stderr)
-            return 1
-        print(f"OK: {len(recent)} recent run(s), all 'succeeded'")
-        return 0
+                if row["return_message"]:
+                    print(f"      → {row['return_message']}", file=sys.stderr)
+                exit_code = 1
+            else:
+                print(f"OK:   {jobname:32s} succeeded {row['start_time']}")
+        return exit_code
     finally:
         await conn.close()
 

--- a/supabase/migrations/20260418141500_cron_heartbeat_engine.sql
+++ b/supabase/migrations/20260418141500_cron_heartbeat_engine.sql
@@ -1,0 +1,90 @@
+-- Spec 215 PR 215-E: Register pg_cron jobs for heartbeat engine + close GH #335.
+--
+-- THREE scheduled HTTP POSTs from pg_cron → Cloud Run task endpoints
+-- (mirrors the format of all 9 existing nikita-* cron jobs):
+--
+--   nikita-heartbeat-hourly       — POST /api/v1/tasks/heartbeat            (00 of every hour)
+--   nikita-generate-daily-arcs    — POST /api/v1/tasks/generate-daily-arcs  (05:00 UTC daily)
+--   nikita-touchpoints            — POST /api/v1/tasks/touchpoints          (every 5 min) [closes GH #335]
+--
+-- B1/GH #335 context: TouchpointEngine writes rows to the `touchpoints` table
+-- via evaluate_and_schedule_for_user; deliver_due_touchpoints() drains that
+-- table via _send_telegram_message; route /api/v1/tasks/touchpoints exists
+-- but had NO cron registered in prod (cron.job query 2026-04-18: 9 jobs, none
+-- of them this one). Heartbeat fan-out and ALL other touchpoint producers
+-- currently land in a queue with no consumer. Registering this cron alongside
+-- the heartbeat crons closes the standing bug in one shot.
+--
+-- The two heartbeat endpoints are auth-gated (verify_task_secret) and no-op
+-- + return 200 {"status":"disabled","reason":"feature_flag_off"} until
+-- HEARTBEAT_ENGINE_ENABLED is flipped to true in Cloud Run env. The
+-- nikita-touchpoints endpoint has its own dispatch logic (no flag gate);
+-- it will start delivering touchpoints immediately after this migration
+-- applies — that is the desired behavior (closes B1).
+--
+-- The hardcoded Bearer token + URL match the pattern of the 9 existing crons
+-- (e.g., nikita-deliver, nikita-decay, nikita-summary). Backfilling all
+-- crons (including these two) into auth.secrets / vault and a templated
+-- migration helper is tracked separately as a hygiene cleanup.
+--
+-- IDEMPOTENCY: cron.schedule will overwrite an existing job with the same
+-- name, but it returns the new jobid each time, which is fine. To guard
+-- against double-scheduling on accidental re-apply, we cron.unschedule
+-- first if exists.
+
+DO $$
+BEGIN
+  PERFORM cron.unschedule('nikita-heartbeat-hourly')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'nikita-heartbeat-hourly');
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  PERFORM cron.unschedule('nikita-generate-daily-arcs')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'nikita-generate-daily-arcs');
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  PERFORM cron.unschedule('nikita-touchpoints')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'nikita-touchpoints');
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+SELECT cron.schedule(
+    'nikita-heartbeat-hourly',
+    '0 * * * *',
+    $cron$
+    SELECT net.http_post(
+        url := 'https://nikita-api-1040094048579.us-central1.run.app/api/v1/tasks/heartbeat',
+        body := '{}'::jsonb,
+        headers := '{"Authorization": "Bearer S7fBvwplxGNuzX39hG2osZwdeixLzuBx3dWOik6N3b0", "Content-Type": "application/json"}'::jsonb
+    );
+    $cron$
+);
+
+SELECT cron.schedule(
+    'nikita-generate-daily-arcs',
+    '0 5 * * *',
+    $cron$
+    SELECT net.http_post(
+        url := 'https://nikita-api-1040094048579.us-central1.run.app/api/v1/tasks/generate-daily-arcs',
+        body := '{}'::jsonb,
+        headers := '{"Authorization": "Bearer S7fBvwplxGNuzX39hG2osZwdeixLzuBx3dWOik6N3b0", "Content-Type": "application/json"}'::jsonb
+    );
+    $cron$
+);
+
+SELECT cron.schedule(
+    'nikita-touchpoints',
+    '*/5 * * * *',
+    $cron$
+    SELECT net.http_post(
+        url := 'https://nikita-api-1040094048579.us-central1.run.app/api/v1/tasks/touchpoints',
+        body := '{}'::jsonb,
+        headers := '{"Authorization": "Bearer S7fBvwplxGNuzX39hG2osZwdeixLzuBx3dWOik6N3b0", "Content-Type": "application/json"}'::jsonb
+    );
+    $cron$
+);

--- a/workbook.md
+++ b/workbook.md
@@ -1,81 +1,91 @@
-# Handover — Spec 215 Heartbeat Engine, Parallel Orchestration BLOCKED on prune decision
+# Handover — Spec 215 PR 215-E mid-execution + B1-B4 ready to dispatch
 
-**Date**: 2026-04-18 · **Session**: post-/plan-rewrite Wave 1+2+3, awaiting user input on worktree prune
+**Date**: 2026-04-18 18:30 · **Session**: post-intel-refresh; user-approved Plan v6.14 parallel batch
 
 ## 1. Resume command
 
 ```bash
 cd /Users/yangsim/Nanoleq/sideProjects/nikita/.claude/worktrees/delightful-orbiting-ladybug
-git fetch origin && git status                           # confirm on master, clean
-sed -n '1562,2200p' /Users/yangsim/.claude/plans/delightful-orbiting-ladybug.md  # Plan v6 + v6.12
-git worktree list                                        # confirm 9 worktrees still present
+git branch --show-current   # expect feat/215-E-cron-heartbeat
+git status --short          # expect untracked migration + script + diagram
+gh issue list --label bug --state open --search "heartbeat OR touchpoints" | head -5
+sed -n '2196,2400p' /Users/yangsim/.claude/plans/delightful-orbiting-ladybug.md  # v6.13+v6.14
 ```
 
-## 2. Operating files
+## 2. Operating files (current session deliverables)
 
-- `/Users/yangsim/.claude/plans/delightful-orbiting-ladybug.md` — **Plan v6 (parallel orchestration brief, lines 1562-1995) + v6.12 (Wave 3 fix patches, lines ~1880-1995)** — AUTHORITATIVE for next steps
-- `specs/215-heartbeat-engine/{spec,plan,tasks,validation-findings}.md` — SDD artifacts (GATE 2 PASS iter-2)
-- `specs/215-heartbeat-engine/contracts.md` — **DOES NOT EXIST YET** (P2 prereq creates it; literal content embedded in Plan v6.3 P2)
-- `nikita/heartbeat/intensity.py` (PR 215-B, frozen) — math module symbols 215-F imports
-- `nikita/db/repositories/heartbeat_repository.py` (PR 215-A, frozen) — `NikitaDailyPlanRepository.upsert_plan` 215-C+D consume
-- `nikita/api/routes/tasks.py:902-982` — `/refresh-voice-prompts` pattern 215-D mirrors
-- `nikita/agents/text/agent.py:1-66` — Pydantic AI client pattern 215-C mirrors
+- `supabase/migrations/20260418141500_cron_heartbeat_engine.sql` — DRAFT, 3 cron jobs (heartbeat, daily-arcs, touchpoints — closes B1)
+- `scripts/check_heartbeat_cron_jobs.py` — verification script (T6.2), exec-bit set
+- `docs/diagrams/11-heartbeat-engine.md` — full ASCII flow + dep graph + failure tree (this session)
+- `workbook.md` — THIS file
+- `/Users/yangsim/.claude/plans/delightful-orbiting-ladybug.md` — Plan v1-v6.14 (v6.13 intel, v6.14 parallel matrix)
+- ROADMAP.md — NOT YET UPDATED for Spec 215 (still pending)
 
-## 3. Artifact trail (chronological, all in `/Users/yangsim/.claude/plans/delightful-orbiting-ladybug.md`)
+## 3. Artifact trail
 
-1. Plan v3 §A.1-A.6 (lines ~700-960) — math model authority (von Mises × Hawkes × Ogata)
-2. Plan v4 (lines ~970-1310) — SDD handoff brief, Approach A1 locked
-3. Plan v5 (lines ~1320-1560) — post-compaction resume runbook (single-agent serial path, NOW SUPERSEDED)
-4. **Plan v6 (lines 1562-1880)** — parallel multi-worktree orchestration brief (Wave 1+2 evidence)
-5. **Plan v6.12 (lines ~1880-1995)** — Wave 3 fix patches (devil's advocate + process auditor findings)
-6. `specs/215-heartbeat-engine/{spec,plan,tasks,validation-findings}.md` (GATE 2 PASS)
-7. `.claude/plans/handover-2026-04-18-spec215-pr215a.md` (predecessor session brief, pre-PR-#330)
+1. PRs MERGED on master `02911f0`: #331 #332 #333 #334 (Spec 215-A/B/C/D/F)
+2. Cloud Run rev `nikita-api-00258-62c` LIVE since 16:11 (215-D code)
+3. Integration test PASS: both endpoints return 200 `{"status":"disabled","reason":"feature_flag_off"}`
+4. tree-of-thought + pr-codebase-intel agents synthesized → discovered B1-B4
+5. GH issues filed: #335 (B1 CRITICAL), #336 (B2 HIGH), #337 (B3 HIGH), #338 (B4 MEDIUM)
+6. User approved Plan v6.14 parallel matrix (auto-mode now off, was on at approval)
 
 ## 4. Current state
 
-- Branch: `master` at `a3ed2b3` (post-PR-#330 squash); local + origin in sync
-- PRs merged: #326 (215-A), #328 (215-B), #329 (215-G), #330 (rules HARD GATE)
-- Open PRs: none. Spec 215 remaining: 215-C planner, 215-D endpoints, 215-E pg_cron, 215-F parity validator
-- Tests baseline: nikita 30/30 heartbeat pass; portal 632/632 pass
-- Worktrees: 9 active (1 main + 8 sub) — exceeds Plan v6 L2 cap of ≤5 active
-- `gh auth status` PASS (account `yangsi7`); `GH_TOKEN` env var EMPTY → must `export GH_TOKEN=$(gh auth token)` before subagent dispatch (per FIX C1)
+- Branch: `feat/215-E-cron-heartbeat`; HEAD = origin/master `02911f0`; 0 commits ahead
+- Worktrees: 5 active (main + delightful-orbiting-ladybug + 214-c-e2e + 213 + serene-plotting-island)
+- Pruned this session: agent-a024de80 (#304 merged), agent-ac595c68 (#332), agent-adeec65f (#333)
+- Untracked in worktree: 2 hooks + 4 plans + diagram 11 + project-intel-cheatsheet + a11y spec + migration + check_heartbeat script (Plan v2 leftovers + this session)
 
-## 5. Next concrete action — BLOCKED on user decision
+## 5. Next concrete action — RESUME EXECUTION
 
-**Plan v6 prerequisite P1 says prune 5 generic `worktree-agent-*` worktrees to ≤5 active before parallel dispatch. Live check 2026-04-18 found ALL 5 hold unmerged work**:
+### Immediate (in order):
 
-| Worktree | Branch | Ahead/Behind | Last commit | Working tree |
-|---|---|---|---|---|
-| agent-a4fbad53 | worktree-agent-a4fbad53 | 28/11 | F-05 onboarding fix (2026-04-15) | clean |
-| agent-a624dc3c | worktree-agent-a624dc3c | 27/7 | 213-4 FR-2a tests (2026-04-15) | clean |
-| agent-a75bd873 | worktree-agent-a75bd873 | 29/6 | profile_fields migration (2026-04-14) | clean |
-| agent-ac71d488 | worktree-agent-ac71d488 | 27/1 | 213-4 pipeline-ready tests (2026-04-15) | **DIRTY: 9 modified files** |
-| agent-ae4ab076 | worktree-agent-ae4ab076 | 26/6 | Spec 213 ROADMAP sync (2026-04-15) | clean |
-
-Total ~130 unmerged commits across 5 branches. Likely stale (Spec 213 + 214 already shipped via squash-merge under different SHAs) but `--force` removal would discard. **Per Core Behavior #8 carve-out (a) destructive ops require user confirmation.** AskUserQuestion was loaded but not yet sent at end of session.
-
-**Resume action**: surface the prune-or-keep decision via AskUserQuestion. Once decided:
-- If prune → execute Plan v6.3 P1+P2+P3+P4 → dispatch 3 subagents per Plan v6.5 (PATCHED v6.12)
-- If keep → revise L2 cap upward to 12, document reasoning in v6.12 → dispatch anyway
+1. **Add Spec 215 to ROADMAP.md** (CLAUDE.md SDD enforcement #1) — table row for `## Specs` section with status PARTIAL (Phase 1 cron registered, flag OFF)
+2. **Pre-push HARD GATE**: `cd /Users/yangsim/Nanoleq/sideProjects/nikita/.claude/worktrees/delightful-orbiting-ladybug && uv run pytest -q` (full suite ~90s)
+3. **Stage + commit + push 215-E PR**:
+   ```bash
+   git add supabase/migrations/20260418141500_cron_heartbeat_engine.sql \
+           scripts/check_heartbeat_cron_jobs.py \
+           docs/diagrams/11-heartbeat-engine.md \
+           ROADMAP.md
+   git commit -m "feat(215-E): register heartbeat + daily-arcs + touchpoints cron jobs (#335)"
+   git push -u origin feat/215-E-cron-heartbeat
+   gh pr create --title "feat(215-E): heartbeat + daily-arcs + touchpoints pg_cron registration" --body "<closes #335; bundle of 3 cron jobs in one migration; flag-OFF safe>"
+   ```
+4. **Dispatch 3 implementor subagents in parallel** (B2/B3/B4 per Plan v6.14 §subagent dispatch matrix):
+   - Subagent-1 (B2 #336): `nikita/db/repositories/job_execution_repository.py` + `tasks.py:1384-1420` — implement `get_today_cost_usd` OR add hard cap
+   - Subagent-2 (B3 #337): `tasks.py:1262-1298` — convert advisory lock to `pg_try_advisory_lock` + skip semantics
+   - Subagent-3 (B4 #338): `nikita/heartbeat/planner.py:144-153` — `asyncio.wait_for(agent.run, timeout=30)` + `Final PLANNER_TIMEOUT_S=30.0`
+   - Each: HARD CAP 25, isolation worktree, GH_TOKEN exported, TDD red-green, full pytest pre-push, gh pr create
+5. **Run /qa-review --pr N for 215-E SEQUENTIALLY** (HARD CAP 5, scope = migration + script + diagram + ROADMAP)
+6. **Apply migration via `mcp__supabase__apply_migration(name='cron_heartbeat_engine', query=<file contents>)`** AFTER 215-E merges
+7. **Verify**: run `uv run python scripts/check_heartbeat_cron_jobs.py` after first :00 minute tick
+8. **Sequentially merge B4 → B3 → B2** (Plan v6.14 merge-order rationale: avoid tasks.py conflicts; B4 is planner.py = no conflict)
+9. **Address user's onboarding walk ask** (still pending; agent-browser + plus-alias)
 
 ## 6. Locked decisions (do NOT re-litigate)
 
-1. **Approach A1** (new endpoint + `nikita_daily_plan` table) — Plan v4 §v4.1
-2. **OD1=Haiku 4.5** for daily arc generation (cost ceiling per G3)
-3. **OD2=BOTH** `arc_json` + `narrative_text` columns
-4. **OD7=LLM planner** Phase 1 (NOT rule-based)
-5. **R7**: Phase 1 `arc_json` is throwaway; Phase 2 parallel `nikita_daily_intensity_state` table
-6. **TouchpointEngine handoff** via `evaluate_and_schedule_for_user(trigger_reason="heartbeat")` — heartbeat NEVER writes `scheduled_events` directly (FR-007/R1)
-7. **Pre-push HARD GATE** full test suite for touched area before `git push` (`.claude/rules/pr-workflow.md`)
-8. **Plan v6 parallel orchestration**: subagent + `isolation: "worktree"`, NOT TeamCreate (experimental blockers per Anthropic docs); 3-shape contract-first; 215-C+215-F truly parallel; 215-D after contract lock; 215-E ops-only no worktree
-9. **Iter-2 kill-switch on 215-D**: if 215-D fails second fresh QA review, halt parallel topology, pull 215-D into main session single-agent
-10. **Implementor caps**: 25 tool calls for 215-C+215-F, 40 for 215-D (per Plan v6.12 FIX H2)
+1. **Cron via MIGRATION not MCP execute_sql** (PR-reviewable, version-controlled)
+2. **B1 BUNDLED into 215-E migration** (single SQL surface; user approved "Fix all issues")
+3. **Apply via `mcp__supabase__apply_migration`** post-merge (NOT `execute_sql`)
+4. **Phase 1 ship-state**: cron-on with flag-OFF; B1-B4 are pre-flag-flip blockers; flag-flip is separate user decision after baseline
+5. **Subagent dispatch matrix**: 3 parallel for B2/B3/B4; orchestrator owns 215-E + verification
+6. **Merge order**: 215-E → B4 → B3 → B2 (minimize tasks.py rebase pain)
+7. **Hardcoded Bearer matches 9-existing pattern**; vault cleanup deferred separately
+8. **Generated arcs are write-only Phase 1**; intensity math offline-only Phase 1; Phase 2 wires both
+9. **No flag-flip** until B1-B4 land + 24h baseline + onboarding walk passes
 
-## 7. Caveats / dirty files
+## 7. Caveats
 
-- 9 untracked files at worktree root (Plan v2 hook scripts + plan/ledger drafts + a11y-gate.spec.ts + project-intel-cheatsheet.md) — deferred per Plan v5 §5, do NOT auto-commit
-- 5 stale-looking worktrees with 130+ unmerged commits (see §5) — DO NOT --force without user confirmation
-- `GH_TOKEN` env empty — must export before any `gh` subagent dispatch (FIX C1)
-- Plan v6 v6.5 dispatch prompts contain `git checkout -b` step which is WRONG for `isolation: worktree` (framework auto-creates branch); v6.12 FIX C2 overrides with `git fetch origin master && git branch -m HEAD <name> && git rebase origin/master`
-- ROADMAP.md:112 already lists Spec 215 as PLANNED — status update to PARTIAL after 215-C ships, COMPLETE after 215-F
-- Wave 3 reviewer agent IDs (for replay if needed): pr-devils-advocate `aed48776176f4ddd7`, pr-process-auditor `a7f66e6bd765451c3`. Wave 1 IDs: claude-code-guide `aa68b5dd2d3a09820`, general-purpose web `a2fd868aeafe399eb`, pr-codebase-intel `a4c17846d70fbbd4d`. Wave 2: pr-scope-reviewer `a23cffb1b21dffbca`
+- **Auto mode WAS ON during approval, now OFF** per system reminder; resume sub-tasks should ask before scope expansion
+- **GH_TOKEN env may be empty in fresh shells**: `export GH_TOKEN=$(gh auth token)` before subagent dispatch (FIX C1)
+- **Migration apply requires service-role connection**: `mcp__supabase__apply_migration` handles this; do NOT try via Cloud Run proxy
+- **Pre-existing untracked files** (.claude/hooks, .claude/plans, docs/project-intel-cheatsheet, portal/e2e/a11y-gate, brief-spec215, ledgers) — NOT this session's; defer to separate cleanup PR
+- **Worktree `serene-plotting-island`** unclear purpose; left intact (orchestrator did not investigate origin)
+- **`a8dd1287` worktree** = feat/214-c-e2e-deploy = active Spec 214 work; do NOT prune
+- **`ac71d488` worktree** = Spec 213 active per workbook precedent; do NOT prune
+- **Dogfood**: plus-alias `simon.yang.ch+dogfood5@gmail.com` (1-3 burned + cleaned earlier per `feedback_dogfood_gmail_mcp_mismatch.md`)
+- **B2 fix may require column-add migration** if `job_executions.cost_usd` doesn't exist; subagent should detect + scope appropriately
+- **Cost-breaker degraded warning** lands in Cloud Run logs every daily-arc tick once flag flips — log-based alert routing TBD
+- **Cron starts firing 5 min after migration apply** (touchpoints */5) and at next :00 (heartbeat); both will return `{"status":"disabled"}` until flag-flip — verify via `cron.job_run_details`


### PR DESCRIPTION
## Summary

Spec 215 PR 215-E — registers 3 pg_cron jobs via Supabase migration to enable Spec 215 Phase 1 fan-out + close standing bug GH #335.

**3 cron jobs registered:**

| Job | Schedule | Endpoint | Purpose |
|---|---|---|---|
| `nikita-heartbeat-hourly` | `0 * * * *` | `/api/v1/tasks/heartbeat` | Spec 215 Phase 1 hourly safety-net |
| `nikita-generate-daily-arcs` | `0 5 * * *` | `/api/v1/tasks/generate-daily-arcs` | Spec 215 Phase 1 daily LLM plan |
| `nikita-touchpoints` | `*/5 * * * *` | `/api/v1/tasks/touchpoints` | **Closes #335** — drains touchpoints queue |

The first two are safe via `heartbeat_engine_enabled=false` flag (both return `200 {"status":"disabled","reason":"feature_flag_off"}` until flipped).

The third closes GH #335 (B1 CRITICAL): TouchpointEngine + `/touchpoints` route + touchpoints DB table all exist, but no cron drained the queue. Bundled here since same SQL surface.

## Phase 1 ship-state

After this merges + applies, Spec 215 Phase 1 is functionally complete (cron registered, flag OFF). NO flag-flip until:

1. ✅ B1 (closed by this PR — touchpoints cron registered)
2. ⏳ B2 #336 — cost circuit breaker `get_today_cost_usd` missing → uncapped Anthropic spend if flag ON
3. ⏳ B3 #337 — `pg_advisory_lock` (blocking) serializes whole tick on slow user
4. ⏳ B4 #338 — planner `agent.run()` has NO timeout → 15min Cloud Run hang risk
5. 24h baseline observation post-flip

## What's in this PR

- `supabase/migrations/20260418141500_cron_heartbeat_engine.sql` — 3 cron jobs + idempotency guards (DO blocks with `cron.unschedule WHERE EXISTS`)
- `scripts/check_heartbeat_cron_jobs.py` — T6.2 verification (asyncpg query of `cron.job` + `cron.job_run_details`)
- `docs/diagrams/11-heartbeat-engine.md` — full ASCII tree-of-thought map (activation flow + dep graph + failure-mode tree)
- `ROADMAP.md` — Spec 215 PLANNED → PARTIAL Phase 1; Cloud Run rev `nikita-api-00251-w7m` → `nikita-api-00258-62c`; pg_cron count 8→9 (12 post-apply)
- `workbook.md` — handover refresh

## Application path

After merge:
\`\`\`
mcp__supabase__apply_migration(
  name='cron_heartbeat_engine',
  query=<contents of 20260418141500_cron_heartbeat_engine.sql>
)
\`\`\`

NOT via `execute_sql` — `apply_migration` records to migration history.

## Verification

After cron starts ticking (5 min):

\`\`\`sql
SELECT jobname FROM cron.job WHERE jobname IN
  ('nikita-heartbeat-hourly', 'nikita-generate-daily-arcs', 'nikita-touchpoints');
-- expect 3 rows

SELECT jobname, status, return_message, start_time
FROM cron.job_run_details
WHERE jobname IN (above) AND start_time > now() - interval '10 min'
ORDER BY start_time DESC;
-- heartbeat/arcs: status=succeeded, return_message contains "status":"disabled"
-- touchpoints:    status=succeeded, return_message contains "status":"ok" or row count
\`\`\`

Plus `uv run python scripts/check_heartbeat_cron_jobs.py` (requires `DATABASE_URL`).

## Local tests

- `uv run pytest -q` → **6326 passed, 0 failed** (172.59s, full nikita suite)
- Migration is data-layer only (cron.schedule SQL); no application-code path tested by unit tests.

## Test plan

- [x] Pre-push HARD GATE (full pytest suite)
- [ ] `/qa-review --pr N` to absolute zero findings
- [ ] CI green (lint, type, integration)
- [ ] Squash merge
- [ ] `mcp__supabase__apply_migration` (post-merge)
- [ ] `cron.job` query confirms 3 new rows
- [ ] `cron.job_run_details` confirms first ticks succeed
- [ ] `scripts/check_heartbeat_cron_jobs.py` exits 0

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)