### PR TITLE
fix(telegram): suppress duplicate reply when handoff opener fires (#348)

### DIFF
--- a/nikita/platforms/telegram/message_handler.py
+++ b/nikita/platforms/telegram/message_handler.py
@@ -801,7 +801,7 @@ class MessageHandler:
         except Exception as e:
             logger.error(f"[BOSS] Failed to send boss opening: {e}")
 
-    async def _execute_pending_handoff(self, user) -> None:
+    async def _execute_pending_handoff(self, user) -> bool:
         """Fire a deferred portal→Telegram handoff (PR-2 / GH #198-linked).
 
         When portal onboarding completes without a linked ``telegram_id``,
@@ -818,6 +818,14 @@ class MessageHandler:
         message. The row-lock obtained in :meth:`handle` via
         ``get_by_telegram_id_for_update`` prevents double-fire on rapid
         messages.
+
+        Returns:
+            True if the handoff opener was sent successfully (caller MUST
+            suppress downstream MessageHandler dispatch — see GH #348:
+            handoff opener IS the response to user's first message).
+            False on failure or transient error (caller allows downstream
+            dispatch so user still gets *some* reply; pending_handoff
+            stays True for retry on next inbound).
 
         Note on transaction scope: this awaits inside the outer ``handle``
         transaction which holds ``FOR UPDATE`` on the user row. The only
@@ -847,20 +855,46 @@ class MessageHandler:
             )
 
             if result.success:
-                await self.user_repository.set_pending_handoff(user.id, False)
+                # Opener was sent. Try to clear the flag, but if the DB write
+                # fails we MUST still return True — the user-visible side
+                # effect (Telegram message) already happened, and returning
+                # False here would let downstream MessageHandler dispatch fire
+                # → duplicate reply (the exact failure mode this PR fixes).
+                #
+                # Trade-off (tracked in GH #369): flag stays True → next
+                # inbound message will re-enter this method and call
+                # execute_handoff AGAIN. execute_handoff currently has NO
+                # idempotency guard (verified handoff.py:383-502 — no
+                # scheduled_events dedup, no handoff_completed_at column),
+                # so the user MAY receive a duplicate opener on the next
+                # turn. We accept this rare next-turn duplicate (only fires
+                # when DB write fails post-Telegram-send) in exchange for
+                # eliminating the always-on same-turn duplicate from #348.
+                # GH #369 tracks adding the real idempotency guard.
+                try:
+                    await self.user_repository.set_pending_handoff(user.id, False)
+                except Exception as flag_err:
+                    logger.error(
+                        f"[HANDOFF-RETRY] Opener sent but flag-clear failed for "
+                        f"user {user.id}: {flag_err}. Suppressing dispatch this "
+                        f"turn; flag stays True so next inbound retries "
+                        f"(see GH #369 for idempotency gap)."
+                    )
                 logger.info(
                     f"[HANDOFF-RETRY] Fired deferred handoff for user {user.id}"
                 )
-            else:
-                logger.error(
-                    f"[HANDOFF-RETRY] Deferred handoff failed for user {user.id}: "
-                    f"{result.error}"
-                )
+                return True
+            logger.error(
+                f"[HANDOFF-RETRY] Deferred handoff failed for user {user.id}: "
+                f"{result.error}"
+            )
+            return False
         except Exception as e:
             logger.exception(
                 f"[HANDOFF-RETRY] Unexpected error for user {getattr(user, 'id', '?')}: {e}"
             )
             # Intentionally do NOT clear the flag — next message will retry.
+            return False
 
     async def _pre_onboard_gate_fires(
         self,
@@ -1001,7 +1035,17 @@ class MessageHandler:
                     getattr(user, "pending_handoff", False)
                     and user.telegram_id is not None
                 ):
-                    await self._execute_pending_handoff(user)
+                    handoff_succeeded = await self._execute_pending_handoff(user)
+                    if handoff_succeeded:
+                        # GH #348: handoff opener IS the response to user's first
+                        # message; suppress downstream dispatch to prevent the
+                        # duplicate-reply seen in Walk M (2026-04-19): handoff
+                        # opener at +5s + regular MessageHandler reply at +32s.
+                        logger.debug(
+                            f"[ONBOARDING-GATE] User {user_id} handoff fired — "
+                            "suppressing downstream dispatch (GH #348)"
+                        )
+                        return True
                 logger.debug(
                     f"[ONBOARDING-GATE] User {user_id} onboarding_status={onboarding_status} - allowing"
                 )

--- a/tests/platforms/telegram/test_message_handler.py
+++ b/tests/platforms/telegram/test_message_handler.py
@@ -1292,8 +1292,10 @@ class TestPendingHandoffRetry:
             mock_manager.execute_handoff.return_value = mock_result
             mock_cls.return_value = mock_manager
 
-            await handler._execute_pending_handoff(deferred_user)
+            returned = await handler._execute_pending_handoff(deferred_user)
 
+        # GH #348: must return True on success so caller suppresses downstream dispatch
+        assert returned is True
         mock_manager.execute_handoff.assert_awaited_once()
         kwargs = mock_manager.execute_handoff.call_args.kwargs
         assert kwargs["user_id"] == deferred_user.id
@@ -1315,8 +1317,10 @@ class TestPendingHandoffRetry:
             mock_manager.execute_handoff.return_value = mock_result
             mock_cls.return_value = mock_manager
 
-            await handler._execute_pending_handoff(deferred_user)
+            returned = await handler._execute_pending_handoff(deferred_user)
 
+        # GH #348: must return False on failure so caller allows downstream retry
+        assert returned is False
         mock_manager.execute_handoff.assert_awaited_once()
         mock_user_repository.set_pending_handoff.assert_not_awaited()
 
@@ -1331,8 +1335,10 @@ class TestPendingHandoffRetry:
             mock_cls.return_value = mock_manager
 
             # Should not raise
-            await handler._execute_pending_handoff(deferred_user)
+            returned = await handler._execute_pending_handoff(deferred_user)
 
+        # GH #348: exception path must return False (allow downstream retry)
+        assert returned is False
         mock_user_repository.set_pending_handoff.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1363,21 +1369,93 @@ class TestPendingHandoffRetry:
         deferred-handoff retry into the message pipeline. A typo in the
         ``pending_handoff and telegram_id is not None`` predicate would
         silently skip the first-message opening — this test catches that.
+
+        GH #348 update: handoff returning True → _needs_onboarding returns
+        True so downstream MessageHandler dispatch is suppressed (handoff
+        opener IS the response to user's first message, no duplicate reply).
         """
         mock_user_repository.get.return_value = deferred_user
 
         # Patch the inner method so we can observe the gate without running
         # HandoffManager end-to-end (covered by the other tests in this class).
+        # NOTE: spy returns truthy by default (AsyncMock default return = MagicMock,
+        # which is truthy) — we explicitly set False here to test the legacy path
+        # where handoff has already been retried in a prior turn (idempotency).
         with patch.object(
             handler, "_execute_pending_handoff", new_callable=AsyncMock
         ) as spy:
+            spy.return_value = False  # simulate handoff already-fired or transient fail
             result = await handler._needs_onboarding(
                 user_id=deferred_user.id,
                 telegram_id=deferred_user.telegram_id,
                 chat_id=12345,
             )
 
-        assert result is False  # Onboarding is completed — allow through
+        assert result is False  # handoff didn't fire (or failed) — allow regular dispatch through
+        spy.assert_awaited_once_with(deferred_user)
+
+    @pytest.mark.asyncio
+    async def test_execute_pending_handoff_returns_true_when_flag_clear_fails_after_opener_sent(
+        self, handler, mock_user_repository, deferred_user
+    ):
+        """GH #348 partial-success edge: opener sent + flag-clear DB write fails.
+
+        Reviewer-flagged nitpick: if HandoffManager succeeds but the
+        subsequent set_pending_handoff(False) raises (DB hiccup, lost
+        connection mid-transaction), the user has ALREADY received the
+        Telegram opener. Returning False here would let downstream
+        MessageHandler dispatch fire → duplicate reply (the exact bug
+        this PR exists to prevent). Flag stays True for next-message retry,
+        but THIS turn must suppress dispatch.
+        """
+        mock_result = MagicMock(success=True, error=None)
+        mock_user_repository.set_pending_handoff.side_effect = RuntimeError(
+            "db connection lost mid-flush"
+        )
+        with patch("nikita.onboarding.handoff.HandoffManager") as mock_cls:
+            mock_manager = AsyncMock()
+            mock_manager.execute_handoff.return_value = mock_result
+            mock_cls.return_value = mock_manager
+
+            returned = await handler._execute_pending_handoff(deferred_user)
+
+        # Opener was sent → MUST suppress dispatch even though flag-clear failed
+        assert returned is True
+        mock_manager.execute_handoff.assert_awaited_once()
+        mock_user_repository.set_pending_handoff.assert_awaited_once_with(
+            deferred_user.id, False
+        )
+
+    @pytest.mark.asyncio
+    async def test_needs_onboarding_returns_true_when_handoff_succeeded_blocks_double_reply(
+        self, handler, mock_user_repository, deferred_user
+    ):
+        """GH #348 regression: successful handoff suppresses downstream dispatch.
+
+        Walk M (2026-04-19) saw two Nikita replies arrive within 37s of one
+        user message ("hey"): handoff opener AT 5s + regular MessageHandler
+        reply AT 32s. Both fired because pending_handoff was checked AFTER
+        MessageHandler dispatch decision.
+
+        Fix: when _execute_pending_handoff returns True (handoff opener was
+        sent + pending_handoff cleared), _needs_onboarding returns True so
+        the outer handle() method early-returns. The opener IS the response
+        to the user's first message; no duplicate reply.
+        """
+        mock_user_repository.get.return_value = deferred_user
+        with patch.object(
+            handler, "_execute_pending_handoff", new_callable=AsyncMock
+        ) as spy:
+            spy.return_value = True  # handoff fired successfully
+            result = await handler._needs_onboarding(
+                user_id=deferred_user.id,
+                telegram_id=deferred_user.telegram_id,
+                chat_id=12345,
+            )
+        assert result is True, (
+            "handoff success must suppress downstream dispatch (GH #348). "
+            "Returning False here causes the duplicate-reply regression."
+        )
         spy.assert_awaited_once_with(deferred_user)
 
     @pytest.mark.asyncio
@@ -1417,6 +1495,7 @@ class TestPendingHandoffRetry:
         with patch.object(
             handler, "_execute_pending_handoff", new_callable=AsyncMock
         ) as spy:
+            spy.return_value = False  # GH #348: simulate handoff already-fired path
             result = await handler._needs_onboarding(
                 user_id=deferred_user.id,
                 telegram_id=deferred_user.telegram_id,


### PR DESCRIPTION
## Summary
Walk M (2026-04-19 08:44-08:45 UTC) caught two Nikita replies arriving within 37s of single user message "hey":
- 22232 at +5s: handoff opener via HandoffManager
- 22233 at +37s: regular MessageHandler reply

Root cause: \`_execute_pending_handoff\` returned None and never signaled whether the handoff opener was actually sent. \`_needs_onboarding\` returned False unconditionally for completed/skipped users, so the regular MessageHandler dispatch always ran even when an opener had just been sent.

Closes #348.

## Fix
- \`_execute_pending_handoff\` now returns \`bool\` (True on success, False on failure/exception).
- \`_needs_onboarding\` returns \`True\` (suppress downstream dispatch) when handoff fires successfully — opener IS the response.
- Failure path unchanged: \`pending_handoff\` stays True, downstream dispatch proceeds so user still gets *some* reply; retry on next inbound.

## Tests
- New \`test_needs_onboarding_returns_true_when_handoff_succeeded_blocks_double_reply\` asserts handoff success → return True (regression guard).
- Updated 3 existing \`_execute_pending_handoff\` tests to assert return type contract.
- Updated 2 existing \`_needs_onboarding\` tests to set spy.return_value explicitly for legacy already-fired/transient-fail paths.

## Test plan
- [x] \`uv run pytest tests/platforms/telegram/test_message_handler.py -v\` → 36/36 PASS
- [x] \`uv run pytest -q\` (pre-push HARD GATE) → 6489 passed, 2 skipped, 184 deselected, 3 xpassed in 180 s
- [ ] Post-merge live test: trigger a fresh wizard → bot bind → first message; verify exactly ONE Nikita reply within 60 s.

## Walk M evidence
\`docs-to-process/20260419-adv-e2e/M-bug-hunt-walk.md\` HIGH-2.