### PR TITLE
fix(heartbeat): planner LLM call timeout 30s (#338)

### DIFF
--- a/nikita/heartbeat/planner.py
+++ b/nikita/heartbeat/planner.py
@@ -20,10 +20,11 @@ import without `ANTHROPIC_API_KEY` set.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import date
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent
@@ -36,6 +37,26 @@ if TYPE_CHECKING:
     from nikita.db.models.user import User
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tuning constants (per .claude/rules/tuning-constants.md)
+# ---------------------------------------------------------------------------
+
+# Per-call wall-clock budget for the planner's Pydantic AI `agent.run()` to
+# the upstream Anthropic API. A single hung LLM call must NOT block the daily-
+# arcs tick, which fans out across all active users inside Cloud Run's 15-min
+# request budget. 30s is well above p99 Haiku 4.5 latency (~2-4s observed) yet
+# small enough that one stuck call only costs that user's slot, not the tick.
+#
+# Current value: 30.0
+# Prior values: ∞ (unbounded — no asyncio.wait_for wrapping; bug GH #338)
+# Driving change: GH #338 (B4 MEDIUM, Spec 215 pre-flag-flip blocker).
+# Rationale: caps the worst-case per-user planner cost so the orchestrator
+# in `nikita/api/routes/tasks.py::generate_daily_arcs` can record the failure
+# (handler change tracked separately in GH #336 / B2) and skip rather than
+# taking down the whole tick for ~100 users due to one hung Anthropic call.
+PLANNER_TIMEOUT_S: Final[float] = 30.0
 
 
 # ---------------------------------------------------------------------------
@@ -147,9 +168,18 @@ async def _run_planner_agent(user: User, plan_date: date) -> DailyArc:
     Isolated as its own coroutine so unit tests can mock this single seam
     (`patch("nikita.heartbeat.planner._run_planner_agent")`) without touching
     Pydantic AI internals or requiring an `ANTHROPIC_API_KEY`.
+
+    Wraps `agent.run()` in `asyncio.wait_for(timeout=PLANNER_TIMEOUT_S)` so
+    a single hung Anthropic call cannot block the daily-arcs fan-out tick
+    (GH #338, B4 MEDIUM). On timeout, raises `asyncio.TimeoutError` for the
+    `generate_daily_arcs` handler in `nikita/api/routes/tasks.py` to record
+    + skip the offending user (handler change tracked in GH #336).
     """
     agent = get_planner_agent()
-    result = await agent.run(_user_prompt_for(user, plan_date))
+    result = await asyncio.wait_for(
+        agent.run(_user_prompt_for(user, plan_date)),
+        timeout=PLANNER_TIMEOUT_S,
+    )
     return result.output
 
 

--- a/tests/heartbeat/test_planner.py
+++ b/tests/heartbeat/test_planner.py
@@ -9,19 +9,31 @@ and spec.md AC-FR2-001 / OD1):
 - AC-4: DailyArc.narrative is a non-empty string (prompt-injection blob)
 - AC-5: DailyArc.model_used is populated (audit column, per OD1: Haiku 4.5)
 
+Timeout safety (GH #338, B4 MEDIUM, Spec 215 pre-flag-flip blocker):
+- A single hung Anthropic API call must not block the daily-arcs tick to the
+  Cloud Run 15-min timeout. The planner wraps `agent.run()` in
+  `asyncio.wait_for(timeout=PLANNER_TIMEOUT_S)`.
+
 All LLM calls are mocked — no live network access (per contracts.md docstring
 "Mock all LLM calls in tests").
 """
 
 from __future__ import annotations
 
+import asyncio
 from datetime import date
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
-from nikita.heartbeat.planner import ArcStep, DailyArc, generate_daily_arc
+from nikita.heartbeat.planner import (
+    PLANNER_TIMEOUT_S,
+    ArcStep,
+    DailyArc,
+    _run_planner_agent,
+    generate_daily_arc,
+)
 
 
 def _make_mock_arc(
@@ -158,3 +170,77 @@ async def test_planner_invokes_pydantic_ai_agent(
         user=mock_user, plan_date=date(2026, 4, 18), session=mock_session
     )
     mocked.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Timeout safety (GH #338, B4 MEDIUM)
+# ---------------------------------------------------------------------------
+
+
+def test_planner_timeout_constant_is_30_seconds():
+    """Regression guard per .claude/rules/tuning-constants.md.
+
+    Every tuning constant needs a test asserting its exact current value with
+    a comment pointing to the driving issue. Silent drift is the anti-pattern;
+    intentional change requires updating BOTH this assertion and the docstring
+    on PLANNER_TIMEOUT_S in nikita/heartbeat/planner.py.
+
+    Driving issue: GH #338 (B4 MEDIUM, Spec 215 pre-flag-flip blocker).
+    Rationale: a single hung Anthropic LLM call must not block the
+    daily-arcs tick to Cloud Run's 15-minute timeout. 30s is well above
+    p99 Haiku latency (~2-4s) yet far below the per-tick budget shared
+    across the user fan-out.
+    """
+    assert PLANNER_TIMEOUT_S == 30.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(10)
+async def test_planner_raises_timeout_when_agent_hangs_beyond_budget(
+    mock_user, mock_session
+):
+    """GH #338: hung agent.run() must raise asyncio.TimeoutError, not block.
+
+    Implementation note: we patch PLANNER_TIMEOUT_S to a tiny value so this
+    test runs in ~0.05s wall-clock instead of 30s. The behavior under test
+    (wait_for raises TimeoutError when the awaitable exceeds budget) is
+    identical regardless of the timeout magnitude. The pytest.mark.timeout(10)
+    is a hard upper bound: if the timeout wrapper is ever removed, this test
+    will hang forever and pytest-timeout kills it after 10s.
+    """
+
+    async def _hang(*_args, **_kwargs):
+        await asyncio.sleep(60)  # would exceed any sane PLANNER_TIMEOUT_S
+
+    with (
+        patch("nikita.heartbeat.planner.PLANNER_TIMEOUT_S", 0.05),
+        patch(
+            "nikita.heartbeat.planner.get_planner_agent",
+            return_value=MagicMock(run=AsyncMock(side_effect=_hang)),
+        ),
+        pytest.raises(asyncio.TimeoutError),
+    ):
+        await _run_planner_agent(mock_user, date(2026, 4, 18))
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(10)
+async def test_planner_succeeds_within_timeout(mock_user, mock_session):
+    """GH #338: agent.run() returning quickly must not raise TimeoutError.
+
+    Confirms the timeout wrapper does not introduce false positives — when
+    the LLM responds within budget, the structured output is returned
+    unchanged.
+    """
+    arc = _make_mock_arc()
+    fake_result = MagicMock()
+    fake_result.output = arc
+
+    with patch(
+        "nikita.heartbeat.planner.get_planner_agent",
+        return_value=MagicMock(run=AsyncMock(return_value=fake_result)),
+    ):
+        result = await _run_planner_agent(mock_user, date(2026, 4, 18))
+
+    assert isinstance(result, DailyArc)
+    assert result.model_used == arc.model_used


### PR DESCRIPTION
## Summary
Wraps planner `agent.run()` in `asyncio.wait_for(timeout=PLANNER_TIMEOUT_S=30.0)` so a single hung Anthropic API call cannot block the daily-arcs tick to Cloud Run's 15-min timeout.

## Closes
- #338 (B4 MEDIUM, Spec 215 pre-flag-flip blocker)

## Changes
- `nikita/heartbeat/planner.py`: added `PLANNER_TIMEOUT_S: Final[float] = 30.0` constant (per `.claude/rules/tuning-constants.md` — multi-line docstring with current value, prior `inf`, driving issue, rationale) + wrapped `agent.run()` in `asyncio.wait_for`.
- `tests/heartbeat/test_planner.py`: 3 new tests
  - `test_planner_timeout_constant_is_30_seconds` — regression guard per tuning-constants rule
  - `test_planner_raises_timeout_when_agent_hangs_beyond_budget` — patches `PLANNER_TIMEOUT_S` to 0.05s, mocks agent.run with a 60s sleep, asserts `asyncio.TimeoutError`; `pytest.mark.timeout(10)` hard-bound
  - `test_planner_succeeds_within_timeout` — confirms wrapper does not introduce false positives

On timeout, raises `asyncio.TimeoutError` for the `generate_daily_arcs` handler in `nikita/api/routes/tasks.py` to record + skip the offending user (handler change tracked separately in #336 / B2 per Plan v6.14 dispatch matrix).

## Local tests
- `uv run pytest tests/heartbeat/test_planner.py -v` -> 9 passed (3 new + 6 existing)
- `uv run pytest -q` (full suite, pre-push HARD GATE) -> 6329 passed, 184 deselected, 3 xpassed in 158s

## Test plan
- [x] Pre-push HARD GATE (full suite green locally)
- [ ] /qa-review --pr N to absolute zero findings (orchestrator dispatches)
- [ ] CI green
- [ ] Squash merge into master after B3 (#337) merges first per Plan v6.14 merge order