### PR TITLE
fix(db): drop greenlet-unsafe @event listeners; use asyncpg server_settings (#359)

### DIFF
--- a/nikita/db/database.py
+++ b/nikita/db/database.py
@@ -13,7 +13,7 @@ import logging
 from collections.abc import AsyncGenerator
 from functools import lru_cache
 
-from sqlalchemy import event, text
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import AsyncAdaptedQueuePool
 from supabase import AsyncClient, create_async_client
@@ -21,6 +21,25 @@ from supabase import AsyncClient, create_async_client
 from nikita.config.settings import get_settings
 
 logger = logging.getLogger(__name__)
+
+
+def _build_connect_args(settings) -> dict:
+    """Build asyncpg connect_args dict (factored for testability — GH #359).
+
+    Returns:
+        dict suitable for `connect_args=` kwarg of create_async_engine.
+        Includes statement_cache disabling (Supavisor-required) plus
+        server_settings.statement_timeout (replaces the greenlet-unsafe
+        @event.listens_for sync cursor.execute("SET statement_timeout") block
+        that was removed for GH #359).
+    """
+    return {
+        "statement_cache_size": 0,
+        "prepared_statement_cache_size": 0,
+        "server_settings": {
+            "statement_timeout": f"{settings.db_statement_timeout_ms}",
+        },
+    }
 
 
 @lru_cache
@@ -55,38 +74,16 @@ def get_async_engine():
         pool_reset_on_return="rollback",
         # Use async-adapted queue pool
         poolclass=AsyncAdaptedQueuePool,
-        # Fix: Disable asyncpg prepared statement cache for Supavisor compatibility
-        connect_args={
-            "statement_cache_size": 0,
-            "prepared_statement_cache_size": 0,
-        },
+        # GH #359 fix: replaces sync cursor.execute() in @event.listens_for blocks
+        # with asyncpg-native server_settings. Sync cursor calls inside async
+        # connect/checkout listeners triggered `greenlet_spawn has not been called;
+        # can't call await_only() here` during background-task DB writes (Walk M
+        # 2026-04-19 09:48 UTC reproduction). pool_reset_on_return='rollback'
+        # above already handles connection cleanup; the manual ROLLBACK was
+        # redundant. statement_timeout via server_settings is set once at
+        # asyncpg connection time (works under Supavisor session pooling).
+        connect_args=_build_connect_args(settings),
     )
-
-    # Fix: Send ROLLBACK on every connection checkout to clean dirty Supavisor
-    # backend connections. Supavisor (Supabase's connection pooler) may hand out
-    # backend PostgreSQL connections with aborted transactions from prior clients.
-    @event.listens_for(engine.sync_engine, "connect")
-    def _on_connect(dbapi_connection, connection_record):
-        """Send ROLLBACK when a new raw connection is established."""
-        # asyncpg connections need special handling - we use the cursor
-        try:
-            cursor = dbapi_connection.cursor()
-            cursor.execute("ROLLBACK")
-            cursor.execute(f"SET statement_timeout = '{settings.db_statement_timeout_ms}ms'")
-            cursor.close()
-        except Exception as e:
-            logger.warning("[DB] Connection init ROLLBACK failed (ok if clean): %s", e)
-
-    @event.listens_for(engine.sync_engine, "checkout")
-    def _on_checkout(dbapi_connection, connection_record, connection_proxy):
-        """Send ROLLBACK and set statement_timeout when a connection is checked out."""
-        try:
-            cursor = dbapi_connection.cursor()
-            cursor.execute("ROLLBACK")
-            cursor.execute(f"SET statement_timeout = '{settings.db_statement_timeout_ms}ms'")
-            cursor.close()
-        except Exception as e:
-            logger.warning("[DB] Checkout ROLLBACK failed: %s", e)
 
     return engine
 

--- a/tests/db/test_statement_timeout.py
+++ b/tests/db/test_statement_timeout.py
@@ -1,4 +1,4 @@
-"""Tests for configurable statement_timeout (GH #83)."""
+"""Tests for configurable statement_timeout (GH #83) + engine listener regression (GH #359)."""
 from unittest.mock import MagicMock, patch
 import pytest
 from nikita.config.settings import Settings
@@ -30,3 +30,67 @@ class TestStatementTimeoutConfig:
         """Custom value within range should be accepted."""
         settings = Settings(_env_file=None, db_statement_timeout_ms=60000)
         assert settings.db_statement_timeout_ms == 60000
+
+
+class TestEngineConnectArgs:
+    """Regression guard for GH #359 — sync cursor in async listeners.
+
+    Walk M (2026-04-19) caught:
+        nikita.onboarding.handoff - WARNING - Pipeline bootstrap failed:
+        greenlet_spawn has not been called; can't call await_only() here.
+
+    Root cause: @event.listens_for(engine.sync_engine, "connect"|"checkout")
+    blocks ran sync cursor.execute("ROLLBACK") + cursor.execute("SET
+    statement_timeout=...") inside async coroutine context. asyncpg's DBAPI
+    wrapper requires await_only() to be inside greenlet_spawn. Background-task
+    DB writes (handoff.py:283 → social_circle_repository.flush) hit this on
+    every fresh pool checkout.
+
+    Fix: drop the listeners; use asyncpg-native server_settings in connect_args
+    + rely on pool_reset_on_return='rollback' (already configured) for cleanup.
+    """
+
+    def test_no_event_listeners_on_engine(self):
+        """Engine MUST NOT have nikita-defined @event.listens_for callbacks (greenlet-unsafe)."""
+        from nikita.db.database import get_async_engine
+
+        get_async_engine.cache_clear()
+        engine = get_async_engine()
+        # When no listener is registered, dispatch.<event> raises AttributeError.
+        # Treat absence as "no custom listener" (the desired post-fix state).
+        for event_name in ("connect", "checkout"):
+            try:
+                listeners = list(getattr(engine.sync_engine.dispatch, event_name))
+            except AttributeError:
+                continue  # no listeners registered = pass
+            custom = [
+                fn for fn in listeners
+                if getattr(fn, "__module__", "").startswith("nikita.db.database")
+            ]
+            assert custom == [], (
+                f"Greenlet-unsafe {event_name} listener present: {custom}. "
+                "Use connect_args server_settings + pool_reset_on_return='rollback' — see GH #359."
+            )
+
+    def test_statement_timeout_in_server_settings(self):
+        """_build_connect_args MUST set statement_timeout via asyncpg server_settings."""
+        from nikita.db.database import _build_connect_args
+
+        cargs = _build_connect_args(Settings(_env_file=None))
+        assert "server_settings" in cargs, (
+            f"connect_args missing server_settings: {cargs}. See GH #359."
+        )
+        st = cargs["server_settings"].get("statement_timeout")
+        assert st is not None and st != "", (
+            f"server_settings.statement_timeout missing or empty: {cargs}"
+        )
+        # Default 30000ms (3 zeros means raw asyncpg syntax; pg accepts as 'milliseconds')
+        assert st == "30000", f"Expected '30000' (default), got {st!r}"
+
+    def test_statement_cache_disabled(self):
+        """Supavisor compat — both prepared_statement_cache_size and statement_cache_size = 0."""
+        from nikita.db.database import _build_connect_args
+
+        cargs = _build_connect_args(Settings(_env_file=None))
+        assert cargs["statement_cache_size"] == 0
+        assert cargs["prepared_statement_cache_size"] == 0

--- a/tests/regression/test_supavisor_compat.py
+++ b/tests/regression/test_supavisor_compat.py
@@ -3,8 +3,11 @@
 Prevents removal of connect_args that disable prepared statement caching,
 which causes 'prepared statement does not exist' errors with Supabase pooler.
 
-Adapted for Spec 109 database.py which uses flat connect_args (integer values)
-and SQLAlchemy event listeners on engine.sync_engine.
+Updated 2026-04-19 (GH #359): event listeners on engine.sync_engine were
+removed because their sync cursor.execute() calls violated greenlet_spawn
+in async background-task contexts. statement_timeout now flows through
+asyncpg server_settings via connect_args (see nikita/db/database.py
+_build_connect_args).
 """
 import pytest
 from unittest.mock import patch, MagicMock
@@ -22,12 +25,12 @@ class TestSupavisorCompatibility:
             mock_settings.return_value = MagicMock(
                 database_url="postgresql+asyncpg://test:test@localhost/test",
                 debug=False,
+                db_statement_timeout_ms=30000,
             )
             mock_engine = MagicMock()
             mock_engine.sync_engine = MagicMock()
             with patch("nikita.db.database.create_async_engine", return_value=mock_engine) as mock_create:
-                with patch("nikita.db.database.event"):  # suppress event.listens_for
-                    get_async_engine()
+                get_async_engine()
 
                 call_kwargs = mock_create.call_args.kwargs
                 assert "connect_args" in call_kwargs, (
@@ -52,14 +55,26 @@ class TestSupavisorCompatibility:
             mock_settings.return_value = MagicMock(
                 database_url="postgresql+asyncpg://test:test@localhost/test",
                 debug=False,
+                db_statement_timeout_ms=30000,
             )
             mock_engine = MagicMock()
             mock_engine.sync_engine = MagicMock()
             with patch("nikita.db.database.create_async_engine", return_value=mock_engine) as mock_create:
-                with patch("nikita.db.database.event"):
-                    get_async_engine()
+                get_async_engine()
 
                 call_kwargs = mock_create.call_args.kwargs
                 assert call_kwargs.get("pool_reset_on_return") == "rollback"
 
         get_async_engine.cache_clear()
+
+    def test_connect_args_has_server_settings_statement_timeout(self):
+        """GH #359: statement_timeout MUST be in asyncpg server_settings, not via @event listener."""
+        from nikita.db.database import _build_connect_args
+        from nikita.config.settings import Settings
+        cargs = _build_connect_args(Settings(_env_file=None))
+        assert "server_settings" in cargs, (
+            "Missing server_settings — statement_timeout used to live in a sync "
+            "@event.listens_for(connect/checkout) block which violated greenlet_spawn "
+            "in async background-task contexts (Walk M 2026-04-19, GH #359)."
+        )
+        assert cargs["server_settings"].get("statement_timeout") == "30000"


### PR DESCRIPTION
## Summary
Walk M (2026-04-19 09:48 UTC) caught pipeline bootstrap failure post-wizard:
\`greenlet_spawn has not been called; can't call await_only() here.\`
Background-task DB writes from \`generate_and_store_social_circle\` →
\`flush()\` crashed on every fresh pool checkout because the
\`@event.listens_for(engine.sync_engine, "connect"|"checkout")\` listeners
ran sync \`cursor.execute("ROLLBACK")\` + \`cursor.execute("SET statement_timeout=...")\`
inside an async coroutine context. asyncpg's DBAPI wrapper requires
\`greenlet_spawn\` for sync cursor calls; FastAPI BackgroundTask greenlets
don't supply one.

Closes #359.

## Diff (3 files)
- \`nikita/db/database.py\` (-21, +18): drop both \`@event.listens_for\` blocks; add new \`_build_connect_args(settings)\` helper that puts \`statement_timeout\` into asyncpg-native \`server_settings\`; drop unused \`event\` import.
- \`tests/db/test_statement_timeout.py\` (+58, +1 imports): new \`TestEngineConnectArgs\` (3 tests).
- \`tests/regression/test_supavisor_compat.py\` (+18, -3): drop \`event\` patch (no longer imported); add \`db_statement_timeout_ms\` to mock Settings; add new regression guard test.

## Why \`pool_reset_on_return="rollback"\` covers the dropped manual ROLLBACK
Already configured at \`database.py:55\` (\`pool_reset_on_return="rollback"\`) — SQLAlchemy invokes \`ROLLBACK\` on every connection checkin natively, with proper greenlet handling. The manual cursor.execute("ROLLBACK") in \`_on_connect\` and \`_on_checkout\` was redundant. Original PR #122 (BKD-001) added the listeners; \`pool_reset_on_return\` was added later and superseded the need.

## Why asyncpg \`server_settings\` is the right vehicle
asyncpg sets server_settings during connection handshake (PostgreSQL startup parameters), no SET-statement round-trip needed. Persists for the connection lifetime. Works under all Supavisor pooling modes. Documented at https://magicstack.github.io/asyncpg/current/api/index.html#asyncpg.connection.Connection .

## Test plan
- [x] \`uv run pytest tests/db/test_statement_timeout.py tests/regression/test_supavisor_compat.py -v\` → 10/10 PASS
- [x] \`uv run pytest -q\` (pre-push HARD GATE) → 6488 passed, 2 skipped, 184 deselected, 3 xpassed in 185 s
- [ ] Post-merge live test: trigger fresh wizard onboarding; verify no \`greenlet_spawn\` warning in Cloud Run logs; \`user_social_circle\` row created.

## Walk M evidence
\`docs-to-process/20260419-adv-e2e/M-bug-hunt-walk.md\` CRITICAL-3.