### PR TITLE
fix(telegram): CRITICAL webhook 500 from CommandHandler DI mismatch (#371)

### DIFF
--- a/nikita/api/routes/telegram.py
+++ b/nikita/api/routes/telegram.py
@@ -28,7 +28,6 @@ from nikita.db.database import get_async_session, get_session_maker, get_supabas
 from nikita.db.dependencies import (
     ConversationRepoDep,
     MetricsRepoDep,
-    OnboardingStateRepoDep,
     PendingRegistrationRepoDep,
     ProfileRepoDep,
     TelegramLinkRepoDep,
@@ -176,24 +175,26 @@ async def get_command_handler(
     telegram_auth: TelegramAuthDep,
     bot: BotDep,
     profile_repo: ProfileRepoDep,
-    onboarding_repo: OnboardingStateRepoDep,
     telegram_link_repo: TelegramLinkRepoDep,
 ) -> CommandHandler:
     """Get CommandHandler with injected dependencies.
 
-    Issue #7 Fix: Added profile_repo and onboarding_repo for limbo state detection.
-    When a user exists but has no profile (due to Bug #2), we detect this and
-    create a fresh onboarding state to restart the flow.
-
     GH #321: Added telegram_link_repo so `/start <payload>` from portal
     deep-links can consume the code and atomically bind users.telegram_id.
+
+    GH #371 (2026-04-20): dropped `onboarding_repo` param + kwarg. PR #357
+    (commit 371fb97, FR-11c) removed `onboarding_repository` from
+    `CommandHandler.__init__` but forgot to update this DI wiring, causing
+    100% webhook 500 with `TypeError: unexpected keyword argument
+    'onboarding_repository'` for ~23h (rev 00262 onward). Tests here mock
+    CommandHandler directly and did not exercise the real DI path.
 
     Args:
         user_repo: Injected UserRepository.
         telegram_auth: Injected TelegramAuth.
         bot: Injected TelegramBot from app.state.
-        profile_repo: Injected ProfileRepository for limbo state detection.
-        onboarding_repo: Injected OnboardingStateRepository for limbo state fix.
+        profile_repo: Injected ProfileRepository for FR-11c limbo-state
+            detection in `_handle_start`.
         telegram_link_repo: Injected TelegramLinkRepository for deep-link
             code verification (GH #321).
 
@@ -205,7 +206,6 @@ async def get_command_handler(
         telegram_auth=telegram_auth,
         bot=bot,
         profile_repository=profile_repo,
-        onboarding_repository=onboarding_repo,
         telegram_link_repository=telegram_link_repo,
     )
 

--- a/tests/api/routes/test_telegram.py
+++ b/tests/api/routes/test_telegram.py
@@ -765,3 +765,47 @@ class TestWebhookRateLimiting:
         )
         assert resp.status_code == 200
         rate_limiter.check_by_telegram_id.assert_called_once_with(telegram_id=99999)
+
+
+class TestDIContract:
+    """GH #371 regression: real DI assembly path must stay consistent.
+
+    PR #357 (FR-11c) removed `onboarding_repository` from
+    `CommandHandler.__init__` but forgot to update `get_command_handler`,
+    which silently passed an unknown kwarg. Every mocked test passed
+    because they mocked `CommandHandler` directly. 23h of 100% webhook
+    500 in prod before a live dogfood walk caught it.
+
+    This contract test reflects the DI factory against the class
+    signature so any future drift fails in CI instead of prod.
+    """
+
+    def test_get_command_handler_kwargs_match_command_handler_init(self):
+        """Every kwarg passed by `get_command_handler` must exist on `CommandHandler.__init__`."""
+        import ast
+        import inspect
+        from pathlib import Path
+
+        from nikita.api.routes import telegram as tel_module
+        from nikita.platforms.telegram.commands import CommandHandler
+
+        # Parse the factory's return statement to discover the kwargs it
+        # actually hands to CommandHandler. Works without executing the DI
+        # graph (which would need a real DB session, settings, etc.).
+        factory_source = inspect.getsource(tel_module.get_command_handler)
+        call_node = None
+        for node in ast.walk(ast.parse(factory_source)):
+            if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "CommandHandler":
+                call_node = node
+                break
+        assert call_node is not None, "get_command_handler must call CommandHandler(...)"
+
+        passed_kwargs = {kw.arg for kw in call_node.keywords if kw.arg is not None}
+        accepted_kwargs = set(inspect.signature(CommandHandler.__init__).parameters) - {"self"}
+
+        unknown = passed_kwargs - accepted_kwargs
+        assert not unknown, (
+            f"get_command_handler passes kwargs not accepted by CommandHandler.__init__: "
+            f"{sorted(unknown)}. Either add them to the __init__ signature or drop them "
+            f"from the factory. (GH #371 regression guard)"
+        )


### PR DESCRIPTION
## Summary

Fixes GH #371. Production Telegram bot has been 100% down for ~23h with `TypeError: CommandHandler.__init__() got an unexpected keyword argument 'onboarding_repository'` on every webhook POST. Discovered during Spec 214 FR-11e live dogfood walk.

## Root cause

PR #357 (commit `371fb97`, FR-11c T1.3) removed `onboarding_repository` from `CommandHandler.__init__` but did not update `get_command_handler` in `nikita/api/routes/telegram.py:174-210`, which still passed it as a kwarg. All existing tests in `tests/api/routes/test_telegram.py` mock `CommandHandler` directly via `app.dependency_overrides[get_command_handler]`, so they never exercised the real DI factory call. CI green, QA green, prod outage.

## Fix

1. Drop the `onboarding_repo: OnboardingStateRepoDep` param from `get_command_handler` signature.
2. Drop the `onboarding_repository=onboarding_repo` kwarg from the `CommandHandler(...)` call.
3. Drop the now-unused `OnboardingStateRepoDep` import from this file (the type alias stays defined in `nikita/db/dependencies.py` for future callers).
4. New `TestDIContract::test_get_command_handler_kwargs_match_command_handler_init` — AST-walks `get_command_handler` body, extracts every kwarg passed to `CommandHandler(...)`, reflects against `inspect.signature(CommandHandler.__init__)`. Any future drift fails in CI rather than prod.

## Local tests

- `uv run pytest tests/api/routes/test_telegram.py tests/api/routes/test_telegram_adversarial.py tests/platforms/telegram/test_commands.py tests/platforms/telegram/test_commands_fr11c.py -q` → 68 passed

## Deploy plan

Merge + auto-deploy via Cloud Build → Cloud Run. Post-deploy verification: re-trigger `/start` from V. via Telegram MCP, assert 200 OK + bot response (FR-11c routes to portal bridge URL for unknown users).

## Test plan

- [x] Unit: 68 tests including new DI contract guard
- [ ] Post-merge: Cloud Run deploy green
- [ ] Post-merge: live `/start` returns 200 OK
- [ ] Post-merge: bot replies to V. within 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)