### PR TITLE
fix(214,382): D4b — extract_scene + extract_phone tool-sig Literal drift

### DIFF
--- a/nikita/agents/onboarding/conversation_agent.py
+++ b/nikita/agents/onboarding/conversation_agent.py
@@ -112,11 +112,21 @@ def _create_conversation_agent() -> Agent[ConverseDeps, str]:
     @agent.tool
     def extract_scene(
         ctx: RunContext[ConverseDeps],
-        scene: str,
+        scene: Literal["techno", "art", "food", "cocktails", "nature"],
         confidence: float,
-        life_stage: str | None = None,
+        life_stage: Literal[
+            "tech", "finance", "creative", "student", "entrepreneur", "other"
+        ] | None = None,
     ) -> str:
-        """Commit a social-scene extraction (optionally with life stage)."""
+        """Commit a social-scene extraction (optionally with life stage).
+
+        GH #382 D4b (Walk R 2026-04-21): `scene` and `life_stage` must
+        match the Literal set SceneExtraction accepts. Before this fix,
+        the LLM could emit `scene="techno_club"` / `"bar"` / anything,
+        which flowed past the tool boundary into SceneExtraction
+        and raised ValidationError. Walk R observed this directly
+        with loc=scene type=literal_error.
+        """
         ctx.deps.extracted.append(
             SceneExtraction.model_validate(
                 {
@@ -179,11 +189,15 @@ def _create_conversation_agent() -> Agent[ConverseDeps, str]:
     @agent.tool
     def extract_phone(
         ctx: RunContext[ConverseDeps],
-        phone_preference: str,
+        phone_preference: Literal["voice", "text"],
         confidence: float,
         phone: str | None = None,
     ) -> str:
-        """Commit the user's voice/text preference (+ phone if voice)."""
+        """Commit the user's voice/text preference (+ phone if voice).
+
+        GH #382 D4b: `phone_preference` constrained to PhoneExtraction's
+        Literal[2] at the tool boundary, matching the D4 pattern.
+        """
         ctx.deps.extracted.append(
             PhoneExtraction.model_validate(
                 {

--- a/nikita/agents/onboarding/conversation_agent.py
+++ b/nikita/agents/onboarding/conversation_agent.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Literal
 from uuid import UUID
 
 from pydantic_ai import Agent, RunContext
@@ -41,11 +40,16 @@ from nikita.agents.onboarding.extraction_schemas import (
     BackstoryExtraction,
     ConverseResult,
     DarknessExtraction,
+    DrugToleranceValue,
     IdentityExtraction,
+    LifeStageValue,
     LocationExtraction,
     NoExtraction,
+    NoExtractionReasonValue,
     PhoneExtraction,
+    PhonePreferenceValue,
     SceneExtraction,
+    SceneValue,
 )
 from nikita.config.models import Models
 
@@ -112,20 +116,20 @@ def _create_conversation_agent() -> Agent[ConverseDeps, str]:
     @agent.tool
     def extract_scene(
         ctx: RunContext[ConverseDeps],
-        scene: Literal["techno", "art", "food", "cocktails", "nature"],
+        scene: SceneValue,
         confidence: float,
-        life_stage: Literal[
-            "tech", "finance", "creative", "student", "entrepreneur", "other"
-        ] | None = None,
+        life_stage: LifeStageValue | None = None,
     ) -> str:
         """Commit a social-scene extraction (optionally with life stage).
 
         GH #382 D4b (Walk R 2026-04-21): `scene` and `life_stage` must
         match the Literal set SceneExtraction accepts. Before this fix,
         the LLM could emit `scene="techno_club"` / `"bar"` / anything,
-        which flowed past the tool boundary into SceneExtraction
-        and raised ValidationError. Walk R observed this directly
-        with loc=scene type=literal_error.
+        which flowed past the tool boundary into SceneExtraction and
+        raised ValidationError. Walk R observed this directly with
+        loc=scene type=literal_error. Type aliases (SceneValue,
+        LifeStageValue) live in ``extraction_schemas.py`` as the single
+        source of truth — DO NOT re-declare Literal sets here.
         """
         ctx.deps.extracted.append(
             SceneExtraction.model_validate(
@@ -140,9 +144,16 @@ def _create_conversation_agent() -> Agent[ConverseDeps, str]:
 
     @agent.tool
     def extract_darkness(
-        ctx: RunContext[ConverseDeps], drug_tolerance: int, confidence: float
+        ctx: RunContext[ConverseDeps],
+        drug_tolerance: DrugToleranceValue,
+        confidence: float,
     ) -> str:
-        """Commit a 1-5 darkness rating."""
+        """Commit a 1-5 darkness rating.
+
+        GH #382 D4b (QA iter-1): drug_tolerance uses the shared
+        ``DrugToleranceValue = Annotated[int, Field(ge=1, le=5)]``
+        alias so the LLM can't emit 0 / 6 / 99 past the tool boundary.
+        """
         ctx.deps.extracted.append(
             DarknessExtraction(
                 drug_tolerance=drug_tolerance, confidence=confidence
@@ -189,7 +200,7 @@ def _create_conversation_agent() -> Agent[ConverseDeps, str]:
     @agent.tool
     def extract_phone(
         ctx: RunContext[ConverseDeps],
-        phone_preference: Literal["voice", "text"],
+        phone_preference: PhonePreferenceValue,
         confidence: float,
         phone: str | None = None,
     ) -> str:
@@ -212,12 +223,7 @@ def _create_conversation_agent() -> Agent[ConverseDeps, str]:
     @agent.tool
     def no_extraction(
         ctx: RunContext[ConverseDeps],
-        reason: Literal[
-            "off_topic",
-            "clarifying",
-            "backtracking",
-            "low_confidence",
-        ] = "off_topic",
+        reason: NoExtractionReasonValue = "off_topic",
     ) -> str:
         """Declare "no extraction" for off-topic / clarifying / backtracking.
 

--- a/nikita/agents/onboarding/conversation_agent.py
+++ b/nikita/agents/onboarding/conversation_agent.py
@@ -150,10 +150,16 @@ def _create_conversation_agent() -> Agent[ConverseDeps, str]:
     ) -> str:
         """Commit a 1-5 darkness rating.
 
-        GH #382 D4b (QA iter-1): drug_tolerance uses the shared
+        GH #382 D4b (QA iter-2): drug_tolerance uses the shared
         ``DrugToleranceValue = Annotated[int, Field(ge=1, le=5)]``
-        alias so the LLM can't emit 0 / 6 / 99 past the tool boundary.
+        alias — Pydantic AI propagates ge/le into JSON schema as
+        {"minimum":1,"maximum":5} so the LLM is constrained at the
+        tool-call boundary. Belt-and-suspenders body guard below.
         """
+        if not (1 <= drug_tolerance <= 5):
+            raise ValueError(
+                f"drug_tolerance {drug_tolerance} out of 1-5 range"
+            )
         ctx.deps.extracted.append(
             DarknessExtraction(
                 drug_tolerance=drug_tolerance, confidence=confidence
@@ -234,9 +240,7 @@ def _create_conversation_agent() -> Agent[ConverseDeps, str]:
         NoExtraction.model_validate ValidationError up through
         agent.run.
         """
-        ctx.deps.extracted.append(
-            NoExtraction.model_validate({"reason": reason})
-        )
+        ctx.deps.extracted.append(NoExtraction(reason=reason))
         return "ok"
 
     return agent

--- a/nikita/agents/onboarding/extraction_schemas.py
+++ b/nikita/agents/onboarding/extraction_schemas.py
@@ -41,6 +41,35 @@ from nikita.onboarding.tuning import MIN_USER_AGE
 
 
 # ---------------------------------------------------------------------------
+# Shared Literal type aliases (GH #382 D4/D4b — single source of truth)
+# ---------------------------------------------------------------------------
+# Both the Pydantic extraction schemas (below) AND the Pydantic AI tool
+# signatures in ``conversation_agent.py`` must use these aliases, so that
+# the LLM tool-call boundary rejects freeform strings identically to the
+# model_validate path. Reviewers: do NOT duplicate these Literal sets at
+# the tool-signature site; import these aliases.
+
+SceneValue = Literal["techno", "art", "food", "cocktails", "nature"]
+"""Allowed social-scene values. Any drift MUST update this single alias."""
+
+LifeStageValue = Literal[
+    "tech", "finance", "creative", "student", "entrepreneur", "other"
+]
+"""Allowed life-stage enumeration."""
+
+PhonePreferenceValue = Literal["voice", "text"]
+"""Allowed phone-preference modes."""
+
+NoExtractionReasonValue = Literal[
+    "off_topic", "clarifying", "backtracking", "low_confidence"
+]
+"""Allowed NoExtraction.reason values."""
+
+DrugToleranceValue = Annotated[int, Field(ge=1, le=5)]
+"""Constrained int for DarknessExtraction.drug_tolerance (1-5 scale)."""
+
+
+# ---------------------------------------------------------------------------
 # Per-topic extraction schemas
 # ---------------------------------------------------------------------------
 
@@ -72,17 +101,15 @@ class SceneExtraction(_ConfidenceMixin):
     """Agent emits this when the user has picked a social scene."""
 
     kind: Literal["scene"] = "scene"
-    scene: Literal["techno", "art", "food", "cocktails", "nature"]
-    life_stage: Literal[
-        "tech", "finance", "creative", "student", "entrepreneur", "other"
-    ] | None = None
+    scene: SceneValue
+    life_stage: LifeStageValue | None = None
 
 
 class DarknessExtraction(_ConfidenceMixin):
     """Agent emits this when the user has chosen a 1-5 darkness rating."""
 
     kind: Literal["darkness"] = "darkness"
-    drug_tolerance: int = Field(ge=1, le=5)
+    drug_tolerance: DrugToleranceValue
 
 
 class IdentityExtraction(_ConfidenceMixin):
@@ -124,7 +151,7 @@ class PhoneExtraction(_ConfidenceMixin):
     """
 
     kind: Literal["phone"] = "phone"
-    phone_preference: Literal["voice", "text"]
+    phone_preference: PhonePreferenceValue
     phone: str | None = None
 
     @field_validator("phone")
@@ -188,12 +215,7 @@ class NoExtraction(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     kind: Literal["no_extraction"] = "no_extraction"
-    reason: Literal[
-        "off_topic",
-        "clarifying",
-        "backtracking",
-        "low_confidence",
-    ] = "off_topic"
+    reason: NoExtractionReasonValue = "off_topic"
 
 
 # Discriminated union of 6 extractions + 1 no_extraction sentinel = 7 branches.
@@ -217,9 +239,14 @@ __all__ = [
     "BackstoryExtraction",
     "ConverseResult",
     "DarknessExtraction",
+    "DrugToleranceValue",
     "IdentityExtraction",
+    "LifeStageValue",
     "LocationExtraction",
     "NoExtraction",
+    "NoExtractionReasonValue",
     "PhoneExtraction",
+    "PhonePreferenceValue",
     "SceneExtraction",
+    "SceneValue",
 ]

--- a/nikita/agents/onboarding/extraction_schemas.py
+++ b/nikita/agents/onboarding/extraction_schemas.py
@@ -66,7 +66,13 @@ NoExtractionReasonValue = Literal[
 """Allowed NoExtraction.reason values."""
 
 DrugToleranceValue = Annotated[int, Field(ge=1, le=5)]
-"""Constrained int for DarknessExtraction.drug_tolerance (1-5 scale)."""
+"""Constrained int for DarknessExtraction.drug_tolerance (1-5 scale).
+
+Uses Annotated[int, Field()] rather than Literal so the tool JSON schema
+emits {"type":"integer","minimum":1,"maximum":5} (range constraint) instead
+of an enum. Pydantic v2 propagates ge/le into JSON schema correctly. Do NOT
+change to bare int — that removes the LLM-facing constraint.
+"""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/onboarding/test_conversation_agent.py
+++ b/tests/agents/onboarding/test_conversation_agent.py
@@ -133,6 +133,87 @@ class TestRetriesBudget:
         )
 
 
+class TestAllToolSignaturesMatchSchemaLiterals:
+    """GH #382 D4b (Walk R 2026-04-21): every tool whose underlying
+    schema has a Literal-constrained field must carry the SAME Literal
+    at the tool-signature level. Otherwise the LLM emits freeform
+    strings that flow past the tool boundary into model_validate and
+    raise ValidationError, exhausting retries.
+
+    Walk R reproduced this directly: LLM emitted `extract_scene(scene=<X>)`
+    where X was outside ``["techno","art","food","cocktails","nature"]``.
+    Log: `loc=scene type=literal_error`. D4 fixed no_extraction.reason
+    but extract_scene + extract_phone had the same pattern.
+    """
+
+    @staticmethod
+    def _get_hints(tool_name):
+        """Return runtime-evaluated type hints for a tool function."""
+        import inspect
+
+        from nikita.agents.onboarding.conversation_agent import (
+            _create_conversation_agent,
+        )
+
+        agent = _create_conversation_agent()
+        tool = agent._function_toolset.tools[tool_name]
+        return inspect.get_annotations(tool.function, eval_str=True)
+
+    def test_extract_scene_scene_is_literal(self):
+        """extract_scene.scene MUST be Literal[
+            "techno","art","food","cocktails","nature"]."""
+        from typing import Literal, get_args, get_origin
+
+        hints = self._get_hints("extract_scene")
+        scene = hints.get("scene")
+        assert get_origin(scene) is Literal, (
+            f"extract_scene.scene is {scene}; must match SceneExtraction.scene Literal"
+        )
+        assert set(get_args(scene)) == {
+            "techno",
+            "art",
+            "food",
+            "cocktails",
+            "nature",
+        }
+
+    def test_extract_scene_life_stage_is_literal(self):
+        """extract_scene.life_stage MUST be Literal[6] | None."""
+        from typing import Literal, get_args, get_origin
+
+        hints = self._get_hints("extract_scene")
+        life_stage = hints.get("life_stage")
+        # life_stage is Optional[Literal[...]] → get_origin is Union,
+        # get_args returns (Literal[...], NoneType)
+        args = get_args(life_stage)
+        literal_arg = next(
+            (a for a in args if get_origin(a) is Literal), None
+        )
+        assert literal_arg is not None, (
+            f"extract_scene.life_stage {life_stage} must include a Literal"
+        )
+        assert set(get_args(literal_arg)) == {
+            "tech",
+            "finance",
+            "creative",
+            "student",
+            "entrepreneur",
+            "other",
+        }
+
+    def test_extract_phone_preference_is_literal(self):
+        """extract_phone.phone_preference MUST be Literal["voice","text"]."""
+        from typing import Literal, get_args, get_origin
+
+        hints = self._get_hints("extract_phone")
+        pref = hints.get("phone_preference")
+        assert get_origin(pref) is Literal, (
+            f"extract_phone.phone_preference is {pref}; must match "
+            f"PhoneExtraction.phone_preference Literal"
+        )
+        assert set(get_args(pref)) == {"voice", "text"}
+
+
 class TestNoExtractionToolSignature:
     """GH #382 regression guard — `no_extraction` tool signature must
     constrain `reason` to the Literal set defined in the schema.

--- a/tests/agents/onboarding/test_conversation_agent.py
+++ b/tests/agents/onboarding/test_conversation_agent.py
@@ -213,6 +213,41 @@ class TestAllToolSignaturesMatchSchemaLiterals:
         )
         assert set(get_args(pref)) == {"voice", "text"}
 
+    def test_extract_darkness_tolerance_is_bounded(self):
+        """extract_darkness.drug_tolerance MUST be Annotated[int, ge=1, le=5]
+        so the LLM can't emit 0/6/99 past the tool boundary (GH #382 D4b
+        iter-1 important finding).
+        """
+        from typing import Annotated, get_args, get_origin
+
+        from pydantic.fields import FieldInfo
+
+        hints = self._get_hints("extract_darkness")
+        dt = hints.get("drug_tolerance")
+        # Must be an Annotated wrapper (Annotated[int, Field(ge=1, le=5)])
+        # rather than bare int.
+        assert dt is not None, "drug_tolerance missing from extract_darkness"
+        assert get_origin(dt) is not None, (
+            f"extract_darkness.drug_tolerance is bare {dt}; must be "
+            f"Annotated[int, Field(ge=1, le=5)]"
+        )
+        args = get_args(dt)
+        # args[0] is the base type (int); args[1..] contain the metadata.
+        # Find the FieldInfo (Pydantic's Field() produces a FieldInfo when
+        # stacked in an Annotated).
+        metas = list(args[1:])
+        field_info = next((m for m in metas if isinstance(m, FieldInfo)), None)
+        assert field_info is not None, (
+            f"drug_tolerance Annotated metadata {metas} missing a FieldInfo"
+        )
+        # ge=1, le=5 live on FieldInfo.metadata as Ge/Le or on
+        # FieldInfo directly depending on Pydantic version.
+        constraint_texts = [repr(x) for x in field_info.metadata]
+        joined = " ".join(constraint_texts)
+        assert "1" in joined and "5" in joined, (
+            f"drug_tolerance constraints {field_info.metadata} must bound 1-5"
+        )
+
 
 class TestNoExtractionToolSignature:
     """GH #382 regression guard — `no_extraction` tool signature must

--- a/tests/agents/onboarding/test_conversation_agent.py
+++ b/tests/agents/onboarding/test_conversation_agent.py
@@ -148,14 +148,15 @@ class TestAllToolSignaturesMatchSchemaLiterals:
 
     @staticmethod
     def _get_hints(tool_name):
-        """Return runtime-evaluated type hints for a tool function."""
+        """Return runtime-evaluated type hints for a tool function.
+
+        Uses the production singleton (get_conversation_agent) so we
+        inspect the same agent instance as the endpoint — avoids
+        coupling to the private _create_conversation_agent factory.
+        """
         import inspect
 
-        from nikita.agents.onboarding.conversation_agent import (
-            _create_conversation_agent,
-        )
-
-        agent = _create_conversation_agent()
+        agent = get_conversation_agent()
         tool = agent._function_toolset.tools[tool_name]
         return inspect.get_annotations(tool.function, eval_str=True)
 
@@ -240,12 +241,19 @@ class TestAllToolSignaturesMatchSchemaLiterals:
         assert field_info is not None, (
             f"drug_tolerance Annotated metadata {metas} missing a FieldInfo"
         )
-        # ge=1, le=5 live on FieldInfo.metadata as Ge/Le or on
-        # FieldInfo directly depending on Pydantic version.
-        constraint_texts = [repr(x) for x in field_info.metadata]
-        joined = " ".join(constraint_texts)
-        assert "1" in joined and "5" in joined, (
-            f"drug_tolerance constraints {field_info.metadata} must bound 1-5"
+        # ge=1, le=5 live on FieldInfo.metadata as annotated_types.Ge/Le
+        # objects. Check via hasattr to remain stable across pydantic versions.
+        has_ge_1 = any(
+            hasattr(m, "ge") and m.ge == 1 for m in field_info.metadata
+        )
+        has_le_5 = any(
+            hasattr(m, "le") and m.le == 5 for m in field_info.metadata
+        )
+        assert has_ge_1, (
+            f"drug_tolerance metadata {field_info.metadata!r} must include ge=1"
+        )
+        assert has_le_5, (
+            f"drug_tolerance metadata {field_info.metadata!r} must include le=5"
         )
 
 
@@ -274,11 +282,7 @@ class TestNoExtractionToolSignature:
         import inspect
         from typing import Literal, get_args, get_origin
 
-        from nikita.agents.onboarding.conversation_agent import (
-            _create_conversation_agent,
-        )
-
-        agent = _create_conversation_agent()
+        agent = get_conversation_agent()
         tool = agent._function_toolset.tools["no_extraction"]
         hints = inspect.get_annotations(tool.function, eval_str=True)
         reason_hint = hints.get("reason")

--- a/tests/agents/onboarding/test_conversation_agent.py
+++ b/tests/agents/onboarding/test_conversation_agent.py
@@ -61,7 +61,7 @@ class TestAgentShape:
         assert isinstance(agent, Agent)
 
         # Pydantic AI 1.x exposes registered tools via the internal
-        # ``_function_toolset.tools`` dict; each ``@agent.tool_plain``
+        # ``_function_toolset.tools`` dict; each ``@agent.tool``
         # registration adds an entry keyed by function name.
         tools = list(agent._function_toolset.tools.keys())
         # 6 extraction tools + 1 no_extraction sentinel = 7.


### PR DESCRIPTION
## Summary

Walk R (2026-04-21, post PR #383 deploy) reproduced the same D4 class-of-bug on **extract_scene**. PR #383 fixed `no_extraction.reason`; this PR closes the remaining tool-signature Literal drift on `extract_scene.scene`, `extract_scene.life_stage`, and `extract_phone.phone_preference`.

## Evidence from Walk R

Cloud Run log (rev 00271-lp9, walkr user_id 949f2d50…):
```
WARNING converse_validation_reject user_id=949f2d50-… loc=scene type=literal_error err_count=2 is_age_under_18=False
```

The enriched log from PR #383 (D3) pinned the real cause on the first try — previously this would have shown only `err_count=2` and been un-triagable.

Wizard behavior vs Walk Q:
- ✅ No longer age-18 template (D2 works): response was `FALLBACK_REPLY = "hold on, let me try that again."`
- ✅ User turn persisted to JSONB (D7 works): `users.onboarding_profile.conversation[0]` contains the user message
- ❌ Wizard still stuck at 0%: the LLM can't pass scene validation

## Fix

- `extract_scene.scene`: `str` → `Literal["techno","art","food","cocktails","nature"]`
- `extract_scene.life_stage`: `str | None` → `Literal["tech","finance","creative","student","entrepreneur","other"] | None`
- `extract_phone.phone_preference`: `str` → `Literal["voice","text"]`

Pydantic AI now rejects freeform values at the tool-call boundary with a structured error the LLM can self-correct on, instead of bubbling a ValidationError through `model_validate` and exhausting the retry budget.

## Tests

- `TestAllToolSignaturesMatchSchemaLiterals` (3 new, in `test_conversation_agent.py`): introspects tool annotations via `inspect.get_annotations(..., eval_str=True)` and asserts Literal args match the schema Literal sets. Any future drift breaks CI.
- Full suite: `uv run pytest -q` → **6553 passed** (+3 new).

## Non-blocking deferrals

- `extract_backstory.chosen_option_id` + `cache_key` have regex patterns in the schema but not in the tool sig. Less critical because the LLM copy-pastes these from a prior server response (not freeform). Track as D4c if Walk R surfaces it.
- `extract_darkness.drug_tolerance: int` (ge=1 le=5) is enforced by the schema; the tool sig accepts any int, but ValidationError on 6/7/etc would still be handled correctly by the D2 fallback routing.

## Pre-PR grep gates

- Zero-assertion test shells: empty
- PII in log format strings: empty
- Raw `cache_key` in changed files: none

Refs GH #382, PR #383, Walk Q + Walk R reports, Spec 214 FR-11d.