### PR TITLE
fix(touchpoints): use User.telegram_id (not telegram_chat_id) in dispatch (#358)

### DIFF
--- a/nikita/touchpoints/engine.py
+++ b/nikita/touchpoints/engine.py
@@ -515,8 +515,8 @@ class TouchpointEngine:
         user_repo = UserRepository(self.session)
         user = await user_repo.get_by_id(user_id)
 
-        if user and user.telegram_chat_id:
-            return user.telegram_chat_id
+        if user and user.telegram_id:
+            return user.telegram_id
 
         return None
 

--- a/tests/touchpoints/test_delivery.py
+++ b/tests/touchpoints/test_delivery.py
@@ -446,6 +446,69 @@ class TestPhasECoverage:
 
 
 # =============================================================================
+# _get_chat_id real-body tests (GH #358)
+# =============================================================================
+
+
+class TestGetChatId:
+    """Real-body tests for TouchpointEngine._get_chat_id (GH #358 regression guard).
+
+    Pre-fix tests at lines 252/267/276 patch _get_chat_id directly so they
+    never exercised the actual attribute access. Walk M (2026-04-19) caught
+    `'User' object has no attribute 'telegram_chat_id'` in production.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_telegram_id_when_user_bound(self, engine_with_mocks):
+        """_get_chat_id returns user.telegram_id (NOT telegram_chat_id) when bound."""
+        from nikita.db.models.user import User
+
+        user_id = uuid4()
+        # Use real User model to catch attribute drift between code and schema.
+        user = User(id=user_id, telegram_id=746410893)
+
+        with patch("nikita.db.repositories.user_repository.UserRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo.get_by_id = AsyncMock(return_value=user)
+            mock_repo_class.return_value = mock_repo
+
+            result = await engine_with_mocks._get_chat_id(user_id)
+
+        assert result == 746410893
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_telegram_id_unbound(self, engine_with_mocks):
+        """_get_chat_id returns None when user.telegram_id is NULL."""
+        from nikita.db.models.user import User
+
+        user_id = uuid4()
+        user = User(id=user_id, telegram_id=None)
+
+        with patch("nikita.db.repositories.user_repository.UserRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo.get_by_id = AsyncMock(return_value=user)
+            mock_repo_class.return_value = mock_repo
+
+            result = await engine_with_mocks._get_chat_id(user_id)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_user_missing(self, engine_with_mocks):
+        """_get_chat_id returns None when user lookup yields no row."""
+        user_id = uuid4()
+
+        with patch("nikita.db.repositories.user_repository.UserRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo.get_by_id = AsyncMock(return_value=None)
+            mock_repo_class.return_value = mock_repo
+
+            result = await engine_with_mocks._get_chat_id(user_id)
+
+        assert result is None
+
+
+# =============================================================================
 # Engine Scheduling Tests
 # =============================================================================
 
@@ -460,7 +523,7 @@ class TestEngineScheduling:
         mock_user.id = uuid4()
         mock_user.chapter = 2
         mock_user.last_interaction_at = datetime.now(timezone.utc) - timedelta(hours=6)
-        mock_user.telegram_chat_id = 12345
+        mock_user.telegram_id = 12345
 
         engine_with_mocks.store.get_recent_touchpoints = AsyncMock(return_value=[])
 


### PR DESCRIPTION
## Summary
Walk M (2026-04-19) caught Spec 215 heartbeat chain broken at Telegram dispatch:
```
nikita.touchpoints.engine - ERROR - Telegram send failed: 'User' object has no attribute 'telegram_chat_id'
```
TouchpointEngine.\_get\_chat\_id referenced a nonexistent attribute. The User model has \`telegram_id\` (per memory \`project_scheduled_events_delivery.md\`: chat_id ≡ telegram_id convention). Existing tests patched \`_get_chat_id\` directly so the real body was never exercised; the one MagicMock that set \`telegram_chat_id\` got away with it because MagicMock auto-whitelists any attribute access.

Closes #358.

## Diff (2 files)
- \`nikita/touchpoints/engine.py\`: 2-line attribute rename
- \`tests/touchpoints/test_delivery.py\`: new \`TestGetChatId\` class (3 real-User regression tests) + 1-line mock correction at line 463

## Test plan
- [x] \`uv run pytest tests/touchpoints/test_delivery.py::TestGetChatId -v\` → 3/3 PASS (RED→GREEN verified)
- [x] \`uv run pytest tests/touchpoints/ -q\` → 254/254 PASS
- [x] \`uv run pytest -q\` (pre-push HARD GATE) → 6484 passed, 2 skipped, 184 deselected, 3 xpassed in 163 s
- [ ] Post-merge: re-trigger heartbeat chain on prod against fresh user; expect Telegram outreach within 10 min

## Walk M evidence
\`docs-to-process/20260419-adv-e2e/M-bug-hunt-walk.md\` CRITICAL-2 (filed pre-fix).