### PR TITLE
fix(portal,376): converse 422 — strip client-only turn_id from Turn rows

### DIFF
--- a/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
+++ b/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
@@ -259,6 +259,35 @@ describe("OnboardingWizard — PR #363 QA iter-1 fixes", () => {
     expect(history.at(-1)?.role).toBe("user")
     expect(history.at(-1)?.content).toBe("zurich")
   })
+
+  it("GH #376: conversation_history Turn rows must NOT contain client-only fields (turn_id, superseded)", async () => {
+    // Backend Turn model in nikita/agents/onboarding/converse_contracts.py:24
+    // sets ConfigDict(extra='forbid'). Allowed keys: role, content, extracted,
+    // timestamp, source. Forwarding client-only fields (turn_id, superseded)
+    // triggers HTTP 422 — exactly the Walk O 2026-04-21 finding.
+    mockConverseOnce({ nikita_reply: "ack" })
+    render(<OnboardingWizard userId="u1" />)
+    const input = screen.getByLabelText("chat input") as HTMLInputElement
+    fireEvent.change(input, { target: { value: "zurich" } })
+    fireEvent.submit(input.closest("form")!)
+
+    await waitFor(() => expect(converseMock).toHaveBeenCalledTimes(1))
+    const firstCall = converseMock.mock.calls[0][0]
+    const history = firstCall.conversation_history as Array<Record<string, unknown>>
+    const allowedTurnKeys = new Set([
+      "role",
+      "content",
+      "extracted",
+      "timestamp",
+      "source",
+    ])
+    for (const turn of history) {
+      const extraKeys = Object.keys(turn).filter(
+        (k) => !allowedTurnKeys.has(k)
+      )
+      expect(extraKeys).toEqual([])
+    }
+  })
 })
 
 describe("OnboardingWizard — AC-T3.9.3 legacy files live under steps/legacy/", () => {

--- a/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
+++ b/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
@@ -275,10 +275,10 @@ describe("OnboardingWizard — PR #363 QA iter-1 fixes", () => {
     const firstCall = converseMock.mock.calls[0][0]
     const history = firstCall.conversation_history as Array<Record<string, unknown>>
     // Mirrors the backend Turn allow-list at
-    // nikita/agents/onboarding/converse_contracts.py:24
-    // (Pydantic ConfigDict extra='forbid'). If the backend adds a new
-    // allowed field, update BOTH this set AND the toWireTurn serializer
-    // in portal/src/app/onboarding/hooks/use-onboarding-api.ts.
+    // nikita/agents/onboarding/converse_contracts.py:23-35
+    // (class def :23, ConfigDict extra='forbid' :27). If the backend adds
+    // a new allowed field, update BOTH this set AND the toWireTurn
+    // serializer in portal/src/app/onboarding/hooks/use-onboarding-api.ts.
     const allowedTurnKeys = new Set([
       "role",
       "content",

--- a/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
+++ b/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
@@ -274,6 +274,11 @@ describe("OnboardingWizard — PR #363 QA iter-1 fixes", () => {
     await waitFor(() => expect(converseMock).toHaveBeenCalledTimes(1))
     const firstCall = converseMock.mock.calls[0][0]
     const history = firstCall.conversation_history as Array<Record<string, unknown>>
+    // Mirrors the backend Turn allow-list at
+    // nikita/agents/onboarding/converse_contracts.py:24
+    // (Pydantic ConfigDict extra='forbid'). If the backend adds a new
+    // allowed field, update BOTH this set AND the toWireTurn serializer
+    // in portal/src/app/onboarding/hooks/use-onboarding-api.ts.
     const allowedTurnKeys = new Set([
       "role",
       "content",

--- a/portal/src/app/onboarding/__tests__/useConversationState.test.ts
+++ b/portal/src/app/onboarding/__tests__/useConversationState.test.ts
@@ -76,8 +76,11 @@ describe("conversationReducer — AC-T3.1.1 each action transitions as documente
     expect(next.turns[0]).toMatchObject({
       role: "user",
       content: "zurich",
-      turn_id: "u1",
     })
+    // GH #376: turn_id must NOT be on the Turn — backend rejects extra fields
+    // and conversation_history is built from state.turns. The action.turnId
+    // lives on the request envelope only.
+    expect(next.turns[0]).not.toHaveProperty("turn_id")
     expect(next.isLoading).toBe(true)
   })
 

--- a/portal/src/app/onboarding/hooks/use-onboarding-api.ts
+++ b/portal/src/app/onboarding/hooks/use-onboarding-api.ts
@@ -34,20 +34,29 @@ import type {
 } from "@/app/onboarding/types/converse"
 
 /**
+ * Wire-shape of a Turn — explicitly excludes client-only fields. Used as
+ * the return type of `toWireTurn` so a future contributor cannot
+ * accidentally add a stripped field back into the serializer output
+ * without TypeScript catching it.
+ */
+type WireTurn = Omit<Turn, "superseded">
+
+/**
  * Whitelist serializer: Turn → wire shape accepted by backend.
  *
- * GH #376: backend Turn model in `nikita/agents/onboarding/converse_contracts.py:24`
- * uses `ConfigDict(extra='forbid')`. Allowed keys: {role, content, extracted,
- * timestamp, source}. Client-only fields (`turn_id` removed in #376;
- * `superseded` retained for MessageBubble opacity rendering) MUST be stripped
- * here — this is the single load-bearing wire-contract enforcement point.
+ * GH #376: backend Turn model in `nikita/agents/onboarding/converse_contracts.py:23-35`
+ * uses `ConfigDict(extra='forbid')` (line :27). Allowed keys: {role, content,
+ * extracted, timestamp, source}. Client-only fields (`turn_id` removed in
+ * #376; `superseded` retained for MessageBubble opacity rendering) MUST be
+ * stripped here — this is the single load-bearing wire-contract enforcement
+ * point.
  *
  * Optional fields (`extracted`, `source`) are spread only when defined so
  * they don't appear as `null`/`undefined` placeholders that the backend
  * could mis-interpret. Null values ARE preserved (only literal `undefined`
  * is omitted) — matches the Pydantic `field: T | None = None` semantics.
  */
-function toWireTurn(t: Turn): Turn {
+function toWireTurn(t: Turn): WireTurn {
   return {
     role: t.role,
     content: t.content,

--- a/portal/src/app/onboarding/hooks/use-onboarding-api.ts
+++ b/portal/src/app/onboarding/hooks/use-onboarding-api.ts
@@ -30,7 +30,32 @@ import { normalizeUserInput } from "@/app/onboarding/types/ControlSelection"
 import type {
   ConverseRequest,
   ConverseResponse,
+  Turn,
 } from "@/app/onboarding/types/converse"
+
+/**
+ * Whitelist serializer: Turn → wire shape accepted by backend.
+ *
+ * GH #376: backend Turn model in `nikita/agents/onboarding/converse_contracts.py:24`
+ * uses `ConfigDict(extra='forbid')`. Allowed keys: {role, content, extracted,
+ * timestamp, source}. Client-only fields (`turn_id` removed in #376;
+ * `superseded` retained for MessageBubble opacity rendering) MUST be stripped
+ * here — this is the single load-bearing wire-contract enforcement point.
+ *
+ * Optional fields (`extracted`, `source`) are spread only when defined so
+ * they don't appear as `null`/`undefined` placeholders that the backend
+ * could mis-interpret. Null values ARE preserved (only literal `undefined`
+ * is omitted) — matches the Pydantic `field: T | None = None` semantics.
+ */
+function toWireTurn(t: Turn): Turn {
+  return {
+    role: t.role,
+    content: t.content,
+    timestamp: t.timestamp,
+    ...(t.extracted !== undefined ? { extracted: t.extracted } : {}),
+    ...(t.source !== undefined ? { source: t.source } : {}),
+  }
+}
 
 /**
  * Backoff delays between attempts in milliseconds, per Spec 214 NFR-001.
@@ -175,18 +200,8 @@ export function useOnboardingAPI(): UseOnboardingAPI {
       // via Idempotency-Key header; client retry would race the cache TTL).
       converse: (req, signal) => {
         const turnId = req.turn_id ?? crypto.randomUUID()
-        // GH #376: strip client-only Turn fields (turn_id, superseded) before
-        // serializing. Backend Turn model uses ConfigDict(extra='forbid');
-        // a forwarded `turn_id` on a Turn row triggers HTTP 422. Keep
-        // turn_id at the request envelope level only.
         const body: ConverseRequest = {
-          conversation_history: req.conversation_history.map((t) => ({
-            role: t.role,
-            content: t.content,
-            timestamp: t.timestamp,
-            ...(t.extracted !== undefined ? { extracted: t.extracted } : {}),
-            ...(t.source !== undefined ? { source: t.source } : {}),
-          })),
+          conversation_history: req.conversation_history.map(toWireTurn),
           user_input: normalizeUserInput(req.user_input),
           locale: req.locale ?? "en",
           turn_id: turnId,

--- a/portal/src/app/onboarding/hooks/use-onboarding-api.ts
+++ b/portal/src/app/onboarding/hooks/use-onboarding-api.ts
@@ -175,8 +175,18 @@ export function useOnboardingAPI(): UseOnboardingAPI {
       // via Idempotency-Key header; client retry would race the cache TTL).
       converse: (req, signal) => {
         const turnId = req.turn_id ?? crypto.randomUUID()
+        // GH #376: strip client-only Turn fields (turn_id, superseded) before
+        // serializing. Backend Turn model uses ConfigDict(extra='forbid');
+        // a forwarded `turn_id` on a Turn row triggers HTTP 422. Keep
+        // turn_id at the request envelope level only.
         const body: ConverseRequest = {
-          conversation_history: req.conversation_history,
+          conversation_history: req.conversation_history.map((t) => ({
+            role: t.role,
+            content: t.content,
+            timestamp: t.timestamp,
+            ...(t.extracted !== undefined ? { extracted: t.extracted } : {}),
+            ...(t.source !== undefined ? { source: t.source } : {}),
+          })),
           user_input: normalizeUserInput(req.user_input),
           locale: req.locale ?? "en",
           turn_id: turnId,

--- a/portal/src/app/onboarding/hooks/useConversationState.ts
+++ b/portal/src/app/onboarding/hooks/useConversationState.ts
@@ -118,11 +118,14 @@ export function conversationReducer(
       }
 
     case "user_input": {
+      // GH #376: turn_id stays on the action envelope for idempotency header;
+      // the Turn stored in state.turns must NOT carry it because state.turns
+      // is spread into conversation_history on each converse call, and the
+      // backend Turn model rejects extra fields (extra='forbid').
       const userTurn: Turn = {
         role: "user",
         content: renderUserContent(action.input),
         timestamp: new Date().toISOString(),
-        turn_id: action.turnId,
       }
       return {
         ...state,

--- a/portal/src/app/onboarding/onboarding-wizard.tsx
+++ b/portal/src/app/onboarding/onboarding-wizard.tsx
@@ -80,11 +80,13 @@ function ChatOnboardingWizard({ userId }: OnboardingWizardProps) {
       // turn we are about to emit, so it can extract fields + idempotency-
       // key the response. Using `state.turns` alone would omit the latest
       // user turn because React state updates are batched (N2 fix).
+      // GH #376: do NOT put turn_id on the Turn itself. Backend Turn has
+      // ConfigDict(extra='forbid'); turn_id lives only on the request envelope
+      // (used for the Idempotency-Key header).
       const userTurn = {
         role: "user" as const,
         content: typeof input === "string" ? input : String(input.value),
         timestamp: new Date().toISOString(),
-        turn_id: turnId,
       }
       dispatch({ type: "user_input", input, turnId })
       try {

--- a/portal/src/app/onboarding/types/converse.ts
+++ b/portal/src/app/onboarding/types/converse.ts
@@ -14,11 +14,10 @@ export interface Turn {
   source?: "llm" | "fallback" | "idempotent" | "validation_reject" | null
   /**
    * Client-only flag set when the user rejects a confirmation (Fix-that).
-   * Rendered with `opacity: 0.5`. Server never sees this field.
+   * Rendered with `opacity: 0.5`. Server never sees this field — the
+   * api.converse() serializer strips it before POSTing (GH #376).
    */
   superseded?: boolean
-  /** Client-generated turn identifier; used for idempotency header. */
-  turn_id?: string
 }
 
 export interface ConverseRequest {


### PR DESCRIPTION
## Summary
Fixes GH #376 (HIGH): chat wizard 100% broken on prod after PR #375 deploy. POST /api/v1/onboarding/converse returns HTTP 422 because frontend forwards client-only \`turn_id\` field on Turn rows in conversation_history, violating backend's \`extra='forbid'\` Pydantic config.

Walk O (2026-04-21) reproducer: simon.yang.ch+walko@gmail.com → wizard turn 1 → 422 within 200ms.

## Root cause
- \`onboarding-wizard.tsx:83-88\` userTurn includes \`turn_id\` → posted in conversation_history
- \`useConversationState.ts:121-126\` reducer also writes \`turn_id\` into state.turns Turn → spread into conversation_history on each call
- Backend \`Turn\` model in \`nikita/agents/onboarding/converse_contracts.py:24\` enforces \`ConfigDict(extra='forbid')\` — rejects any extra field

## Fix (3 layers)
1. **Wizard**: drop \`turn_id\` from userTurn (envelope-level only, used for Idempotency-Key header)
2. **Reducer**: drop \`turn_id\` from state.turns userTurn
3. **API hook (defense-in-depth)**: map conversation_history through a whitelist of allowed Turn keys before POST — catches future client-only field additions (e.g., \`superseded\` flag)
4. **Turn type**: remove \`turn_id\` from interface (no consumers — was write-only). \`superseded\` retained — actively used by MessageBubble for \`opacity:0.5\` rendering, stripped at the wire by api hook

## Regression guards
- \`onboarding-wizard.test.tsx\` — new test asserts every Turn in conversation_history has ONLY \`{role, content, extracted, timestamp, source}\`. RED before fix, GREEN after.
- \`useConversationState.test.ts\` — updated to assert \`not.toHaveProperty('turn_id')\` on the reducer Turn.

## Local tests
- \`uv run pytest -q\` → **6519 passed** (no backend touch)
- \`(cd portal && npm run test -- --run)\` → **717 passed** (was 716; +1 new test)
- \`(cd portal && npm run lint)\` → 0 errors, 2 pre-existing warnings
- \`(cd portal && npm run build)\` → SUCCESS

## Pre-PR grep gates
- Zero-assertion shells: empty
- PII format strings: empty
- Raw cache_key: empty

## Post-merge auto-dispatch
1. Vercel auto-deploys frontend on master push
2. Walk P re-runs the wizard happy path; expect B3 PASS (conv_len > 0 after turn 1)

Closes #376. Refs Spec 214 FR-11d, Walk O, PR #375.