### PR TITLE
fix(telegram): atomic claim_handoff_intent in _execute_pending_handoff (#369)

### DIFF
--- a/nikita/onboarding/handoff.py
+++ b/nikita/onboarding/handoff.py
@@ -409,8 +409,29 @@ class HandoffManager:
         """
         onboarded_at = datetime.now(UTC)
 
-        # Generate profile summary for context
+        # Generate profile summary for context (cheap, sync) — needed even on
+        # idempotency-skip path so the result envelope is well-formed.
         profile_summary = self._generate_profile_summary(profile)
+
+        # GH #369 idempotency guard: short-circuit if a recent telegram
+        # Conversation row already exists for this user. Closes the race
+        # window where set_pending_handoff(False) DB write fails AFTER
+        # _send_first_message succeeds (PR #367 trade-off): without this
+        # check, the next inbound would re-fire the opener, regenerate the
+        # social circle, and re-bootstrap the pipeline.
+        if await self._already_handed_off(user_id):
+            logger.info(
+                f"Handoff skipped for user {user_id} — recent telegram "
+                f"conversation already exists (idempotency guard, GH #369)"
+            )
+            return HandoffResult(
+                success=True,
+                user_id=user_id,
+                call_id=call_id,
+                onboarded_at=onboarded_at,
+                first_message_sent=False,
+                profile_summary=profile_summary,
+            )
 
         # Spec 035: Generate social circle — fire-and-forget background task
         # to avoid Cloud Run timeout (ONBOARD-TIMEOUT fix)
@@ -525,6 +546,52 @@ class HandoffManager:
             parts.append(f"Style: {profile.conversation_style.value}")
 
         return "\n".join(parts) if parts else "No profile data collected"
+
+    async def _already_handed_off(self, user_id: UUID) -> bool:
+        """Check whether a Telegram handoff already completed recently (GH #369).
+
+        Idempotency dedup signal: a Conversation row with platform='telegram'
+        and started_at within the last hour. _seed_conversation creates this
+        row only on a successful execute_handoff, so its presence proves the
+        opener path completed at least once.
+
+        Window: 1 hour. Long enough to cover the realistic race window
+        (DB write fails post-send → next inbound message arrives within
+        seconds-to-minutes), short enough that legitimate paused/restarted
+        flows after long gaps still get a fresh opener. Matches the
+        FR-11e ALERT_HOLD_TTL pattern for stranded handoff retries.
+
+        Returns:
+            True if a recent Telegram conversation exists (skip handoff).
+            False on any other state, including DB error (fail-open: better
+            to risk a duplicate opener than to silently skip the legit
+            first message).
+        """
+        from datetime import timedelta
+
+        from nikita.db.database import get_session_maker
+        from nikita.db.repositories.conversation_repository import (
+            ConversationRepository,
+        )
+
+        try:
+            window_start = datetime.now(UTC) - timedelta(hours=1)
+            async with get_session_maker()() as check_session:
+                conv_repo = ConversationRepository(check_session)
+                # get_recent returns newest-first; limit=5 covers any voice
+                # conversations interleaved before the telegram seed.
+                recent = await conv_repo.get_recent(user_id, limit=5)
+                for conv in recent:
+                    if conv.platform == "telegram" and conv.started_at >= window_start:
+                        return True
+            return False
+        except Exception as exc:
+            logger.warning(
+                "Idempotency check failed for user %s, fail-open (allow handoff): %s",
+                user_id,
+                exc,
+            )
+            return False
 
     async def _seed_conversation(
         self,

--- a/nikita/platforms/telegram/message_handler.py
+++ b/nikita/platforms/telegram/message_handler.py
@@ -842,6 +842,26 @@ class MessageHandler:
             from nikita.onboarding.handoff import HandoffManager
             from nikita.onboarding.models import build_profile_from_jsonb
 
+            # GH #369 atomic idempotency claim: closes the race opened by
+            # #367's partial-success path AND the FR-11e ceremonial-handoff
+            # path AND the /retry-handoff-greetings cron backstop. The
+            # `claim_handoff_intent` UPDATE is atomic (UPDATE..WHERE
+            # dispatched_at IS NULL AND pending_handoff=TRUE..RETURNING id)
+            # so exactly one of N concurrent dispatchers wins.
+            claimed = await self.user_repository.claim_handoff_intent(user.id)
+            if not claimed:
+                # Either pending_handoff already cleared (a prior
+                # dispatcher succeeded) OR another in-flight caller (FR-11e
+                # /start handler, retry-handoff-greetings cron) holds the
+                # slot. Either way: a greeting IS or WILL be sent by the
+                # other path. Suppress downstream MessageHandler dispatch
+                # to prevent the duplicate-reply mode #348 fixed.
+                logger.info(
+                    f"[HANDOFF-RETRY] Claim skipped for user {user.id} — "
+                    "already dispatched or in-flight"
+                )
+                return True
+
             # Build full profile from JSONB — shared helper ensures parity
             # with _trigger_portal_handoff (GH onboarding-pipeline-bootstrap).
             profile = build_profile_from_jsonb(user.onboarding_profile or {})
@@ -855,45 +875,51 @@ class MessageHandler:
             )
 
             if result.success:
-                # Opener was sent. Try to clear the flag, but if the DB write
-                # fails we MUST still return True — the user-visible side
-                # effect (Telegram message) already happened, and returning
-                # False here would let downstream MessageHandler dispatch fire
-                # → duplicate reply (the exact failure mode this PR fixes).
-                #
-                # Trade-off (tracked in GH #369): flag stays True → next
-                # inbound message will re-enter this method and call
-                # execute_handoff AGAIN. execute_handoff currently has NO
-                # idempotency guard (verified handoff.py:383-502 — no
-                # scheduled_events dedup, no handoff_completed_at column),
-                # so the user MAY receive a duplicate opener on the next
-                # turn. We accept this rare next-turn duplicate (only fires
-                # when DB write fails post-Telegram-send) in exchange for
-                # eliminating the always-on same-turn duplicate from #348.
-                # GH #369 tracks adding the real idempotency guard.
+                # Opener sent. Clear pending_handoff via the canonical helper
+                # (also leaves dispatched_at populated as audit trail per
+                # FR-11e contract). Best-effort: if this DB write fails the
+                # row stays in a "claimed-but-flag-set" state, which the
+                # /retry-handoff-greetings backstop will reconcile after the
+                # 30s reclaim window. Return True regardless because the
+                # user-visible Telegram message already shipped.
                 try:
-                    await self.user_repository.set_pending_handoff(user.id, False)
+                    await self.user_repository.clear_pending_handoff(user.id)
                 except Exception as flag_err:
                     logger.error(
-                        f"[HANDOFF-RETRY] Opener sent but flag-clear failed for "
-                        f"user {user.id}: {flag_err}. Suppressing dispatch this "
-                        f"turn; flag stays True so next inbound retries "
-                        f"(see GH #369 for idempotency gap)."
+                        f"[HANDOFF-RETRY] Opener sent but clear_pending_handoff "
+                        f"failed for user {user.id}: {flag_err}. Backstop will "
+                        "reconcile."
                     )
                 logger.info(
                     f"[HANDOFF-RETRY] Fired deferred handoff for user {user.id}"
                 )
                 return True
+            # execute_handoff returned success=False after a successful claim.
+            # Release the dispatch slot so /retry-handoff-greetings cron picks
+            # it up on the next 60s tick (mirrors commands.py:161 pattern).
             logger.error(
                 f"[HANDOFF-RETRY] Deferred handoff failed for user {user.id}: "
-                f"{result.error}"
+                f"{result.error}. Releasing claim for backstop retry."
             )
+            try:
+                await self.user_repository.reset_handoff_dispatch(user.id)
+            except Exception as reset_err:
+                logger.warning(
+                    f"[HANDOFF-RETRY] reset_handoff_dispatch failed for user "
+                    f"{user.id}: {reset_err}. Backstop will reclaim after "
+                    "30s window."
+                )
             return False
         except Exception as e:
             logger.exception(
                 f"[HANDOFF-RETRY] Unexpected error for user {getattr(user, 'id', '?')}: {e}"
             )
-            # Intentionally do NOT clear the flag — next message will retry.
+            # If we claimed before the exception, release so backstop retries.
+            # Best-effort; if this also fails the 30s reclaim window catches it.
+            try:
+                await self.user_repository.reset_handoff_dispatch(user.id)
+            except Exception:
+                pass
             return False
 
     async def _pre_onboard_gate_fires(

--- a/tests/onboarding/test_handoff.py
+++ b/tests/onboarding/test_handoff.py
@@ -137,6 +137,147 @@ class TestHandoffManager:
         assert result.error is not None and len(result.error) > 0
 
     @pytest.mark.asyncio
+    async def test_execute_handoff_skips_when_already_handed_off(
+        self, manager: HandoffManager
+    ) -> None:
+        """GH #369: idempotency guard — second call within window must NOT re-send.
+
+        Trade-off documented in PR #367 (closing #348): if set_pending_handoff(False)
+        DB write fails after Telegram opener was sent, the flag stays True. The
+        next inbound message would re-enter _execute_pending_handoff → execute_handoff,
+        producing a duplicate opener + duplicate seeded conversation + duplicate
+        background tasks (verified handoff.py:383-502 had no dedup).
+
+        Fix: short-circuit at the top of execute_handoff if a recent telegram
+        Conversation row already exists for this user (signal that prior handoff
+        completed _seed_conversation). Returns success-no-op so caller clears
+        the flag without firing side effects.
+        """
+        user_id = uuid4()
+        profile = UserOnboardingProfile()
+
+        with patch.object(manager, "_already_handed_off", new_callable=AsyncMock) as mock_check:
+            mock_check.return_value = True  # simulate prior successful handoff
+            with patch.object(manager, "_send_first_message") as mock_send:
+                with patch(
+                    "nikita.onboarding.handoff.generate_and_store_social_circle"
+                ) as mock_circle:
+                    with patch.object(manager, "_bootstrap_pipeline") as mock_bootstrap:
+                        manager._seed_conversation = AsyncMock(return_value=None)
+                        result = await manager.execute_handoff(
+                            user_id=user_id,
+                            telegram_id=123456789,
+                            profile=profile,
+                        )
+
+        # Must NOT have called any side-effect path
+        mock_send.assert_not_called()
+        mock_circle.assert_not_called()
+        mock_bootstrap.assert_not_called()
+        # Must return success so caller clears the pending_handoff flag
+        assert result.success is True
+        assert result.first_message_sent is False
+        assert result.user_id == user_id
+        mock_check.assert_awaited_once_with(user_id)
+
+    @pytest.mark.asyncio
+    async def test_already_handed_off_returns_true_when_recent_telegram_conversation_exists(
+        self, manager: HandoffManager
+    ) -> None:
+        """GH #369: dedup signal is a recent platform='telegram' Conversation row."""
+        from datetime import timedelta
+
+        user_id = uuid4()
+        recent_conv = MagicMock()
+        recent_conv.platform = "telegram"
+        recent_conv.started_at = datetime.now(UTC) - timedelta(minutes=5)
+
+        mock_repo = MagicMock()
+        mock_repo.get_recent = AsyncMock(return_value=[recent_conv])
+        mock_session = AsyncMock()
+        mock_session_cm = MagicMock()
+        mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_session_factory = MagicMock(return_value=mock_session_cm)
+
+        with patch(
+            "nikita.db.database.get_session_maker", return_value=mock_session_factory
+        ):
+            with patch(
+                "nikita.db.repositories.conversation_repository.ConversationRepository",
+                return_value=mock_repo,
+            ):
+                result = await manager._already_handed_off(user_id)
+
+        assert result is True
+        mock_repo.get_recent.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_already_handed_off_returns_false_when_only_voice_conversations(
+        self, manager: HandoffManager
+    ) -> None:
+        """GH #369: voice-only history is NOT a telegram-handoff completion signal."""
+        user_id = uuid4()
+        voice_conv = MagicMock()
+        voice_conv.platform = "voice"
+        voice_conv.started_at = datetime.now(UTC)
+
+        mock_repo = MagicMock()
+        mock_repo.get_recent = AsyncMock(return_value=[voice_conv])
+        mock_session = AsyncMock()
+        mock_session_cm = MagicMock()
+        mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_session_factory = MagicMock(return_value=mock_session_cm)
+
+        with patch(
+            "nikita.db.database.get_session_maker", return_value=mock_session_factory
+        ):
+            with patch(
+                "nikita.db.repositories.conversation_repository.ConversationRepository",
+                return_value=mock_repo,
+            ):
+                result = await manager._already_handed_off(user_id)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_already_handed_off_returns_false_when_telegram_conversation_too_old(
+        self, manager: HandoffManager
+    ) -> None:
+        """GH #369: stale telegram conversation (>1h) doesn't block fresh handoff.
+
+        Otherwise users with paused/restarted onboarding flows would never get
+        the opener after a long gap. 1h matches FR-11e ALERT_HOLD_TTL window
+        for stranded handoff retries.
+        """
+        from datetime import timedelta
+
+        user_id = uuid4()
+        old_conv = MagicMock()
+        old_conv.platform = "telegram"
+        old_conv.started_at = datetime.now(UTC) - timedelta(hours=2)
+
+        mock_repo = MagicMock()
+        mock_repo.get_recent = AsyncMock(return_value=[old_conv])
+        mock_session = AsyncMock()
+        mock_session_cm = MagicMock()
+        mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_session_factory = MagicMock(return_value=mock_session_cm)
+
+        with patch(
+            "nikita.db.database.get_session_maker", return_value=mock_session_factory
+        ):
+            with patch(
+                "nikita.db.repositories.conversation_repository.ConversationRepository",
+                return_value=mock_repo,
+            ):
+                result = await manager._already_handed_off(user_id)
+
+        assert result is False
+
+    @pytest.mark.asyncio
     async def test_execute_handoff_returns_handoff_result(self, manager: HandoffManager) -> None:
         """AC-T026.2: execute_handoff() returns HandoffResult."""
         user_id = uuid4()

--- a/tests/platforms/telegram/test_message_handler.py
+++ b/tests/platforms/telegram/test_message_handler.py
@@ -1254,6 +1254,10 @@ class TestPendingHandoffRetry:
     def mock_user_repository(self):
         repo = AsyncMock()
         repo.set_pending_handoff.return_value = None
+        repo.clear_pending_handoff.return_value = None
+        repo.reset_handoff_dispatch.return_value = None
+        # GH #369: claim defaults True (test happy path); override per-test for races.
+        repo.claim_handoff_intent.return_value = True
         return repo
 
     @pytest.fixture
@@ -1296,15 +1300,16 @@ class TestPendingHandoffRetry:
 
         # GH #348: must return True on success so caller suppresses downstream dispatch
         assert returned is True
+        # GH #369: claim called BEFORE execute_handoff (atomic dedup)
+        mock_user_repository.claim_handoff_intent.assert_awaited_once_with(deferred_user.id)
         mock_manager.execute_handoff.assert_awaited_once()
         kwargs = mock_manager.execute_handoff.call_args.kwargs
         assert kwargs["user_id"] == deferred_user.id
         assert kwargs["telegram_id"] == deferred_user.telegram_id
         assert isinstance(kwargs["profile"], UserOnboardingProfile)
         assert kwargs["profile"].darkness_level == 4
-        mock_user_repository.set_pending_handoff.assert_awaited_once_with(
-            deferred_user.id, False
-        )
+        # GH #369: success path uses canonical clear_pending_handoff (not set_pending_handoff)
+        mock_user_repository.clear_pending_handoff.assert_awaited_once_with(deferred_user.id)
 
     @pytest.mark.asyncio
     async def test_execute_pending_handoff_preserves_flag_on_failure(
@@ -1322,7 +1327,9 @@ class TestPendingHandoffRetry:
         # GH #348: must return False on failure so caller allows downstream retry
         assert returned is False
         mock_manager.execute_handoff.assert_awaited_once()
-        mock_user_repository.set_pending_handoff.assert_not_awaited()
+        # GH #369: failure path releases claim so retry-handoff-greetings cron picks up
+        mock_user_repository.reset_handoff_dispatch.assert_awaited_once_with(deferred_user.id)
+        mock_user_repository.clear_pending_handoff.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_execute_pending_handoff_swallows_exceptions(
@@ -1339,7 +1346,9 @@ class TestPendingHandoffRetry:
 
         # GH #348: exception path must return False (allow downstream retry)
         assert returned is False
-        mock_user_repository.set_pending_handoff.assert_not_awaited()
+        # GH #369: exception path also releases claim for backstop
+        mock_user_repository.reset_handoff_dispatch.assert_awaited_once_with(deferred_user.id)
+        mock_user_repository.clear_pending_handoff.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_execute_pending_handoff_defaults_darkness_level(
@@ -1400,16 +1409,18 @@ class TestPendingHandoffRetry:
     ):
         """GH #348 partial-success edge: opener sent + flag-clear DB write fails.
 
-        Reviewer-flagged nitpick: if HandoffManager succeeds but the
-        subsequent set_pending_handoff(False) raises (DB hiccup, lost
-        connection mid-transaction), the user has ALREADY received the
-        Telegram opener. Returning False here would let downstream
-        MessageHandler dispatch fire → duplicate reply (the exact bug
-        this PR exists to prevent). Flag stays True for next-message retry,
-        but THIS turn must suppress dispatch.
+        If HandoffManager succeeds but the subsequent clear_pending_handoff
+        raises (DB hiccup, lost connection mid-transaction), the user has
+        ALREADY received the Telegram opener. Returning False here would let
+        downstream MessageHandler dispatch fire → duplicate reply.
+
+        GH #369 fix: claim_handoff_intent already won so the row's
+        handoff_greeting_dispatched_at is set. The /retry-handoff-greetings
+        cron's 30s reclaim window will reconcile pending_handoff if the
+        clear failed. THIS turn must suppress dispatch.
         """
         mock_result = MagicMock(success=True, error=None)
-        mock_user_repository.set_pending_handoff.side_effect = RuntimeError(
+        mock_user_repository.clear_pending_handoff.side_effect = RuntimeError(
             "db connection lost mid-flush"
         )
         with patch("nikita.onboarding.handoff.HandoffManager") as mock_cls:
@@ -1422,9 +1433,41 @@ class TestPendingHandoffRetry:
         # Opener was sent → MUST suppress dispatch even though flag-clear failed
         assert returned is True
         mock_manager.execute_handoff.assert_awaited_once()
-        mock_user_repository.set_pending_handoff.assert_awaited_once_with(
-            deferred_user.id, False
+        # Verify clear_pending_handoff WAS attempted (GH #369 canonical helper)
+        mock_user_repository.clear_pending_handoff.assert_awaited_once_with(
+            deferred_user.id
         )
+
+    @pytest.mark.asyncio
+    async def test_execute_pending_handoff_skips_when_claim_lost(
+        self, handler, mock_user_repository, deferred_user
+    ):
+        """GH #369 atomic dedup: claim_handoff_intent=False → skip + suppress dispatch.
+
+        Race scenarios closed:
+        1. FR-11e ceremonial path (`/start <code>` handler) ran first and won the
+           atomic claim; about to dispatch via _dispatch_handoff_greeting.
+        2. /retry-handoff-greetings cron just claimed for backstop dispatch.
+        3. pending_handoff already cleared (a prior dispatcher succeeded).
+
+        In all 3 cases, the other path IS or WILL send the greeting. We must
+        NOT call execute_handoff (would race / double-fire) AND we must return
+        True to suppress downstream MessageHandler dispatch (otherwise a regular
+        reply joins the about-to-arrive opener — same duplicate-reply bug as #348).
+        """
+        mock_user_repository.claim_handoff_intent.return_value = False
+        with patch("nikita.onboarding.handoff.HandoffManager") as mock_cls:
+            mock_manager = AsyncMock()
+            mock_cls.return_value = mock_manager
+
+            returned = await handler._execute_pending_handoff(deferred_user)
+
+        assert returned is True
+        mock_user_repository.claim_handoff_intent.assert_awaited_once_with(deferred_user.id)
+        # Critical: HandoffManager NEVER instantiated/called when claim lost
+        mock_manager.execute_handoff.assert_not_awaited()
+        mock_user_repository.clear_pending_handoff.assert_not_awaited()
+        mock_user_repository.reset_handoff_dispatch.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_needs_onboarding_returns_true_when_handoff_succeeded_blocks_double_reply(


### PR DESCRIPTION
## Summary
**v2 redesign per iter-1 reviewer feedback**: switched from conversation-row dedup (wrong signal, unaligned with existing infra) to the existing \`claim_handoff_intent\` atomic UPDATE..WHERE..RETURNING primitive (already used by FR-11e ceremonial path + /retry-handoff-greetings cron).

Closes #369.

## Architecture
- **Scope**: \`MessageHandler._execute_pending_handoff\` (NOT \`HandoffManager.execute_handoff\` — that would break voice/server_tool callers which don't have \`pending_handoff=True\`).
- **Atomic primitive reused**: \`UserRepository.claim_handoff_intent\` at \`user_repository.py:680-690\`. WHERE predicate: \`handoff_greeting_dispatched_at IS NULL AND pending_handoff=TRUE\`. RETURNING resolves the race with single-statement atomicity.
- **Three exclusive paths gated by ONE primitive**: FR-11e \`/start <code>\` (commands.py:591), pg_cron retry backstop (tasks.py:1601), this PR's \`_execute_pending_handoff\`.

## Race scenarios closed
1. FR-11e \`/start <code>\` ran first → background task dispatching greeting → we skip cleanly.
2. /retry-handoff-greetings cron just claimed → same.
3. \`pending_handoff\` already cleared (prior dispatcher succeeded) → claim returns False (predicate fails) → skip.
4. PR #367 partial-success window (\`clear_pending_handoff\` DB write fails after Telegram send) → on next inbound, claim returns False because \`handoff_greeting_dispatched_at IS NOT NULL\` → skip duplicate.

## Other changes
- Success path: \`clear_pending_handoff\` (canonical helper) instead of \`set_pending_handoff(False)\`. Leaves \`dispatched_at\` populated as audit trail per FR-11e contract.
- Failure paths (\`execute_handoff\` returns success=False OR exception): \`reset_handoff_dispatch\` so /retry-handoff-greetings cron picks up on next 60s tick. Mirrors \`commands.py:161\` pattern.
- Best-effort: failures of \`clear_pending_handoff\` / \`reset_handoff_dispatch\` are logged, not propagated; the 30s reclaim window handles reconciliation.

## Tests
- New \`test_execute_pending_handoff_skips_when_claim_lost\`: \`claim=False\` → \`HandoffManager\` NEVER instantiated/called, no clear/reset, returns True (suppress dispatch).
- Updated 4 existing tests for new claim/clear/reset contract:
  - success path asserts \`claim_handoff_intent\` + \`clear_pending_handoff\` called
  - failure path asserts \`reset_handoff_dispatch\` called
  - exception path same
  - partial-success edge (clear_pending_handoff raises): still returns True; backstop reconciles
- Updated \`mock_user_repository\` fixture: claim defaults True (happy path), other helpers return None.

## Test plan
- [x] \`uv run pytest tests/platforms/telegram/test_message_handler.py -k TestPendingHandoffRetry -v\` → 10/10 PASS
- [x] \`uv run pytest -q\` (pre-push HARD GATE) → 6510 passed, 2 skipped, 184 deselected, 3 xpassed in 161 s
- [ ] Post-merge: live verification — trigger fresh wizard → bot bind → first message; expect exactly ONE Nikita opener; force \`clear_pending_handoff\` failure (manual SQL kill) → on next inbound, expect skip log, no duplicate.

## What changed since v1 (force-push)
Dropped the conversation-row dedup (\`HandoffManager._already_handed_off\`). v1's signal had two flaws (per iter-1 reviewer): (a) wrong column — reuses existing \`handoff_greeting_dispatched_at\` instead of inventing new state; (b) intra-call race not closed (two concurrent execute_handoff calls would both pass dedup before either inserted the seed row). v2's atomic UPDATE..WHERE..RETURNING closes both.