### PR TITLE
fix(214,373,374): converse path 3-way drift + portal URL canonical

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -27,6 +27,15 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
       - run: pip install -e ".[dev]"
+      - name: Stale portal URL grep gate (GH #374)
+        run: |
+          # Pre-test fast gate. Scope strictly to nikita/ + portal/ — historical
+          # references in docs/, ROADMAP.md, etc. are out of scope by design.
+          if grep -rE 'or[[:space:]]+"https://portal-phi-orcin' nikita/ portal/ 2>/dev/null; then
+            echo "::error::Stale portal-phi-orcin.vercel.app fallback in production code (GH #374)."
+            echo "Per .claude/rules/vercel-cors-canonical.md, canonical is nikita-mygirl.com."
+            exit 1
+          fi
       - name: Run unit tests
         env:
           ANTHROPIC_API_KEY: sk-ant-dummy-key-for-ci-unit-tests

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -515,7 +515,7 @@ _VALIDATION_REJECT_AGE_REPLY: Final[str] = (
 
 
 @router.post(
-    "/onboarding/converse",
+    "/converse",
     response_model=ConverseResponse,
     summary="Conversational onboarding turn (Spec 214 FR-11d)",
     # B4 QA iter-1: advertise the 429 schema explicitly so the OpenAPI

--- a/nikita/config/settings.py
+++ b/nikita/config/settings.py
@@ -111,10 +111,8 @@ class Settings(BaseSettings):
     )
 
     # Portal (Vercel deployment) - canonical apex per .claude/rules/vercel-cors-canonical.md
-    # Default = production canonical host. Override via PORTAL_URL env var for staging.
-    # GH #374 (PR fix-373-374): was Optional[str] = None with 5 production fallbacks
-    # to a stale Vercel preview alias. Switched to required str with canonical default
-    # to eliminate the fallback footgun.
+    # GH #374: switched from Optional[str]=None (with 5 stale Vercel-alias fallbacks)
+    # to required str with canonical default. Override via PORTAL_URL for staging.
     portal_url: str = Field(
         default="https://nikita-mygirl.com",
         description="Portal frontend URL (default: canonical production apex)",

--- a/nikita/config/settings.py
+++ b/nikita/config/settings.py
@@ -110,10 +110,14 @@ class Settings(BaseSettings):
         description="Authentication secret for pg_cron task endpoints (separate from webhook secret for security isolation)",
     )
 
-    # Portal (Vercel deployment) - Optional
-    portal_url: str | None = Field(
-        default=None,
-        description="Portal frontend URL (e.g., https://nikita-portal.vercel.app)",
+    # Portal (Vercel deployment) - canonical apex per .claude/rules/vercel-cors-canonical.md
+    # Default = production canonical host. Override via PORTAL_URL env var for staging.
+    # GH #374 (PR fix-373-374): was Optional[str] = None with 5 production fallbacks
+    # to a stale Vercel preview alias. Switched to required str with canonical default
+    # to eliminate the fallback footgun.
+    portal_url: str = Field(
+        default="https://nikita-mygirl.com",
+        description="Portal frontend URL (default: canonical production apex)",
     )
 
     # Backend URL (Cloud Run service URL) - Required for OTP email redirects

--- a/nikita/onboarding/bridge_tokens.py
+++ b/nikita/onboarding/bridge_tokens.py
@@ -53,14 +53,10 @@ BridgeReason = Literal["resume", "re-onboard"]
 
 def _portal_base_url() -> str:
     """Resolve the portal base URL from settings."""
-    settings = get_settings()
-    # Fall back to the canonical production URL if settings lack it; the
-    # same fallback the legacy helper uses. In practice settings always
-    # carry portal_url in deployed environments.
-    return (
-        settings.portal_url
-        or "https://portal-phi-orcin.vercel.app"
-    )
+    # GH #374: settings.portal_url default is now the canonical production
+    # host (PR fix-373-374); the prior fallback to a stale Vercel preview
+    # alias is dead code and removed.
+    return get_settings().portal_url
 
 
 async def _mint_or_reuse_bridge_token(

--- a/nikita/platforms/telegram/auth.py
+++ b/nikita/platforms/telegram/auth.py
@@ -109,7 +109,9 @@ class TelegramAuth:
 
         settings = get_settings()
 
-        if registration_source == "portal" and settings.portal_url:
+        # GH #374: settings.portal_url is now required str (canonical default),
+        # so the prior truthy check is vestigial. Branch only on registration source.
+        if registration_source == "portal":
             # Portal flow: redirect to portal's /auth/callback for session exchange
             redirect_url = f"{settings.portal_url}/auth/callback"
         else:

--- a/nikita/platforms/telegram/commands.py
+++ b/nikita/platforms/telegram/commands.py
@@ -731,8 +731,8 @@ class CommandHandler:
             from nikita.config.settings import get_settings
             from nikita.platforms.telegram.utils import generate_portal_bridge_url
 
-            settings = get_settings()
-            portal_url = settings.portal_url or "https://portal-phi-orcin.vercel.app"
+            # GH #374: settings.portal_url default is canonical; fallback removed.
+            portal_url = get_settings().portal_url
 
             # Zero-click portal auth via bridge token (GH #187 / GH #233)
             magic_link = await generate_portal_bridge_url(

--- a/nikita/platforms/telegram/message_handler.py
+++ b/nikita/platforms/telegram/message_handler.py
@@ -1159,8 +1159,8 @@ class MessageHandler:
             telegram_id: Telegram user ID.
             chat_id: Telegram chat ID for sending message.
         """
-        settings = get_settings()
-        portal_url = settings.portal_url or "https://portal-phi-orcin.vercel.app"
+        # GH #374: settings.portal_url default is canonical; fallback removed.
+        portal_url = get_settings().portal_url
 
         # Generate bridge URL for zero-click portal auth (GH #187 / GH #233).
         # Function-local import — patch source at utils module, per testing rule.

--- a/nikita/platforms/telegram/otp_handler.py
+++ b/nikita/platforms/telegram/otp_handler.py
@@ -341,8 +341,8 @@ class OTPVerificationHandler:
             user_id: User's UUID for building portal URL.
             telegram_id: Telegram user ID for logging.
         """
-        settings = get_settings()
-        portal_url = settings.portal_url or "https://portal-phi-orcin.vercel.app"
+        # GH #374: settings.portal_url default is canonical; fallback removed.
+        portal_url = get_settings().portal_url
 
         # Generate bridge URL for zero-click portal auth (GH #187 / GH #233).
         # Function-local import keeps the patch target as the source module

--- a/nikita/platforms/telegram/utils.py
+++ b/nikita/platforms/telegram/utils.py
@@ -46,8 +46,8 @@ async def generate_portal_bridge_url(
             AuthBridgeRepository,
         )
 
-        settings = get_settings()
-        portal_url = settings.portal_url or "https://portal-phi-orcin.vercel.app"
+        # GH #374: settings.portal_url default is canonical; fallback removed.
+        portal_url = get_settings().portal_url
 
         session_maker = get_session_maker()
         async with session_maker() as session:

--- a/portal/e2e/onboarding-chat.spec.ts
+++ b/portal/e2e/onboarding-chat.spec.ts
@@ -9,7 +9,10 @@
 
 import { test, expect, Route } from "@playwright/test"
 
-const API = "**/api/v1/portal/onboarding/converse"
+// GH #373: route was `/api/v1/portal/onboarding/converse` (4-way drift between
+// frontend hook + backend mount + test docstrings); fixed to canonical
+// `/api/v1/onboarding/converse`. Mock pattern updated to match production hook.
+const API = "**/api/v1/onboarding/converse"
 const LINK = "**/api/v1/portal/link-telegram"
 
 type MockTurn = {

--- a/portal/src/app/onboarding/__tests__/useOnboardingAPI.converse.test.ts
+++ b/portal/src/app/onboarding/__tests__/useOnboardingAPI.converse.test.ts
@@ -51,7 +51,7 @@ describe("useOnboardingAPI.converse — T3.4 idempotency + wire shape", () => {
     })
     expect(api.post).toHaveBeenCalledTimes(1)
     const [path, body, headers] = (api.post as ReturnType<typeof vi.fn>).mock.calls[0]
-    expect(path).toBe("/portal/onboarding/converse")
+    expect(path).toBe("/onboarding/converse")
     const bodyObj = body as { turn_id?: string; user_input: unknown }
     expect(typeof bodyObj.turn_id).toBe("string")
     // UUID v4 shape (36 chars, hyphenated)

--- a/portal/src/app/onboarding/hooks/use-onboarding-api.ts
+++ b/portal/src/app/onboarding/hooks/use-onboarding-api.ts
@@ -182,7 +182,7 @@ export function useOnboardingAPI(): UseOnboardingAPI {
           turn_id: turnId,
         }
         return api.post<ConverseResponse>(
-          "/portal/onboarding/converse",
+          "/onboarding/converse",
           body,
           { "Idempotency-Key": turnId },
           signal

--- a/portal/src/app/onboarding/types/ControlSelection.ts
+++ b/portal/src/app/onboarding/types/ControlSelection.ts
@@ -4,7 +4,7 @@
  * Discriminated TypeScript union that mirrors the Pydantic ControlSelection
  * server model in `nikita/agents/onboarding/control_selection.py`. The portal
  * serializes chip/slider/toggle/cards selections in this shape before
- * POSTing to `/portal/onboarding/converse`. Free-text input is normalized to
+ * POSTing to `/onboarding/converse` (resolves to `/api/v1/onboarding/converse`
  * a raw `string` before POST (see `normalizeUserInput` below).
  *
  * Design decision D4 (plan.md §3): TS union with `kind` discriminator +

--- a/tests/api/routes/test_converse_endpoint.py
+++ b/tests/api/routes/test_converse_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for POST /api/v1/portal/onboarding/converse (Spec 214 FR-11d).
+"""Tests for POST /api/v1/onboarding/converse (Spec 214 FR-11d).
 
 Split across three concerns:
 
@@ -304,3 +304,48 @@ class TestConverseJsonbPersistence:
         mock_ledger.add_spend.assert_awaited_once()
         # Idempotency cache get() fired (turn_id=None path → skipped put).
         mock_idem.get.assert_not_awaited()  # turn_id is None → no HIT check
+
+
+# ---------------------------------------------------------------------------
+# GH #373 — route registration regression guard (real FastAPI app)
+# ---------------------------------------------------------------------------
+
+
+class TestConverseEndpointPath:
+    """GH #373 regression guard — POST /api/v1/onboarding/converse must be
+    registered at the canonical path (no doubled /onboarding prefix, no
+    /portal prefix).
+
+    Walk N (2026-04-20) caught a 3-way drift: frontend posted to
+    /portal/onboarding/converse, backend declaration produced
+    /api/v1/onboarding/onboarding/converse (doubled), test docstring
+    advertised yet a third path. Mock tests passed; prod 404'd for 5+ days.
+    """
+
+    def test_converse_endpoint_path_resolves_via_real_app(self):
+        """The canonical path /api/v1/onboarding/converse MUST be registered.
+
+        Before the #373 fix: route declaration ``"/onboarding/converse"`` under
+        mount ``prefix="/api/v1/onboarding"`` produces a doubled
+        ``/api/v1/onboarding/onboarding/converse`` path; no auth-or-anything
+        request lands at the canonical path → 404 here. After the fix
+        (declaration becomes ``"/converse"``) this passes with a 401/403/422
+        (auth/schema rejection, route exists).
+        """
+        from fastapi.testclient import TestClient
+
+        from nikita.api.main import create_app
+
+        app = create_app()
+        client = TestClient(app)
+        # No auth header → expect 401/403; bad body → may produce 422.
+        # All three are "route exists, request rejected" — opposite of 404.
+        response = client.post(
+            "/api/v1/onboarding/converse",
+            json={"user_input": "x", "conversation_history": []},
+        )
+        assert response.status_code != 404, (
+            f"Route /api/v1/onboarding/converse not registered. Got 404. "
+            f"Check portal_onboarding.py route declaration vs main.py mount prefix "
+            f"for #373-class regression."
+        )

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -66,3 +66,66 @@ class TestHeartbeatEngineSettings:
         get_settings.cache_clear()
         settings = get_settings()
         assert settings.heartbeat_cost_circuit_breaker_usd_per_day == 100.0
+
+
+# ---------------------------------------------------------------------------
+# GH #374 — portal_url canonical-host regression guard
+# ---------------------------------------------------------------------------
+
+
+class TestPortalUrlCanonical:
+    """GH #374 regression: settings.portal_url default must be the canonical
+    host nikita-mygirl.com, NOT the stale portal-phi-orcin.vercel.app
+    Vercel preview alias.
+
+    Walk N (2026-04-20) caught a /start reply with a button URL host of
+    portal-phi-orcin.vercel.app — driven by 5 production sites that fall
+    back to that literal when ``settings.portal_url is None``. Cloud Run
+    PORTAL_URL env var is unset; settings default is also None; the 5
+    fallbacks fire. Fix: settings default = canonical, drop the 5
+    fallbacks, set Cloud Run env var.
+
+    Per .claude/rules/vercel-cors-canonical.md: canonical is apex
+    nikita-mygirl.com (no redirect). Backend CORS allowlist already
+    matches.
+    """
+
+    def test_portal_url_default_is_canonical(self):
+        """AC-#374-001: settings.portal_url default must be canonical host."""
+        settings = Settings()
+        assert settings.portal_url == "https://nikita-mygirl.com", (
+            f"settings.portal_url default drifted to {settings.portal_url!r}. "
+            f"Should be canonical https://nikita-mygirl.com per Vercel "
+            f"canonical-redirect setup (PR #294)."
+        )
+
+    def test_no_stale_portal_url_in_production_code(self):
+        """AC-#374-002: zero hardcoded fallbacks to the stale Vercel preview
+        alias remain in production code (nikita/ + portal/).
+
+        Scope strictly to nikita/ + portal/ — historical references in
+        .claude/, docs/, ROADMAP.md, event-stream.md, specs/archive/, and
+        tests/ are out of scope (separate hygiene PR).
+        """
+        import subprocess
+
+        result = subprocess.run(
+            ["rg", "-l", "portal-phi-orcin", "nikita/", "portal/"],
+            capture_output=True,
+            text=True,
+        )
+        # rg exits 0 if matches found, 1 if none. We want the "no matches" exit.
+        assert result.returncode != 0, (
+            f"Stale portal-phi-orcin.vercel.app references remain in production code:\n"
+            f"{result.stdout}\n"
+            f"All `or 'https://portal-phi-orcin.vercel.app'` fallbacks must be "
+            f"removed; settings.portal_url default is now canonical so the "
+            f"fallback is dead code (#374)."
+        )
+
+    def test_portal_url_env_override(self, monkeypatch):
+        """env override changes portal_url after cache_clear (sanity check)."""
+        monkeypatch.setenv("PORTAL_URL", "https://staging.nikita-mygirl.com")
+        get_settings.cache_clear()
+        settings = get_settings()
+        assert settings.portal_url == "https://staging.nikita-mygirl.com"

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -114,19 +114,21 @@ class TestPortalUrlCanonical:
         import subprocess
 
         # Match `or "https://portal-phi-orcin..."` — the actual bug pattern.
+        # Uses POSIX `grep -rE` (always available on CI runners; `rg` is not
+        # installed on the GitHub Actions Ubuntu image by default).
         result = subprocess.run(
             [
-                "rg",
-                "-l",
-                r'or\s+"https://portal-phi-orcin',
+                "grep",
+                "-rlE",
+                r'or[[:space:]]+"https://portal-phi-orcin',
                 "nikita/",
                 "portal/",
             ],
             capture_output=True,
             text=True,
         )
-        # rg exits 0 if matches found, 1 if none. We want the "no matches" exit.
-        assert result.returncode != 0, (
+        # grep exits 0 if matches found, 1 if none, 2 on error. Want exit 1.
+        assert result.returncode == 1, (
             f"Stale portal-phi-orcin fallback patterns remain in production code:\n"
             f"{result.stdout}\n"
             f"All `or 'https://portal-phi-orcin.vercel.app'` fallbacks must be "

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -99,9 +99,13 @@ class TestPortalUrlCanonical:
             f"canonical-redirect setup (PR #294)."
         )
 
-    def test_no_stale_portal_url_in_production_code(self):
-        """AC-#374-002: zero hardcoded fallbacks to the stale Vercel preview
-        alias remain in production code (nikita/ + portal/).
+    def test_no_stale_portal_url_fallback_in_production_code(self):
+        """AC-#374-002: zero hardcoded ``or "https://portal-phi-orcin..."``
+        fallbacks remain in production code (nikita/ + portal/).
+
+        Greps for the FALLBACK PATTERN (or "https://portal-phi-...") not
+        the bare URL — comments documenting why the fallback was removed
+        legitimately mention the alias and shouldn't trip the gate.
 
         Scope strictly to nikita/ + portal/ — historical references in
         .claude/, docs/, ROADMAP.md, event-stream.md, specs/archive/, and
@@ -109,14 +113,21 @@ class TestPortalUrlCanonical:
         """
         import subprocess
 
+        # Match `or "https://portal-phi-orcin..."` — the actual bug pattern.
         result = subprocess.run(
-            ["rg", "-l", "portal-phi-orcin", "nikita/", "portal/"],
+            [
+                "rg",
+                "-l",
+                r'or\s+"https://portal-phi-orcin',
+                "nikita/",
+                "portal/",
+            ],
             capture_output=True,
             text=True,
         )
         # rg exits 0 if matches found, 1 if none. We want the "no matches" exit.
         assert result.returncode != 0, (
-            f"Stale portal-phi-orcin.vercel.app references remain in production code:\n"
+            f"Stale portal-phi-orcin fallback patterns remain in production code:\n"
             f"{result.stdout}\n"
             f"All `or 'https://portal-phi-orcin.vercel.app'` fallbacks must be "
             f"removed; settings.portal_url default is now canonical so the "

--- a/tests/contracts/test_portal_api_contract.py
+++ b/tests/contracts/test_portal_api_contract.py
@@ -1,0 +1,161 @@
+"""Cross-stack API path contract — Spec 214 GH #373 regression guard.
+
+Parses ``portal/src/app/onboarding/hooks/use-onboarding-api.ts`` via Python
+regex to extract every static-string path argument from
+``api.post(path, ...)`` / ``api.get(path, ...)`` etc. For each, asserts the
+corresponding FastAPI route is registered (via ``app.routes`` inspection).
+
+Why a separate test file: this asserts a contract that spans two systems
+(TS frontend + Python backend). Pattern extends
+``tests/api/routes/test_telegram.py::TestDIContract`` which uses
+``ast.walk`` + ``inspect.signature`` reflection for the intra-Python DI
+factory contract.
+
+Known limitations (tracked here so the test is honest about coverage):
+
+- Template-literal paths (e.g. ``/api/v1/onboarding/${id}``) are skipped,
+  counted, and printed for manual review. Add to ``EXPLICIT_STATIC_PATHS``
+  below if they form a critical backbone.
+- Only the onboarding hook is parsed for iteration 1 (matches the #373
+  bug). Expansion to all ``portal/src/**/hooks/use-*.ts`` is a follow-up
+  if Walk O reveals other path-mismatch bugs.
+
+PR-A introduces this file. The bug it would have caught (had it existed at
+PR #361 merge) was a 3-way drift between the frontend hook path, the
+backend route declaration, and the test docstring — none of the three
+agreed, mock tests passed, prod 404'd for 5+ days.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from nikita.api.main import create_app
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_FILE = REPO_ROOT / "portal/src/app/onboarding/hooks/use-onboarding-api.ts"
+
+# Backbone routes that MUST resolve regardless of AST extractor coverage.
+# Each entry = (HTTP method, full path). Path includes /api/v1 prefix.
+# Hand-curated to stay falsifiable even if the regex misses something.
+# Updating this list is a deliberate contract change.
+EXPLICIT_STATIC_PATHS = [
+    ("POST", "/api/v1/onboarding/converse"),                # #373 fix site
+    ("PATCH", "/api/v1/onboarding/profile"),
+    ("PUT", "/api/v1/onboarding/profile/chosen-option"),
+    ("POST", "/api/v1/onboarding/preview-backstory"),
+    ("POST", "/api/v1/onboarding/profile"),                  # submitProfile
+    ("POST", "/api/v1/portal/link-telegram"),                # linkTelegram
+]
+
+# Minimal regex extractor for ``api.<verb>("/literal-path", ...)`` calls.
+# Pure-Python (no Node deps). Trade-off: only catches static double-quoted
+# paths, NOT template literals or variable references.
+API_CALL_RE = re.compile(
+    r'\bapi\.(get|post|put|patch|delete)(?:<[^>]+>)?\(\s*"([^"]+)"',
+    re.MULTILINE,
+)
+TEMPLATE_LITERAL_RE = re.compile(
+    r'\bapi\.(get|post|put|patch|delete)(?:<[^>]+>)?\(\s*`'
+)
+
+
+def _registered_paths(app) -> set[tuple[str, str]]:
+    """Return ``{(method, path)}`` for every registered FastAPI route."""
+    out: set[tuple[str, str]] = set()
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None)
+        if path and methods:
+            for m in methods:
+                if m != "HEAD":  # FastAPI auto-adds HEAD for GET
+                    out.add((m, path))
+    return out
+
+
+@pytest.fixture(scope="module")
+def app_routes() -> set[tuple[str, str]]:
+    return _registered_paths(create_app())
+
+
+class TestPortalApiContract:
+    """Spec 214 #373 regression guard — frontend↔backend path contract."""
+
+    def test_explicit_static_paths_are_registered(self, app_routes):
+        """Backbone routes referenced by the wizard MUST be registered."""
+        missing = [
+            (m, p) for m, p in EXPLICIT_STATIC_PATHS if (m, p) not in app_routes
+        ]
+        assert not missing, (
+            f"Frontend assumes these routes exist; backend has not registered them: "
+            f"{missing}. Either register the route or remove from EXPLICIT_STATIC_PATHS."
+        )
+
+    def test_negative_case_wrong_path_unregistered(self, app_routes):
+        """Discriminating-power check — known-wrong paths MUST be missing."""
+        wrong = [
+            ("POST", "/api/v1/portal/onboarding/converse"),       # The #373 bug path
+            ("POST", "/api/v1/onboarding/onboarding/converse"),   # Doubled prefix
+        ]
+        for entry in wrong:
+            assert entry not in app_routes, (
+                f"{entry} unexpectedly registered. The contract test's negative "
+                f"case is not discriminating — review test setup."
+            )
+
+    def test_extracted_hook_paths_are_registered(self, app_routes):
+        """For every static-string ``api.<verb>("/path", ...)`` call in the
+        wizard hook, the corresponding ``/api/v1{path}`` route MUST be
+        registered.
+        """
+        if not HOOK_FILE.exists():
+            pytest.skip(f"Hook file not found at {HOOK_FILE} — repo layout changed")
+
+        source = HOOK_FILE.read_text()
+        # Sanity: hook MUST use api.<verb> not raw fetch (per Plan v13 Critical Risk #3).
+        assert "api.post" in source or "api.get" in source, (
+            f"Hook file changed shape; AST extractor expects api.<verb>(...). "
+            f"If migrated to raw fetch(), update extractor + Plan v13 Critical Risk #3."
+        )
+
+        # Print template-literal calls for visibility (skipped from assertion)
+        template_hits = TEMPLATE_LITERAL_RE.findall(source)
+        if template_hits:
+            print(
+                f"\n[contract-test] {len(template_hits)} template-literal api calls "
+                f"skipped (not falsifiable via static extraction): {template_hits}"
+            )
+
+        extracted = [
+            (verb.upper(), f"/api/v1{path}")
+            for verb, path in API_CALL_RE.findall(source)
+        ]
+        assert extracted, (
+            f"Extractor found 0 static api.<verb>('...') calls in {HOOK_FILE}. "
+            f"Either the hook moved to template literals (update extractor) "
+            f"or the regex is broken."
+        )
+
+        missing = [pair for pair in extracted if pair not in app_routes]
+        assert not missing, (
+            f"Frontend hook calls these routes; backend has NOT registered them: "
+            f"{missing}.\n"
+            f"Likely #373-class regression. Either fix the hook path or register "
+            f"the backend route. Hook file: {HOOK_FILE}"
+        )
+
+    def test_telegram_di_contract_present(self):
+        """Sanity: PR #372's TestDIContract (sibling guard) MUST still exist.
+
+        If this test goes missing, the regression-guard layer is degrading.
+        """
+        from tests.api.routes import test_telegram
+
+        assert hasattr(test_telegram, "TestDIContract"), (
+            "PR #372's TestDIContract was removed. That regression guard catches "
+            "DI-factory drift; PR-A's contract test catches FE→BE path drift. "
+            "Both must coexist."
+        )

--- a/tests/contracts/test_portal_api_contract.py
+++ b/tests/contracts/test_portal_api_contract.py
@@ -52,10 +52,12 @@ EXPLICIT_STATIC_PATHS = [
 ]
 
 # Minimal regex extractor for ``api.<verb>("/literal-path", ...)`` calls.
-# Pure-Python (no Node deps). Trade-off: only catches static double-quoted
-# paths, NOT template literals or variable references.
+# Pure-Python (no Node deps). Accepts both double- and single-quoted string
+# literals so a future Prettier config flip (singleQuote: true) does not silently
+# zero out extraction. Template literals + variable references are still skipped
+# (separate TEMPLATE_LITERAL_RE counter prints them for visibility).
 API_CALL_RE = re.compile(
-    r'\bapi\.(get|post|put|patch|delete)(?:<[^>]+>)?\(\s*"([^"]+)"',
+    r'\bapi\.(get|post|put|patch|delete)(?:<[^>]+>)?\(\s*["\']([^"\']+)["\']',
     re.MULTILINE,
 )
 TEMPLATE_LITERAL_RE = re.compile(

--- a/tests/platforms/telegram/test_commands.py
+++ b/tests/platforms/telegram/test_commands.py
@@ -395,7 +395,7 @@ class TestOnboardCommand:
         with patch(
             "nikita.platforms.telegram.utils.generate_portal_bridge_url",
             new=AsyncMock(
-                return_value="https://portal-phi-orcin.vercel.app/auth/bridge?token=abc"
+                return_value="https://nikita-mygirl.com/auth/bridge?token=abc"
             ),
         ):
             await handler.handle(onboard_message)

--- a/tests/platforms/telegram/test_utils.py
+++ b/tests/platforms/telegram/test_utils.py
@@ -74,12 +74,19 @@ class TestGeneratePortalBridgeUrl:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_uses_default_portal_url_when_setting_is_none(self):
-        """Falls back to the hardcoded default portal URL when setting unset."""
+    async def test_uses_canonical_portal_url_when_setting_is_default(self):
+        """GH #374: Settings default is canonical nikita-mygirl.com.
+
+        Prior to PR fix-373-374: settings.portal_url defaulted to None and the
+        helper fell back to a literal stale Vercel preview alias. PR-A removes
+        the fallback and changes settings default to canonical, so this test
+        now asserts the canonical host appears regardless of override.
+        """
+        from nikita.config.settings import Settings
         from nikita.platforms.telegram.utils import generate_portal_bridge_url
 
         mock_bridge = MagicMock()
-        mock_bridge.token = "fallback-token"
+        mock_bridge.token = "canonical-token"
 
         mock_repo = AsyncMock()
         mock_repo.create_token.return_value = mock_bridge
@@ -103,13 +110,20 @@ class TestGeneratePortalBridgeUrl:
                 return_value=mock_repo,
             ),
         ):
-            mock_settings.return_value.portal_url = None
+            # Use the actual default (no override) to assert the production default.
+            mock_settings.return_value.portal_url = Settings().portal_url
             result = await generate_portal_bridge_url(
                 user_id="550e8400-e29b-41d4-a716-446655440000",
             )
 
         assert result is not None
-        assert "portal-phi-orcin.vercel.app" in result
+        assert "nikita-mygirl.com" in result, (
+            f"Expected canonical host, got {result!r}. PR fix-373-374 removed "
+            f"portal-phi-orcin.vercel.app fallback (#374)."
+        )
+        assert "portal-phi-orcin.vercel.app" not in result, (
+            f"Stale Vercel preview alias leaked into bridge URL: {result!r} (#374)."
+        )
 
     @pytest.mark.asyncio
     async def test_default_redirect_path_is_onboarding(self):


### PR DESCRIPTION
## Summary
Bundled fix for two related Spec 214 ship-blockers caught by Walk N (2026-04-20).

- **GH #373 (CRITICAL)** — chat wizard 404 on `POST /api/v1/portal/onboarding/converse`
- **GH #374 (HIGH)** — `/start` reply E1 button URL host = `portal-phi-orcin.vercel.app` instead of canonical `nikita-mygirl.com`

Bundled (Approach B-prime per Plan v13 §2.2): Cloud Run probe (2026-04-21) showed `PORTAL_URL` unset, so the 5 fallback strings would fire in production. Deploying #373 alone would leave Walk O guaranteed to FAIL B1.

## Root causes

**#373 — 3-way path drift (discovered during plan-write exploration; brief was wrong about scope)**
- backend route `"/onboarding/converse"` under prefix `"/api/v1/onboarding"` produced doubled `/api/v1/onboarding/onboarding/converse`
- frontend hook posted to `/portal/onboarding/converse` (a 4th non-existent path)
- mock test asserted the wrong path so CI stayed green for 5+ days

**#374 — settings default + 5 fallback strings**
- `settings.portal_url` defaulted to `None`
- 5 production sites had `or "https://portal-phi-orcin.vercel.app"` fallbacks
- `PORTAL_URL` env var unset on Cloud Run (probed 2026-04-21)

## Changes (12 files)
1. `nikita/api/routes/portal_onboarding.py:518` — `/onboarding/converse` → `/converse`
2. `portal/src/app/onboarding/hooks/use-onboarding-api.ts:185` — drop `/portal` prefix
3. `portal/src/app/onboarding/types/ControlSelection.ts:7` — comment updated
4. `nikita/config/settings.py:113-118` — `portal_url` default = canonical
5-9. Drop 5 stale fallback strings from `bridge_tokens.py`, `telegram/{utils,commands,otp_handler,message_handler}.py`
10. `tests/config/test_settings.py` — `TestPortalUrlCanonical` (3 tests, fallback-pattern grep guard)
11. `tests/platforms/telegram/test_commands.py:398` — mock URL canonical
12. `.github/workflows/backend-ci.yml` — pre-test grep gate for #374 regression

Companion test additions in prior RED commit `87735c5`:
- `tests/contracts/test_portal_api_contract.py` (NEW, 4 tests, AST-extending TestDIContract pattern from PR #372)
- `tests/api/routes/test_converse_endpoint.py` — TestClient route-registration probe + docstring fix

## Regression guards
The new contract test parses `use-onboarding-api.ts` via Python regex (no Node dep), extracts every static `api.<verb>("/path", ...)` call, and asserts the corresponding `/api/v1{path}` route is registered in the FastAPI app. Negative-case test (known-wrong path) confirms discriminating power. Pattern extends `tests/api/routes/test_telegram.py::TestDIContract`. Would have caught the bug at PR #361 if it existed then.

The CI grep gate (`backend-ci.yml`) catches new `or "https://portal-phi-orcin..."` fallbacks before merge.

## Local tests
- `uv run pytest -q` → **6519 passed, 2 skipped, 184 deselected, 3 xpassed (161s)**
- `(cd portal && npm run test -- --run)` → **716 passed (106 files)**
- `(cd portal && npm run lint)` → 0 errors, 2 pre-existing warnings (unrelated to this PR)
- `(cd portal && npm run build)` → SUCCESS

## Pre-PR grep gates
- Zero-assertion shells: empty
- PII format strings: empty
- Raw cache_key: empty
- Stale portal-phi-orcin fallback pattern in `nikita/` + `portal/`: empty

## Orchestrator grep-verify
- `rg "/portal/onboarding/converse" portal/src/` → 0 hits ✓
- `rg '"/converse"' nikita/api/routes/portal_onboarding.py` → 1 hit at L518 ✓
- `rg '"/onboarding/converse"' portal/.../use-onboarding-api.ts` → 1 hit at L185 ✓

## Post-merge auto-dispatch
1. Cloud Run deploy via `gcloud run deploy nikita-api --source .`
2. Set `PORTAL_URL=https://nikita-mygirl.com` env var (belt-and-suspenders; settings default is now canonical)
3. Smoke probe: `curl -X POST .../api/v1/onboarding/converse` → expect 401/422 (NOT 404)
4. Walk O execution per Plan v13 §4

Closes #373 #374. Refs Spec 214 FR-11c/d/e, Plan v13.