### PR TITLE
fix(214,382): converse pipeline batch-fix — unblock wizard after Walk Q

### DIFF
--- a/nikita/agents/onboarding/conversation_agent.py
+++ b/nikita/agents/onboarding/conversation_agent.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from functools import lru_cache
+from typing import Literal
 from uuid import UUID
 
 from pydantic_ai import Agent, RunContext
@@ -76,13 +77,21 @@ class ConverseDeps:
 
 
 def _create_conversation_agent() -> Agent[ConverseDeps, str]:
-    """Build the Pydantic AI agent with six extraction tools registered."""
+    """Build the Pydantic AI agent with six extraction tools registered.
+
+    GH #382 (D5, 2026-04-21): retries raised from 2 to 4. First-turn
+    tool-call schema mistakes (e.g. LLM omits all three identity fields,
+    Pydantic rejects via _at_least_one_field; LLM emits no_extraction
+    with a freeform reason; etc.) need enough retries for the model to
+    self-correct from the error message rather than surfacing as
+    user-facing validation_reject responses.
+    """
     agent: Agent[ConverseDeps, str] = Agent(
         _MODEL_NAME,
         deps_type=ConverseDeps,
         output_type=str,
         system_prompt=WIZARD_SYSTEM_PROMPT,
-        retries=2,
+        retries=4,
     )
 
     # Six extraction tools + 1 sentinel. Each appends the typed schema
@@ -188,9 +197,23 @@ def _create_conversation_agent() -> Agent[ConverseDeps, str]:
 
     @agent.tool
     def no_extraction(
-        ctx: RunContext[ConverseDeps], reason: str = "off_topic"
+        ctx: RunContext[ConverseDeps],
+        reason: Literal[
+            "off_topic",
+            "clarifying",
+            "backtracking",
+            "low_confidence",
+        ] = "off_topic",
     ) -> str:
-        """Declare "no extraction" for off-topic / clarifying / backtracking."""
+        """Declare "no extraction" for off-topic / clarifying / backtracking.
+
+        GH #382 (D4): `reason` is constrained to the 4 Literal values
+        the schema (NoExtraction.reason) accepts. Pydantic AI rejects
+        freeform strings at the tool-call boundary with a clear error
+        message the LLM can act on, instead of bubbling a
+        NoExtraction.model_validate ValidationError up through
+        agent.run.
+        """
         ctx.deps.extracted.append(
             NoExtraction.model_validate({"reason": reason})
         )

--- a/nikita/agents/onboarding/message_history.py
+++ b/nikita/agents/onboarding/message_history.py
@@ -1,0 +1,78 @@
+"""Conversation history → Pydantic AI ModelMessage hydration (GH #382 D1).
+
+The portal wizard sends ``ConverseRequest.conversation_history: list[Turn]``
+with every /converse call. Before GH #382 the endpoint discarded this
+history and called ``agent.run(user_input, deps=deps)`` without
+``message_history=``, so every turn was effectively cold: the LLM had
+no idea what the prior wizard prompt was, guessed the wrong tool-call
+shape, and the retry loop exhausted on the same error.
+
+This module converts the wire-level ``Turn`` objects into Pydantic AI
+``ModelMessage`` objects the agent can consume via ``agent.run(...,
+message_history=...)``. The mapping is intentionally simple:
+
+- ``role="user"`` → ``ModelRequest(parts=[UserPromptPart(content=...)])``
+- ``role="nikita"`` → ``ModelResponse(parts=[TextPart(content=...)])``
+
+Pydantic AI skips re-running the system prompt when ``message_history``
+is non-empty (see pydantic_ai docs). ``WIZARD_SYSTEM_PROMPT`` is
+deterministic, so losing the re-run is fine: the prompt that was in
+scope when the history was produced is identical to what's in scope
+now.
+
+Reference: ``nikita/agents/text/history.py::HistoryLoader._convert_to_model_messages``
+uses the same pattern for the main text agent's Spec 030 history loader.
+"""
+
+from __future__ import annotations
+
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+
+from nikita.agents.onboarding.converse_contracts import Turn
+
+
+def hydrate_message_history(turns: list[Turn]) -> list[ModelMessage]:
+    """Convert wire-level Turn objects to Pydantic AI ModelMessage list.
+
+    Args:
+        turns: The ``conversation_history`` array from a ConverseRequest.
+
+    Returns:
+        A list of ``ModelMessage`` objects suitable for
+        ``agent.run(..., message_history=...)``. Empty input returns
+        an empty list (the caller should then NOT pass
+        ``message_history=`` at all, so Pydantic AI re-runs the system
+        prompt as for a fresh session).
+
+    Notes:
+        - ``superseded`` turns (AC-T3.7.2, rejected confirmations) are
+          currently included. The reducer removes their UI affordance
+          but the text stays in the log; if we were to elide them the
+          LLM would see gaps in the conversation that don't match the
+          user-visible transcript. Keep them for now; revisit if it
+          causes confusion.
+        - ``extracted`` and ``source`` are dropped — they're internal
+          wire metadata and the LLM doesn't need them to reconstruct
+          conversational state.
+        - ``timestamp`` is also dropped; Pydantic AI ModelMessages do
+          not expose a turn-timestamp field.
+    """
+    out: list[ModelMessage] = []
+    for turn in turns:
+        if turn.role == "user":
+            out.append(ModelRequest(parts=[UserPromptPart(content=turn.content)]))
+        elif turn.role == "nikita":
+            out.append(ModelResponse(parts=[TextPart(content=turn.content)]))
+        # Unknown role: skip silently. Turn.role is a Literal['nikita','user']
+        # so Pydantic validation at the wire layer already rejects anything
+        # else; this is belt-and-suspenders.
+    return out
+
+
+__all__ = ["hydrate_message_history"]

--- a/nikita/agents/onboarding/message_history.py
+++ b/nikita/agents/onboarding/message_history.py
@@ -26,6 +26,8 @@ uses the same pattern for the main text agent's Spec 030 history loader.
 
 from __future__ import annotations
 
+import logging
+
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -35,6 +37,8 @@ from pydantic_ai.messages import (
 )
 
 from nikita.agents.onboarding.converse_contracts import Turn
+
+logger = logging.getLogger(__name__)
 
 
 def hydrate_message_history(turns: list[Turn]) -> list[ModelMessage]:
@@ -69,9 +73,16 @@ def hydrate_message_history(turns: list[Turn]) -> list[ModelMessage]:
             out.append(ModelRequest(parts=[UserPromptPart(content=turn.content)]))
         elif turn.role == "nikita":
             out.append(ModelResponse(parts=[TextPart(content=turn.content)]))
-        # Unknown role: skip silently. Turn.role is a Literal['nikita','user']
-        # so Pydantic validation at the wire layer already rejects anything
-        # else; this is belt-and-suspenders.
+        else:
+            # Unknown role: skip + warn. Turn.role is a Literal['nikita','user']
+            # so Pydantic validation at the wire layer already rejects anything
+            # else; this is defensive against a future schema migration that
+            # adds a new role (e.g. "system") without updating the hydrator.
+            # PR #383 QA iter-1 nitpick: don't let a schema drift go silently.
+            logger.warning(
+                "message_history_unknown_role role=%s — hydrator needs update",
+                turn.role,
+            )
     return out
 
 

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -594,7 +594,7 @@ async def _persist_user_turn_best_effort(
     session: AsyncSession,
     user_id: UUID,
     sanitized_input: str,
-) -> None:
+) -> bool:
     """Best-effort user-turn append on fallback branches (GH #382 D7).
 
     Walk Q showed that every /converse fallback branch (timeout,
@@ -603,9 +603,14 @@ async def _persist_user_turn_best_effort(
     zero history in message_history, so the LLM made the same mistake.
 
     This helper appends a user turn with no extracted fields to JSONB.
-    Any DB error is swallowed + logged so the fallback response still
-    goes out on time; the cost of a missing history entry is small
-    compared to 500-ing the endpoint.
+    Any DB error is caught, session rolled back explicitly so a later
+    ledger.add_spend call on the same session doesn't cascade into
+    ``InFailedSqlTransaction``, and the error is logged. Returns
+    ``True`` on success so callers can decide whether to proceed with
+    a coupled side-effect (e.g. spend accrual).
+
+    PR #383 QA iter-1 fix: returns bool + explicit rollback so the
+    caller can avoid charging spend for a ghost turn if persist fails.
     """
     try:
         await append_conversation_turn(
@@ -618,16 +623,22 @@ async def _persist_user_turn_best_effort(
                 "extracted": {},
             },
         )
+        return True
     except Exception as exc:  # pragma: no cover — defensive
         logger.warning(
             "converse_user_turn_persist_failed user_id=%s exc=%s",
             user_id,
             type(exc).__name__,
         )
+        try:  # prevent stale failed-tx state from cascading
+            await session.rollback()
+        except Exception:  # pragma: no cover — defensive
+            pass
+        return False
 
 
 async def _charge_estimated_spend(
-    session: AsyncSession,
+    spend_ledger: LLMSpendLedger,
     user_id: UUID,
 ) -> None:
     """Charge ESTIMATED_TURN_COST_USD on a validator-reject path (GH #382 D8).
@@ -637,10 +648,13 @@ async def _charge_estimated_spend(
     caller evade the daily $2 cap by triggering repeated schema
     errors. Defensive: swallow ledger errors so the fallback still
     returns on time.
+
+    PR #383 QA iter-1 nitpick: reuses the in-scope ``spend_ledger``
+    rather than instantiating a new one — ledgers are stateless
+    wrappers around the session but this is idiomatic.
     """
     try:
-        ledger = LLMSpendLedger(session)
-        await ledger.add_spend(user_id, ESTIMATED_TURN_COST_USD)
+        await spend_ledger.add_spend(user_id, ESTIMATED_TURN_COST_USD)
     except Exception as exc:  # pragma: no cover — defensive
         logger.warning(
             "converse_spend_add_failed user_id=%s exc=%s",
@@ -800,11 +814,19 @@ async def converse(
             summary["err_count"],
             is_age_under_18,
         )
+        # PR #383 QA iter-1 fix: persist BEFORE charging spend so a
+        # failed persist doesn't leave the user paying for a ghost turn.
+        # The helper handles rollback internally if the append fails.
+        persisted = await _persist_user_turn_best_effort(
+            session, current_user.id, sanitized
+        )
         # D8: charge spend even though the run ended in ValidationError —
         # the LLM actually ran; skipping would let callers evade the cap.
-        await _charge_estimated_spend(session, current_user.id)
-        # D7: persist user turn even on validator-reject.
-        await _persist_user_turn_best_effort(session, current_user.id, sanitized)
+        # Only charge if the user-turn was actually persisted (persisted
+        # transaction state is safe) — otherwise we'd be charging for an
+        # effectively-lost turn.
+        if persisted:
+            await _charge_estimated_spend(spend_ledger, current_user.id)
         return _fallback_response(
             latency_ms=_elapsed_ms(started),
             source="validation_reject",

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -49,6 +49,7 @@ from nikita.agents.onboarding.converse_contracts import (
     ConverseResponse,
     RateLimitResponse,
 )
+from nikita.agents.onboarding.message_history import hydrate_message_history
 from nikita.agents.onboarding.extraction_schemas import NoExtraction
 from nikita.agents.onboarding.validators import (
     FALLBACK_REPLY,
@@ -545,6 +546,109 @@ _VALIDATION_REJECT_AGE_REPLY: Final[str] = (
 )
 
 
+def _is_age_under_18_error(errors: list[dict]) -> bool:
+    """Decide whether a Pydantic ValidationError is actually an age<18
+    rejection vs. some other tool-arg schema failure.
+
+    GH #382 (D2): before this helper, ANY ValidationError from the agent
+    mapped to the age-under-18 template, even when the failing constraint
+    was phone format / _at_least_one_field / no_extraction.reason literal.
+    Walk Q user (age=32) saw the age-18 template on EVERY turn because
+    the LLM was tripping a different validator.
+
+    Heuristic: the error is "age<18" iff the first error's `loc` ends
+    with ``"age"`` AND the type is ``greater_than_equal``. Any other
+    shape is routed to the generic ``FALLBACK_REPLY``.
+    """
+    if not errors:
+        return False
+    first = errors[0]
+    loc = first.get("loc") or ()
+    if not loc:
+        return False
+    # `loc` may be ("age",) or ("model_name", "age") etc. — check last entry.
+    last = loc[-1]
+    err_type = first.get("type", "")
+    return last == "age" and err_type == "greater_than_equal"
+
+
+def _summarize_validation_errors(errors: list[dict]) -> dict:
+    """PII-safe summary of a Pydantic ValidationError for logging (D3).
+
+    Returns only the structural shape (loc + type) of the FIRST error.
+    Omits ``input`` (would leak user-provided values) and ``msg`` (often
+    echoes user input).
+    """
+    if not errors:
+        return {"tool": "unknown", "loc": "", "type": ""}
+    first = errors[0]
+    loc = first.get("loc") or ()
+    return {
+        "loc": ".".join(str(p) for p in loc),
+        "type": first.get("type", ""),
+        "err_count": len(errors),
+    }
+
+
+async def _persist_user_turn_best_effort(
+    session: AsyncSession,
+    user_id: UUID,
+    sanitized_input: str,
+) -> None:
+    """Best-effort user-turn append on fallback branches (GH #382 D7).
+
+    Walk Q showed that every /converse fallback branch (timeout,
+    validation_reject, agent error) was returning a fallback reply
+    without persisting the user's turn. Result: the next retry had
+    zero history in message_history, so the LLM made the same mistake.
+
+    This helper appends a user turn with no extracted fields to JSONB.
+    Any DB error is swallowed + logged so the fallback response still
+    goes out on time; the cost of a missing history entry is small
+    compared to 500-ing the endpoint.
+    """
+    try:
+        await append_conversation_turn(
+            session,
+            user_id,
+            {
+                "role": "user",
+                "content": sanitized_input,
+                "timestamp": datetime.now(UTC).isoformat(),
+                "extracted": {},
+            },
+        )
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning(
+            "converse_user_turn_persist_failed user_id=%s exc=%s",
+            user_id,
+            type(exc).__name__,
+        )
+
+
+async def _charge_estimated_spend(
+    session: AsyncSession,
+    user_id: UUID,
+) -> None:
+    """Charge ESTIMATED_TURN_COST_USD on a validator-reject path (GH #382 D8).
+
+    The LLM actually ran and burned tokens before the tool call failed
+    Pydantic validation. Skipping spend accrual would let a determined
+    caller evade the daily $2 cap by triggering repeated schema
+    errors. Defensive: swallow ledger errors so the fallback still
+    returns on time.
+    """
+    try:
+        ledger = LLMSpendLedger(session)
+        await ledger.add_spend(user_id, ESTIMATED_TURN_COST_USD)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning(
+            "converse_spend_add_failed user_id=%s exc=%s",
+            user_id,
+            type(exc).__name__,
+        )
+
+
 @router.post(
     "/converse",
     response_model=ConverseResponse,
@@ -635,9 +739,24 @@ async def converse(
     #    B1 QA iter-1: agent now returns plain text in `result.output`;
     #    structured extractions are accumulated in `deps.extracted` by
     #    the tool-call sidecar.
+    #    GH #382 (D1): pass hydrated message_history so the LLM sees the
+    #    full wizard conversation, not just the latest user message. Before
+    #    this fix, every turn was cold; the LLM guessed wrong tool-call
+    #    shapes and retry loops exhausted on the same ValidationError.
     deps = ConverseDeps(user_id=current_user.id, locale=req.locale)
     agent = get_conversation_agent()
     timeout_ms = get_converse_timeout_ms()
+
+    message_history = hydrate_message_history(req.conversation_history)
+    # Pydantic AI skips re-running system_prompt when message_history is
+    # non-empty; pass None (omit kwarg via default) on a fresh session so
+    # the prompt is emitted per pydantic-ai docs.
+    run_kwargs: dict = {
+        "deps": deps,
+        "model_settings": CACHE_SETTINGS,
+    }
+    if message_history:
+        run_kwargs["message_history"] = message_history
 
     # B3 QA iter-1: split exception handlers — TimeoutError is the
     # success-path bound; everything else is an unexpected failure.
@@ -646,11 +765,7 @@ async def converse(
     # an in-character `validation_reject` response (I9 QA iter-1).
     try:
         result = await asyncio.wait_for(
-            agent.run(
-                sanitized,
-                deps=deps,
-                model_settings=CACHE_SETTINGS,
-            ),
+            agent.run(sanitized, **run_kwargs),
             timeout=timeout_ms / 1000,
         )
     except asyncio.TimeoutError:
@@ -660,19 +775,42 @@ async def converse(
             timeout_ms,
             timeout_ms == CONVERSE_TIMEOUT_MS_COLD,
         )
+        # D7: persist user turn even on timeout so the next retry has
+        # the attempted message in its message_history context.
+        await _persist_user_turn_best_effort(session, current_user.id, sanitized)
         return _fallback_response(latency_ms=_elapsed_ms(started))
     except ValidationError as exc:
         # I9 QA iter-1: surface age<18 (and other schema rejections) as
         # a 200 in-character message rather than a 422 leak.
+        # GH #382 (D2, D3, D7, D8):
+        #   D2: only return the age-18 template when the error is actually
+        #       on the age field. Other schema rejections get FALLBACK_REPLY.
+        #   D3: log includes loc + type (PII-safe) so triage doesn't need
+        #       to reproduce locally.
+        #   D7: persist user turn even on reject so retries have context.
+        #   D8: charge estimated turn cost — the LLM ran and burned tokens.
+        errors = exc.errors()
+        is_age_under_18 = _is_age_under_18_error(errors)
+        summary = _summarize_validation_errors(errors)
         logger.warning(
-            "converse_validation_reject user_id=%s err_count=%d",
+            "converse_validation_reject user_id=%s loc=%s type=%s err_count=%d is_age_under_18=%s",
             current_user.id,
-            len(exc.errors()),
+            summary["loc"],
+            summary["type"],
+            summary["err_count"],
+            is_age_under_18,
         )
+        # D8: charge spend even though the run ended in ValidationError —
+        # the LLM actually ran; skipping would let callers evade the cap.
+        await _charge_estimated_spend(session, current_user.id)
+        # D7: persist user turn even on validator-reject.
+        await _persist_user_turn_best_effort(session, current_user.id, sanitized)
         return _fallback_response(
             latency_ms=_elapsed_ms(started),
             source="validation_reject",
-            nikita_reply=_VALIDATION_REJECT_AGE_REPLY,
+            nikita_reply=(
+                _VALIDATION_REJECT_AGE_REPLY if is_age_under_18 else FALLBACK_REPLY
+            ),
         )
     except (
         UnexpectedModelBehavior,
@@ -685,6 +823,8 @@ async def converse(
             current_user.id,
             type(exc).__name__,
         )
+        # D7: persist attempted user turn for continuity.
+        await _persist_user_turn_best_effort(session, current_user.id, sanitized)
         return _fallback_response(latency_ms=_elapsed_ms(started))
     except Exception as exc:
         # Catch-all preserves traceback (I1 QA iter-1) and ensures the
@@ -694,6 +834,7 @@ async def converse(
             current_user.id,
             type(exc).__name__,
         )
+        await _persist_user_turn_best_effort(session, current_user.id, sanitized)
         return _fallback_response(latency_ms=_elapsed_ms(started))
 
     # 5. Pick the primary extraction from the deps-scoped sidecar

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -630,7 +630,10 @@ async def _persist_user_turn_best_effort(
             user_id,
             type(exc).__name__,
         )
-        try:  # prevent stale failed-tx state from cascading
+        # Rollback is idempotent in SQLAlchemy async (no-op on already-
+        # rolled-back / non-active sessions); the inner except guards
+        # against transport-level failures on a dead connection.
+        try:
             await session.rollback()
         except Exception:  # pragma: no cover — defensive
             pass
@@ -791,7 +794,12 @@ async def converse(
         )
         # D7: persist user turn even on timeout so the next retry has
         # the attempted message in its message_history context.
-        await _persist_user_turn_best_effort(session, current_user.id, sanitized)
+        # Bool return is intentionally discarded here — no coupled side
+        # effect follows on the timeout branch (spend ledger not charged
+        # because we can't confirm the LLM actually ran to completion).
+        _ = await _persist_user_turn_best_effort(
+            session, current_user.id, sanitized
+        )
         return _fallback_response(latency_ms=_elapsed_ms(started))
     except ValidationError as exc:
         # I9 QA iter-1: surface age<18 (and other schema rejections) as
@@ -845,18 +853,24 @@ async def converse(
             current_user.id,
             type(exc).__name__,
         )
-        # D7: persist attempted user turn for continuity.
-        await _persist_user_turn_best_effort(session, current_user.id, sanitized)
+        # D7: persist attempted user turn for continuity. Bool discarded
+        # intentionally — no coupled side effect on this terminal branch.
+        _ = await _persist_user_turn_best_effort(
+            session, current_user.id, sanitized
+        )
         return _fallback_response(latency_ms=_elapsed_ms(started))
     except Exception as exc:
         # Catch-all preserves traceback (I1 QA iter-1) and ensures the
-        # endpoint never 500s on a transient model/network blip.
+        # endpoint never 500s on a transient model/network blip. Bool
+        # discarded intentionally — terminal branch, no coupled spend.
         logger.exception(
             "converse_agent_unexpected user_id=%s exc=%s",
             current_user.id,
             type(exc).__name__,
         )
-        await _persist_user_turn_best_effort(session, current_user.id, sanitized)
+        _ = await _persist_user_turn_best_effort(
+            session, current_user.id, sanitized
+        )
         return _fallback_response(latency_ms=_elapsed_ms(started))
 
     # 5. Pick the primary extraction from the deps-scoped sidecar

--- a/tests/agents/onboarding/test_conversation_agent.py
+++ b/tests/agents/onboarding/test_conversation_agent.py
@@ -112,20 +112,24 @@ class TestRetriesBudget:
 
     def test_retries_at_least_4(self):
         """Retry budget ≥ 4 so first-turn schema guesses don't immediately
-        surface as user-facing failures."""
+        surface as user-facing failures.
+
+        Pydantic AI 1.x splits the retry budget into `_max_tool_retries`
+        (per-tool-call, i.e. when Pydantic rejects the args and the LLM
+        has to re-emit) and `_max_result_retries` (per final output).
+        GH #382 is about tool-call retries; guard that specifically.
+        """
         agent = get_conversation_agent()
-        # Pydantic AI stores `retries` on the internal Agent config; exposed
-        # via the `.retries` attribute or via the internal config object.
-        retries = getattr(agent, "_default_retries", None)
-        if retries is None:  # newer pydantic_ai exposes via ._config
-            retries = getattr(getattr(agent, "_config", None), "retries", None)
+        retries = getattr(agent, "_max_tool_retries", None)
         assert retries is not None, (
-            "could not introspect agent.retries; update test if pydantic_ai "
-            "renamed the attribute"
+            "could not introspect agent._max_tool_retries; pydantic_ai "
+            "may have renamed the attribute, update the test + production "
+            "`retries=` kwarg together"
         )
         assert retries >= 4, (
-            f"agent retries={retries}; GH #382 requires >=4 to absorb first-turn "
-            f"tool-call schema guesses before surfacing a validation_reject"
+            f"agent tool-retries={retries}; GH #382 requires >=4 to absorb "
+            f"first-turn tool-call schema guesses before surfacing a "
+            f"validation_reject"
         )
 
 
@@ -145,6 +149,11 @@ class TestNoExtractionToolSignature:
         """Tool parameter schema must constrain `reason` to the 4
         Literal values; Pydantic AI will then reject at the tool-call
         boundary and the retry error message will self-explain.
+
+        With `from __future__ import annotations` in the agent module
+        every annotation is stringified, so `inspect.signature` returns
+        a bare str. Evaluate via `inspect.get_annotations(..., eval_str=True)`
+        to recover the runtime Literal.
         """
         import inspect
         from typing import Literal, get_args, get_origin
@@ -155,21 +164,21 @@ class TestNoExtractionToolSignature:
 
         agent = _create_conversation_agent()
         tool = agent._function_toolset.tools["no_extraction"]
-        sig = inspect.signature(tool.function)
-        reason_param = sig.parameters["reason"]
-        ann = reason_param.annotation
-        # Default may be wrapped in typing.Literal; accept either a bare
-        # Literal[...] annotation or a Literal with a default value.
-        assert get_origin(ann) is Literal, (
-            f"no_extraction.reason annotation is {ann}; must be "
+        hints = inspect.get_annotations(tool.function, eval_str=True)
+        reason_hint = hints.get("reason")
+        assert reason_hint is not None, (
+            "no_extraction tool has no `reason` annotation at all"
+        )
+        assert get_origin(reason_hint) is Literal, (
+            f"no_extraction.reason annotation is {reason_hint}; must be "
             f"Literal['off_topic','clarifying','backtracking','low_confidence']"
         )
-        assert set(get_args(ann)) == {
+        assert set(get_args(reason_hint)) == {
             "off_topic",
             "clarifying",
             "backtracking",
             "low_confidence",
-        }, f"Literal values drifted: got {get_args(ann)}"
+        }, f"Literal values drifted: got {get_args(reason_hint)}"
 
 
 class TestPersonaDriftScaffolding:

--- a/tests/agents/onboarding/test_conversation_agent.py
+++ b/tests/agents/onboarding/test_conversation_agent.py
@@ -99,6 +99,79 @@ class TestAgentShape:
         assert get_conversation_agent() is get_conversation_agent()
 
 
+class TestRetriesBudget:
+    """GH #382 regression guard — retry budget must absorb first-turn
+    tool-call mistakes.
+
+    Walk Q (2026-04-21) evidence: fresh-user input "I'm Simon, 32, in Zürich"
+    triggered `converse_validation_reject err_count=2`. The agent exhausted
+    its retry budget (previously `retries=2`) on repeated tool-call schema
+    errors. Raising to `retries=4` gives the LLM more chances to self-correct
+    when its first tool-call arg guess fails Pydantic validation.
+    """
+
+    def test_retries_at_least_4(self):
+        """Retry budget ≥ 4 so first-turn schema guesses don't immediately
+        surface as user-facing failures."""
+        agent = get_conversation_agent()
+        # Pydantic AI stores `retries` on the internal Agent config; exposed
+        # via the `.retries` attribute or via the internal config object.
+        retries = getattr(agent, "_default_retries", None)
+        if retries is None:  # newer pydantic_ai exposes via ._config
+            retries = getattr(getattr(agent, "_config", None), "retries", None)
+        assert retries is not None, (
+            "could not introspect agent.retries; update test if pydantic_ai "
+            "renamed the attribute"
+        )
+        assert retries >= 4, (
+            f"agent retries={retries}; GH #382 requires >=4 to absorb first-turn "
+            f"tool-call schema guesses before surfacing a validation_reject"
+        )
+
+
+class TestNoExtractionToolSignature:
+    """GH #382 regression guard — `no_extraction` tool signature must
+    constrain `reason` to the Literal set defined in the schema.
+
+    Root cause D4 (Walk Q deep trace): the tool signature declared
+    `reason: str` with no Literal enforcement, so when the LLM emitted
+    `no_extraction(reason="greeting")` (or any unknown value), the
+    string flowed past the tool boundary into
+    `NoExtraction.model_validate({"reason": reason})` which then raised
+    ValidationError. The retry loop repeated the same error.
+    """
+
+    def test_no_extraction_tool_enforces_literal_reason(self):
+        """Tool parameter schema must constrain `reason` to the 4
+        Literal values; Pydantic AI will then reject at the tool-call
+        boundary and the retry error message will self-explain.
+        """
+        import inspect
+        from typing import Literal, get_args, get_origin
+
+        from nikita.agents.onboarding.conversation_agent import (
+            _create_conversation_agent,
+        )
+
+        agent = _create_conversation_agent()
+        tool = agent._function_toolset.tools["no_extraction"]
+        sig = inspect.signature(tool.function)
+        reason_param = sig.parameters["reason"]
+        ann = reason_param.annotation
+        # Default may be wrapped in typing.Literal; accept either a bare
+        # Literal[...] annotation or a Literal with a default value.
+        assert get_origin(ann) is Literal, (
+            f"no_extraction.reason annotation is {ann}; must be "
+            f"Literal['off_topic','clarifying','backtracking','low_confidence']"
+        )
+        assert set(get_args(ann)) == {
+            "off_topic",
+            "clarifying",
+            "backtracking",
+            "low_confidence",
+        }, f"Literal values drifted: got {get_args(ann)}"
+
+
 class TestPersonaDriftScaffolding:
     """AC-T2.9.* scaffolding.
 

--- a/tests/agents/onboarding/test_extraction_schemas.py
+++ b/tests/agents/onboarding/test_extraction_schemas.py
@@ -46,6 +46,33 @@ class TestIdentityAgeValidation:
         with pytest.raises(ValidationError):
             IdentityExtraction(age=100, confidence=0.9)
 
+    def test_identity_age_accepts_int_string(self):
+        """GH #382 (D6): Anthropic tool use sometimes emits age as a
+        string ('32') or float (32.0). The schema must coerce these to
+        int rather than rejecting with a ValidationError that the agent
+        then repeats on retry.
+        """
+        model = IdentityExtraction(age="32", confidence=0.9)  # type: ignore[arg-type]
+        assert model.age == 32
+
+    def test_identity_age_accepts_float(self):
+        """GH #382 (D6): LLM may serialize age as 32.0 under some tool-
+        use protocols. Coerce to int when value is integral."""
+        model = IdentityExtraction(age=32.0, confidence=0.9)  # type: ignore[arg-type]
+        assert model.age == 32
+
+    def test_identity_age_rejects_non_numeric_string(self):
+        """D6 safety rail: garbage strings must still reject."""
+        with pytest.raises(ValidationError):
+            IdentityExtraction(age="not-an-int", confidence=0.9)  # type: ignore[arg-type]
+
+    def test_identity_age_rejects_non_integral_float(self):
+        """D6 safety rail: 32.5 must reject (user can't be 32.5 years old
+        in this context; must be a whole number).
+        """
+        with pytest.raises(ValidationError):
+            IdentityExtraction(age=32.5, confidence=0.9)  # type: ignore[arg-type]
+
     def test_identity_requires_at_least_one_field(self):
         """AC-T2.2.1 supporting guard: empty identity extraction rejected."""
         with pytest.raises(ValidationError):

--- a/tests/agents/onboarding/test_message_history.py
+++ b/tests/agents/onboarding/test_message_history.py
@@ -1,0 +1,115 @@
+"""Tests for nikita.agents.onboarding.message_history (GH #382 D1).
+
+The portal wizard sends ``ConverseRequest.conversation_history``
+on every turn. Before GH #382 the endpoint discarded this history,
+so the LLM saw every turn cold and repeatedly failed tool-call
+schema validation. The fix hydrates Turn[] → ModelMessage[] and
+passes it via ``agent.run(..., message_history=...)``.
+
+These tests pin the hydration behavior — cover the role mapping,
+empty-input edge, and the required-field invariants the endpoint
+relies on.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+
+from nikita.agents.onboarding.converse_contracts import Turn
+from nikita.agents.onboarding.message_history import hydrate_message_history
+
+
+def _make_turn(role: str, content: str, **extra) -> Turn:
+    return Turn(
+        role=role,  # type: ignore[arg-type]
+        content=content,
+        timestamp=datetime.now(UTC),
+        **extra,
+    )
+
+
+class TestHydrateMessageHistory:
+    def test_empty_returns_empty_list(self):
+        """No history → empty list (caller must then omit message_history=)."""
+        assert hydrate_message_history([]) == []
+
+    def test_user_role_maps_to_model_request(self):
+        """role=user → ModelRequest(parts=[UserPromptPart])"""
+        turns = [_make_turn("user", "hello")]
+        out = hydrate_message_history(turns)
+        assert len(out) == 1
+        assert isinstance(out[0], ModelRequest)
+        parts = out[0].parts
+        assert len(parts) == 1
+        assert isinstance(parts[0], UserPromptPart)
+        assert parts[0].content == "hello"
+
+    def test_nikita_role_maps_to_model_response(self):
+        """role=nikita → ModelResponse(parts=[TextPart])"""
+        turns = [_make_turn("nikita", "hey. building your file.")]
+        out = hydrate_message_history(turns)
+        assert len(out) == 1
+        assert isinstance(out[0], ModelResponse)
+        parts = out[0].parts
+        assert len(parts) == 1
+        assert isinstance(parts[0], TextPart)
+        assert parts[0].content == "hey. building your file."
+
+    def test_alternating_turns_preserve_order(self):
+        """Multi-turn history must preserve strict chronological order."""
+        turns = [
+            _make_turn("nikita", "where do i find you on a thursday?"),
+            _make_turn("user", "Zürich, techno spots near Langstrasse"),
+            _make_turn("nikita", "noted. how old are you?"),
+            _make_turn("user", "32"),
+        ]
+        out = hydrate_message_history(turns)
+        assert len(out) == 4
+        assert isinstance(out[0], ModelResponse)
+        assert isinstance(out[1], ModelRequest)
+        assert isinstance(out[2], ModelResponse)
+        assert isinstance(out[3], ModelRequest)
+
+    def test_drops_extracted_and_source_metadata(self):
+        """Turn's `extracted` dict and `source` enum are wire metadata.
+        The LLM only needs role + content; internal bookkeeping is
+        dropped to keep the history surface minimal."""
+        turns = [
+            _make_turn(
+                "nikita",
+                "noted.",
+                source="llm",
+            ),
+            _make_turn(
+                "user",
+                "32",
+                extracted={"age": 32},
+            ),
+        ]
+        out = hydrate_message_history(turns)
+        # Both turns should be represented; no exception from extra fields
+        assert len(out) == 2
+
+    def test_walk_q_regression_history_is_not_discarded(self):
+        """GH #382 regression guard: given a plausible wizard history,
+        the hydrator produces a non-empty ModelMessage list. This is
+        the single most important invariant for the #382 fix — if
+        hydration silently returned [], the endpoint fix would regress
+        to the original "cold every turn" failure mode.
+        """
+        turns = [
+            _make_turn("nikita", "hey. where do i find you?"),
+            _make_turn("user", "Zürich"),
+        ]
+        out = hydrate_message_history(turns)
+        assert len(out) == 2
+        # Must carry actual content, not empty strings from a bad mapper
+        assert out[0].parts[0].content == "hey. where do i find you?"
+        assert out[1].parts[0].content == "Zürich"

--- a/tests/api/routes/test_converse_endpoint.py
+++ b/tests/api/routes/test_converse_endpoint.py
@@ -618,6 +618,157 @@ class TestConverseValidationRejectRouting:
         mock_ledger.add_spend.assert_awaited_once()
 
 
+class TestValidationErrorAgeHeuristic:
+    """GH #382 (D2): edge-case coverage for _is_age_under_18_error.
+
+    The heuristic routes ValidationError to either the age-18 template
+    or the generic FALLBACK_REPLY based on `errors[0].loc[-1] == "age"`
+    AND `errors[0].type == "greater_than_equal"`. Both conditions must
+    match — PR #383 iter-1 nitpick.
+    """
+
+    def test_nested_loc_ending_in_age_counts_as_age(self):
+        """Pydantic may return `loc=("IdentityExtraction","age")` under
+        nested model validation. Heuristic treats it as age.
+        """
+        from nikita.api.routes.portal_onboarding import _is_age_under_18_error
+
+        errors = [
+            {
+                "loc": ("IdentityExtraction", "age"),
+                "type": "greater_than_equal",
+                "msg": "below 18",
+                "input": 15,
+            }
+        ]
+        assert _is_age_under_18_error(errors) is True
+
+    def test_non_age_field_ending_in_age_rejected(self):
+        """A non-age field whose name happens to end with 'age' (e.g.
+        'language') must NOT trigger the heuristic. The exact loc entry
+        must equal 'age', not merely end-with.
+        """
+        from nikita.api.routes.portal_onboarding import _is_age_under_18_error
+
+        errors = [
+            {
+                "loc": ("language",),
+                "type": "greater_than_equal",
+                "msg": "x",
+                "input": "y",
+            }
+        ]
+        assert _is_age_under_18_error(errors) is False
+
+    def test_age_field_wrong_err_type_rejected(self):
+        """Age loc but a different err_type (e.g. less_than_equal for
+        age>99, or missing) must NOT trigger the under-18 heuristic —
+        the user IS age-valid but hit a different constraint.
+        """
+        from nikita.api.routes.portal_onboarding import _is_age_under_18_error
+
+        errors = [
+            {
+                "loc": ("age",),
+                "type": "less_than_equal",
+                "msg": "above 99",
+                "input": 100,
+            }
+        ]
+        assert _is_age_under_18_error(errors) is False
+
+    def test_empty_errors_rejected(self):
+        """Empty errors list → not age (defensive)."""
+        from nikita.api.routes.portal_onboarding import _is_age_under_18_error
+
+        assert _is_age_under_18_error([]) is False
+
+
+class TestPersistBeforeChargeOrdering:
+    """GH #382 (PR #383 iter-1 IMPORTANT fix): user-turn persistence
+    must happen BEFORE spend accrual on the validator-reject path, and
+    spend must be SKIPPED if persist fails — otherwise the user pays
+    for a ghost turn.
+    """
+
+    @pytest.mark.asyncio
+    async def test_spend_skipped_when_persist_fails(self):
+        """Simulate append_conversation_turn raising — verify spend
+        ledger is NOT charged."""
+        from pydantic import BaseModel, ValidationError
+
+        from nikita.api.dependencies.auth import AuthenticatedUser
+        from nikita.api.routes.portal_onboarding import converse
+        from nikita.agents.onboarding.converse_contracts import ConverseRequest
+
+        user_id = uuid4()
+        user_stub = SimpleNamespace(id=user_id, onboarding_profile=None)
+        mock_session = AsyncMock()
+        select_result = MagicMock()
+        select_result.scalar_one = MagicMock(return_value=user_stub)
+        mock_session.execute = AsyncMock(return_value=select_result)
+        mock_session.rollback = AsyncMock(return_value=None)
+
+        class _Stub(BaseModel):
+            x: int
+
+        try:
+            _Stub(x="not-an-int")  # type: ignore[arg-type]
+        except ValidationError as real_exc:
+            real_exc.errors = MagicMock(
+                return_value=[
+                    {
+                        "loc": ("age",),
+                        "type": "greater_than_equal",
+                        "msg": "below 18",
+                        "input": 15,
+                    }
+                ]
+            )
+            agent_exc = real_exc
+
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(side_effect=agent_exc)
+
+        req = ConverseRequest(conversation_history=[], user_input="test")
+        auth_user = AuthenticatedUser(id=user_id, email="test@example.com")
+
+        with patch(
+            "nikita.api.routes.portal_onboarding.get_conversation_agent",
+            return_value=mock_agent,
+        ), patch(
+            "nikita.api.routes.portal_onboarding.IdempotencyStore"
+        ) as mock_idem_cls, patch(
+            "nikita.api.routes.portal_onboarding.LLMSpendLedger"
+        ) as mock_ledger_cls, patch(
+            "nikita.api.routes.portal_onboarding.append_conversation_turn",
+            side_effect=RuntimeError("simulated persist failure"),
+        ):
+            mock_idem = MagicMock()
+            mock_idem.get = AsyncMock(return_value=None)
+            mock_idem.put = AsyncMock(return_value=None)
+            mock_idem_cls.return_value = mock_idem
+            mock_ledger = MagicMock()
+            mock_ledger.get_today = AsyncMock(return_value=0)
+            mock_ledger.add_spend = AsyncMock(return_value=None)
+            mock_ledger_cls.return_value = mock_ledger
+
+            response = await converse(
+                req=req,
+                current_user=auth_user,
+                session=mock_session,
+                _rate_limit=None,
+                idempotency_key_header=None,
+            )
+
+        # Response still lands (fallback response, 200-equivalent)
+        assert response is not None
+        # Spend NOT charged because persist failed
+        mock_ledger.add_spend.assert_not_awaited()
+        # Session rollback DID happen so next ledger op wouldn't cascade
+        mock_session.rollback.assert_awaited()
+
+
 # ---------------------------------------------------------------------------
 # GH #373 — route registration regression guard (real FastAPI app)
 # ---------------------------------------------------------------------------

--- a/tests/api/routes/test_converse_endpoint.py
+++ b/tests/api/routes/test_converse_endpoint.py
@@ -307,6 +307,318 @@ class TestConverseJsonbPersistence:
 
 
 # ---------------------------------------------------------------------------
+# GH #382 — converse pipeline batch-fix regression guards
+# ---------------------------------------------------------------------------
+
+
+class TestConverseMessageHistoryWiring:
+    """GH #382 (D1): Walk Q showed the endpoint discarded the client's
+    ``conversation_history`` and called ``agent.run(user_input, deps=deps)``
+    without ``message_history=``. Every turn was cold; the LLM had no
+    context for the wizard step, guessed wrong, and tool-call validation
+    failed repeatedly.
+
+    Fix: hydrate Turn[] → ModelMessage[] via
+    ``nikita.agents.onboarding.message_history.hydrate_message_history``
+    and pass via ``agent.run(..., message_history=...)``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_agent_run_receives_hydrated_message_history(self):
+        """Given non-empty ``conversation_history`` in the request body,
+        the handler MUST call ``agent.run(..., message_history=<hydrated>)``.
+        Before the fix this kwarg was absent."""
+        from nikita.api.dependencies.auth import AuthenticatedUser
+        from nikita.api.routes.portal_onboarding import converse
+        from nikita.agents.onboarding.converse_contracts import ConverseRequest, Turn
+
+        user_id = uuid4()
+        user_stub = SimpleNamespace(id=user_id, onboarding_profile=None)
+        mock_session = AsyncMock()
+        select_result = MagicMock()
+        select_result.scalar_one = MagicMock(return_value=user_stub)
+        mock_session.execute = AsyncMock(return_value=select_result)
+
+        agent_result = SimpleNamespace(
+            output="noted. what's your age?",
+            usage=lambda: None,
+        )
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(return_value=agent_result)
+
+        prior_turn = Turn(
+            role="nikita",
+            content="hey. where do i find you on a thursday night?",
+            timestamp=datetime.now(timezone.utc),
+            source="llm",
+        )
+        req = ConverseRequest(
+            conversation_history=[prior_turn],
+            user_input="Zürich",
+        )
+        auth_user = AuthenticatedUser(id=user_id, email="test@example.com")
+
+        with patch(
+            "nikita.api.routes.portal_onboarding.get_conversation_agent",
+            return_value=mock_agent,
+        ), patch(
+            "nikita.api.routes.portal_onboarding.IdempotencyStore"
+        ) as mock_idem_cls, patch(
+            "nikita.api.routes.portal_onboarding.LLMSpendLedger"
+        ) as mock_ledger_cls:
+            mock_idem = MagicMock()
+            mock_idem.get = AsyncMock(return_value=None)
+            mock_idem.put = AsyncMock(return_value=None)
+            mock_idem_cls.return_value = mock_idem
+            mock_ledger = MagicMock()
+            mock_ledger.get_today = AsyncMock(return_value=0)
+            mock_ledger.add_spend = AsyncMock(return_value=None)
+            mock_ledger_cls.return_value = mock_ledger
+
+            await converse(
+                req=req,
+                current_user=auth_user,
+                session=mock_session,
+                _rate_limit=None,
+                idempotency_key_header=None,
+            )
+
+        # Introspect the agent.run call
+        assert mock_agent.run.call_count == 1
+        call_kwargs = mock_agent.run.call_args.kwargs
+        history = call_kwargs.get("message_history")
+        assert history is not None, (
+            "agent.run called WITHOUT message_history — GH #382 regression"
+        )
+        # The single prior Nikita turn should produce a 1-element list
+        assert len(history) == 1, (
+            f"expected 1 hydrated message, got {len(history)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_history_omits_message_history_kwarg(self):
+        """Fresh session (conversation_history=[]) should NOT pass
+        ``message_history=`` — that way Pydantic AI re-runs the system
+        prompt as documented for new sessions."""
+        from nikita.api.dependencies.auth import AuthenticatedUser
+        from nikita.api.routes.portal_onboarding import converse
+        from nikita.agents.onboarding.converse_contracts import ConverseRequest
+
+        user_id = uuid4()
+        user_stub = SimpleNamespace(id=user_id, onboarding_profile=None)
+        mock_session = AsyncMock()
+        select_result = MagicMock()
+        select_result.scalar_one = MagicMock(return_value=user_stub)
+        mock_session.execute = AsyncMock(return_value=select_result)
+
+        agent_result = SimpleNamespace(output="hi.", usage=lambda: None)
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(return_value=agent_result)
+
+        req = ConverseRequest(conversation_history=[], user_input="hi")
+        auth_user = AuthenticatedUser(id=user_id, email="test@example.com")
+
+        with patch(
+            "nikita.api.routes.portal_onboarding.get_conversation_agent",
+            return_value=mock_agent,
+        ), patch(
+            "nikita.api.routes.portal_onboarding.IdempotencyStore"
+        ) as mock_idem_cls, patch(
+            "nikita.api.routes.portal_onboarding.LLMSpendLedger"
+        ) as mock_ledger_cls:
+            mock_idem_cls.return_value.get = AsyncMock(return_value=None)
+            mock_idem_cls.return_value.put = AsyncMock(return_value=None)
+            mock_ledger_cls.return_value.get_today = AsyncMock(return_value=0)
+            mock_ledger_cls.return_value.add_spend = AsyncMock(return_value=None)
+
+            await converse(
+                req=req,
+                current_user=auth_user,
+                session=mock_session,
+                _rate_limit=None,
+                idempotency_key_header=None,
+            )
+
+        call_kwargs = mock_agent.run.call_args.kwargs
+        # Either message_history is absent, or explicitly None/empty
+        history = call_kwargs.get("message_history")
+        assert history in (None, []), (
+            f"empty conversation_history must not pass non-empty message_history; "
+            f"got {history!r}"
+        )
+
+
+class TestConverseValidationRejectRouting:
+    """GH #382 (D2 + D7 + D8): validation-reject path must:
+
+    - D2: return the age<18 template ONLY when the failing constraint
+      is actually age.ge on IdentityExtraction. Other tool validation
+      errors get the generic FALLBACK_REPLY.
+    - D7: persist the USER turn to JSONB even on validator reject so
+      the next turn's message_history reflects reality.
+    - D8: charge the spend ledger (ESTIMATED_TURN_COST_USD) because
+      the LLM actually ran and burned tokens.
+    """
+
+    async def _run_converse_with_validation_error(self, errors_payload):
+        """Helper: drive converse with agent.run raising a ValidationError
+        whose errors() returns the provided payload."""
+        from pydantic import BaseModel, ValidationError
+
+        from nikita.api.dependencies.auth import AuthenticatedUser
+        from nikita.api.routes.portal_onboarding import converse
+        from nikita.agents.onboarding.converse_contracts import ConverseRequest
+
+        user_id = uuid4()
+        user_stub = SimpleNamespace(id=user_id, onboarding_profile=None)
+        mock_session = AsyncMock()
+        select_result = MagicMock()
+        select_result.scalar_one = MagicMock(return_value=user_stub)
+        mock_session.execute = AsyncMock(return_value=select_result)
+
+        # Build a real ValidationError by forcing a Pydantic model to
+        # reject — then monkeypatch .errors() to return our payload so
+        # the test pins the handler's routing rather than Pydantic's
+        # error-shape internals.
+        class _Stub(BaseModel):
+            x: int
+
+        try:
+            _Stub(x="not-an-int")  # type: ignore[arg-type]
+        except ValidationError as real_exc:
+            real_exc.errors = MagicMock(return_value=errors_payload)
+            agent_exc = real_exc
+
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(side_effect=agent_exc)
+
+        req = ConverseRequest(
+            conversation_history=[],
+            user_input="I'm Simon, 32, in Zürich",
+        )
+        auth_user = AuthenticatedUser(id=user_id, email="test@example.com")
+
+        with patch(
+            "nikita.api.routes.portal_onboarding.get_conversation_agent",
+            return_value=mock_agent,
+        ), patch(
+            "nikita.api.routes.portal_onboarding.IdempotencyStore"
+        ) as mock_idem_cls, patch(
+            "nikita.api.routes.portal_onboarding.LLMSpendLedger"
+        ) as mock_ledger_cls:
+            mock_idem = MagicMock()
+            mock_idem.get = AsyncMock(return_value=None)
+            mock_idem.put = AsyncMock(return_value=None)
+            mock_idem_cls.return_value = mock_idem
+            mock_ledger = MagicMock()
+            mock_ledger.get_today = AsyncMock(return_value=0)
+            mock_ledger.add_spend = AsyncMock(return_value=None)
+            mock_ledger_cls.return_value = mock_ledger
+
+            response = await converse(
+                req=req,
+                current_user=auth_user,
+                session=mock_session,
+                _rate_limit=None,
+                idempotency_key_header=None,
+            )
+
+        return response, mock_ledger, user_stub
+
+    @pytest.mark.asyncio
+    async def test_age_constraint_error_returns_age_template(self):
+        """D2: ValidationError whose first error is ``age.greater_than_equal``
+        returns the ``_VALIDATION_REJECT_AGE_REPLY`` template."""
+        from nikita.api.routes.portal_onboarding import _VALIDATION_REJECT_AGE_REPLY
+
+        errors = [
+            {
+                "loc": ("age",),
+                "type": "greater_than_equal",
+                "msg": "Input should be greater than or equal to 18",
+                "input": 15,
+            }
+        ]
+        response, _ledger, _stub = await self._run_converse_with_validation_error(
+            errors
+        )
+        assert response.nikita_reply == _VALIDATION_REJECT_AGE_REPLY
+        assert response.source == "validation_reject"
+
+    @pytest.mark.asyncio
+    async def test_non_age_validation_error_returns_generic_fallback(self):
+        """D2: non-age ValidationError must NOT return the age-18 template.
+
+        Walk Q trapped this: a ValidationError on PhoneExtraction, or on
+        NoExtraction.reason (D4 unblocked), or on _at_least_one_field,
+        returned the age-18 template misleadingly. The correct behavior
+        is the generic FALLBACK_REPLY.
+        """
+        from nikita.agents.onboarding.validators import FALLBACK_REPLY
+
+        errors = [
+            {
+                "loc": ("phone",),
+                "type": "value_error",
+                "msg": "phone must be E.164",
+                "input": "not-a-phone",
+            }
+        ]
+        response, _ledger, _stub = await self._run_converse_with_validation_error(
+            errors
+        )
+        assert response.nikita_reply == FALLBACK_REPLY, (
+            f"non-age validator reject must return generic FALLBACK_REPLY, "
+            f"got {response.nikita_reply!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_validation_reject_persists_user_turn(self):
+        """D7: user turn must land in JSONB even on validator reject,
+        otherwise every retry is cold and the user is stuck in a loop."""
+        errors = [
+            {
+                "loc": ("phone",),
+                "type": "value_error",
+                "msg": "phone must be E.164",
+                "input": "x",
+            }
+        ]
+        _response, _ledger, user_stub = (
+            await self._run_converse_with_validation_error(errors)
+        )
+        # Expect the user turn committed even though reply was fallback
+        assert user_stub.onboarding_profile is not None, (
+            "D7 regression: user turn not persisted on validation_reject; "
+            "next turn will be cold and fail identically"
+        )
+        conv = user_stub.onboarding_profile.get("conversation", [])
+        user_turns = [t for t in conv if t.get("role") == "user"]
+        assert len(user_turns) == 1, (
+            f"expected 1 user turn persisted, got {len(user_turns)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_validation_reject_charges_spend(self):
+        """D8: validator-reject path charged ESTIMATED_TURN_COST_USD
+        because the LLM actually ran and burned tokens. Skipping the
+        spend accrual on this path would let a determined caller evade
+        the daily $2 cap by triggering validation errors."""
+        errors = [
+            {
+                "loc": ("age",),
+                "type": "greater_than_equal",
+                "msg": "below 18",
+                "input": 15,
+            }
+        ]
+        _response, mock_ledger, _stub = (
+            await self._run_converse_with_validation_error(errors)
+        )
+        mock_ledger.add_spend.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
 # GH #373 — route registration regression guard (real FastAPI app)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes **GH #382** (CRITICAL — onboarding validator rejects every wizard turn, blocks every new user on prod). Also addresses 4 additional HIGH/CRITICAL defects enumerated by the Walk Q deep pipeline trace.

Walk Q (2026-04-21) on rev nikita-api-00270-vhv exposed a validator-reject loop: every fresh user saw "we need you to be 18 or older. catch me when you are." regardless of explicit age=32. The timeout fix in PR #379 unmasked a deeper set of pipeline defects that had been hiding behind the 2500ms ceiling.

## Defects addressed (5 of 15 enumerated; 3 CRITICAL, 2 HIGH)

| ID | Severity | Issue |
|---|---|---|
| D1 | CRITICAL | `agent.run()` never received `message_history` — every turn cold |
| D2 | CRITICAL | All `ValidationError`s returned age<18 template (misleading) |
| D3 | CRITICAL | `converse_validation_reject` log was un-triagable (`err_count=2` only) |
| D4 | CRITICAL | `no_extraction` tool `reason` arg was `str`, Pydantic rejected Literal at model_validate after tool boundary |
| D5 | HIGH | `retries=2` too tight; first-turn mistakes surfaced as user-visible failures |
| D7 | HIGH | User turn not persisted on fallback branches → every retry cold |
| D8 | HIGH | Validator-reject skipped spend ledger → cap evadable |

D4+D5 fixed in `conversation_agent.py` (commit cb43161). D1+D2+D3+D7+D8 fixed in `portal_onboarding.py` (commit 03c3128).

Deferred to follow-up PR: D9 (idempotency on fallback), D10 (confirmation on fallback), D11 (stale extracted_fields on reply-reject), D13-D15 (LOW polish). D6 already satisfied by Pydantic default int coercion.

## Changes

### New file
- `nikita/agents/onboarding/message_history.py` — pure hydration: `Turn[]` → `list[ModelMessage]`. Mirrors `nikita/agents/text/history.py::HistoryLoader._convert_to_model_messages`.

### Modified
- `nikita/agents/onboarding/conversation_agent.py` — D4+D5: `no_extraction` tool `reason: Literal[4]`, `retries=4`.
- `nikita/api/routes/portal_onboarding.py` — D1: pass hydrated `message_history`. D2: `_is_age_under_18_error()` helper routes age vs. non-age rejects. D3: `_summarize_validation_errors()` enriches reject log. D7: `_persist_user_turn_best_effort()` on every fallback branch. D8: `_charge_estimated_spend()` on validator-reject.

### New tests (16 total)
- `tests/agents/onboarding/test_message_history.py` — 6 hydrator contracts.
- `tests/agents/onboarding/test_conversation_agent.py::{TestRetriesBudget,TestNoExtractionToolSignature}` — 2.
- `tests/agents/onboarding/test_extraction_schemas.py::TestIdentityAgeValidation` — 4 age-coercion tests (D6 regression guards, already passing).
- `tests/api/routes/test_converse_endpoint.py::{TestConverseMessageHistoryWiring,TestConverseValidationRejectRouting}` — 6 handler integration tests.

## Local tests

- `uv run pytest -q` → **6545 passed** (was 6527; +18 new), 2 skipped
- `(cd portal && npm run test -- --run)` → passing
- `(cd portal && npm run lint)` → 0 errors, 2 pre-existing warnings
- `(cd portal && npm run build)` → SUCCESS

## Pre-PR grep gates

- Zero-assertion test shells: empty
- PII in log format strings: empty
- Raw `cache_key`: 2 hits, both pre-existing (not in diff)

## Walk Q evidence

See `docs-to-process/20260421-adv-e2e/Q-final-walk.md` and the deep-trace report attached to GH #382. Walk R (post-merge) will verify the fix end-to-end.

Closes #382. Refs Spec 214 FR-11d, Walk Q continuation report, deep-trace task #108.