### PR TITLE
fix(214,385): wizard conversation history not restored on page reload

### DIFF
--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -666,6 +666,51 @@ async def _charge_estimated_spend(
         )
 
 
+class ConversationProfileResponse(BaseModel):
+    """GH #385 — prior conversation turns for wizard hydration on page reload."""
+
+    conversation: list[dict] = Field(default_factory=list)
+    progress_pct: int = Field(default=0, ge=0, le=100)
+    elided_extracted: dict = Field(default_factory=dict)
+
+
+@router.get(
+    "/conversation",
+    response_model=ConversationProfileResponse,
+    summary="Fetch prior conversation turns for wizard hydration (GH #385)",
+    description="""
+    Returns the authenticated user's prior onboarding conversation turns so
+    the chat wizard can restore state on page reload instead of restarting.
+
+    Returns empty ``conversation`` list for new users (wizard shows the
+    hardcoded opener). ``progress_pct`` is computed from committed extracted
+    fields; ``elided_extracted`` carries fields committed in prior sessions.
+    """,
+)
+async def get_conversation(
+    current_user: AuthenticatedUser = Depends(get_authenticated_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> ConversationProfileResponse:
+    """Return prior conversation turns from the user's onboarding profile."""
+    from nikita.db.repositories.user_repository import UserRepository
+
+    repo = UserRepository(session)
+    user = await repo.get(current_user.id)
+    if user is None:
+        return ConversationProfileResponse()
+
+    profile: dict = user.onboarding_profile or {}
+    conversation = profile.get("conversation", [])
+    elided_extracted = profile.get("elided_extracted", {})
+    progress_pct = _compute_progress(elided_extracted) if elided_extracted else 0
+
+    return ConversationProfileResponse(
+        conversation=conversation,
+        progress_pct=progress_pct,
+        elided_extracted=elided_extracted,
+    )
+
+
 @router.post(
     "/converse",
     response_model=ConverseResponse,

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -23,7 +23,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from pydantic_ai.exceptions import (
     UnexpectedModelBehavior,
     UsageLimitExceeded,
@@ -666,10 +666,22 @@ async def _charge_estimated_spend(
         )
 
 
+class ConversationTurn(BaseModel):
+    """Single turn in the onboarding conversation stored in onboarding_profile JSONB."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role: Literal["nikita", "user"]
+    content: str
+    timestamp: str
+    source: Literal["llm", "fallback", "idempotent", "validation_reject"] | None = None
+    extracted: dict | None = None
+
+
 class ConversationProfileResponse(BaseModel):
     """GH #385 — prior conversation turns for wizard hydration on page reload."""
 
-    conversation: list[dict] = Field(default_factory=list)
+    conversation: list[ConversationTurn] = Field(default_factory=list)
     progress_pct: int = Field(default=0, ge=0, le=100)
     elided_extracted: dict = Field(default_factory=dict)
 
@@ -692,7 +704,7 @@ async def get_conversation(
     session: AsyncSession = Depends(get_async_session),
 ) -> ConversationProfileResponse:
     """Return prior conversation turns from the user's onboarding profile."""
-    from nikita.db.repositories.user_repository import UserRepository
+    from nikita.db.repositories.user_repository import UserRepository  # intentional: module policy line 97-99
 
     repo = UserRepository(session)
     user = await repo.get(current_user.id)

--- a/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
+++ b/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
@@ -71,6 +71,9 @@ describe("OnboardingWizard — AC-T3.9.1 completion mounts ceremony", () => {
     vi.clearAllMocks()
     converseMock.mockReset()
     linkTelegramMock.mockReset()
+    getConversationMock.mockReset()
+    // Default: empty history so wizard shows hardcoded opener.
+    getConversationMock.mockResolvedValue({ conversation: [], progress_pct: 0, elided_extracted: {} })
     delete process.env.NEXT_PUBLIC_USE_LEGACY_FORM_WIZARD
   })
 
@@ -126,6 +129,7 @@ describe("OnboardingWizard — AC-T3.9.1 completion mounts ceremony", () => {
 describe("OnboardingWizard — AC-T3.9.2 feature flag routes to legacy", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    getConversationMock.mockResolvedValue({ conversation: [], progress_pct: 0, elided_extracted: {} })
   })
   afterEach(() => {
     delete process.env.NEXT_PUBLIC_USE_LEGACY_FORM_WIZARD
@@ -150,6 +154,8 @@ describe("OnboardingWizard — PR #363 QA iter-1 fixes", () => {
     vi.clearAllMocks()
     converseMock.mockReset()
     linkTelegramMock.mockReset()
+    getConversationMock.mockReset()
+    getConversationMock.mockResolvedValue({ conversation: [], progress_pct: 0, elided_extracted: {} })
     delete process.env.NEXT_PUBLIC_USE_LEGACY_FORM_WIZARD
   })
 
@@ -363,8 +369,9 @@ describe("OnboardingWizard — GH #385 conversation hydration on mount", () => {
     })
     render(<OnboardingWizard userId="u1" />)
     await waitFor(() => {
-      expect(screen.getByText("zurich is home")).toBeInTheDocument()
-      expect(screen.getByText("tell me more about zurich.")).toBeInTheDocument()
+      // ChatShell renders each turn as visible + sr-only spans; use getAllByText.
+      expect(screen.getAllByText("zurich is home")[0]).toBeInTheDocument()
+      expect(screen.getAllByText("tell me more about zurich.")[0]).toBeInTheDocument()
     })
   })
 

--- a/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
+++ b/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
@@ -12,11 +12,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 
 const converseMock = vi.fn()
 const linkTelegramMock = vi.fn()
+const getConversationMock = vi.fn()
 
 vi.mock("@/app/onboarding/hooks/use-onboarding-api", () => ({
   useOnboardingAPI: () => ({
     converse: converseMock,
     linkTelegram: linkTelegramMock,
+    getConversation: getConversationMock,
     previewBackstory: vi.fn(),
     submitProfile: vi.fn(),
     patchProfile: vi.fn(),
@@ -311,5 +313,70 @@ describe("OnboardingWizard — AC-T3.9.3 legacy files live under steps/legacy/",
         "SceneStep.tsx",
       ].sort()
     )
+  })
+})
+
+describe("OnboardingWizard — GH #385 conversation hydration on mount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    converseMock.mockReset()
+    linkTelegramMock.mockReset()
+    getConversationMock.mockReset()
+    delete process.env.NEXT_PUBLIC_USE_LEGACY_FORM_WIZARD
+  })
+
+  it("calls getConversation on mount to check for existing history", async () => {
+    getConversationMock.mockResolvedValueOnce({
+      conversation: [],
+      progress_pct: 0,
+      elided_extracted: {},
+    })
+    render(<OnboardingWizard userId="u1" />)
+    await waitFor(() => {
+      expect(getConversationMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("renders prior turns from backend when getConversation returns non-empty history", async () => {
+    getConversationMock.mockResolvedValueOnce({
+      conversation: [
+        {
+          role: "nikita",
+          content: "hey. building your file...",
+          timestamp: "2026-04-21T10:00:00Z",
+          source: "llm",
+        },
+        {
+          role: "user",
+          content: "zurich is home",
+          timestamp: "2026-04-21T10:01:00Z",
+        },
+        {
+          role: "nikita",
+          content: "tell me more about zurich.",
+          timestamp: "2026-04-21T10:02:00Z",
+          source: "llm",
+        },
+      ],
+      progress_pct: 20,
+      elided_extracted: {},
+    })
+    render(<OnboardingWizard userId="u1" />)
+    await waitFor(() => {
+      expect(screen.getByText("zurich is home")).toBeInTheDocument()
+      expect(screen.getByText("tell me more about zurich.")).toBeInTheDocument()
+    })
+  })
+
+  it("falls back to hardcoded greeting when getConversation returns empty conversation", async () => {
+    getConversationMock.mockResolvedValueOnce({
+      conversation: [],
+      progress_pct: 0,
+      elided_extracted: {},
+    })
+    render(<OnboardingWizard userId="u1" />)
+    await waitFor(() => {
+      expect(screen.getByText(/hey\. building your file/i)).toBeInTheDocument()
+    })
   })
 })

--- a/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
+++ b/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
@@ -102,10 +102,10 @@ describe("OnboardingWizard — AC-T3.9.1 completion mounts ceremony", () => {
 
   it("AC-T3.9.4: linkTelegram fires BEFORE ceremony mounts (ordering guarantee)", async () => {
     mockConverseOnce({ conversation_complete: true, progress_pct: 100 })
-    let linkResolvedAt = 0
-    let ceremonyMountedAt = 0
+    // Resolution-order array: immune to sub-millisecond Date.now() collisions.
+    const order: string[] = []
     linkTelegramMock.mockImplementationOnce(async () => {
-      linkResolvedAt = Date.now()
+      order.push("link")
       return { code: "XYZ789", expires_at: "2026-04-20T00:00:00Z" }
     })
     render(<OnboardingWizard userId="u1" />)
@@ -114,12 +114,11 @@ describe("OnboardingWizard — AC-T3.9.1 completion mounts ceremony", () => {
     fireEvent.submit(input.closest("form")!)
     await waitFor(() => {
       expect(screen.getByTestId("clearance-granted-ceremony")).toBeInTheDocument()
-      ceremonyMountedAt = Date.now()
+      order.push("ceremony")
     })
-    // linkTelegram was called; ceremony only paints AFTER resolution.
+    // linkTelegram resolved before ceremony mounted.
     expect(linkTelegramMock).toHaveBeenCalledTimes(1)
-    expect(linkResolvedAt).toBeGreaterThan(0)
-    expect(ceremonyMountedAt).toBeGreaterThanOrEqual(linkResolvedAt)
+    expect(order).toEqual(["link", "ceremony"])
     // CTA href includes the minted code (ensures state.linkCode was set).
     const cta = screen.getByTestId("ceremony-cta") as HTMLAnchorElement
     expect(cta.href).toContain("start=XYZ789")

--- a/portal/src/app/onboarding/hooks/use-onboarding-api.ts
+++ b/portal/src/app/onboarding/hooks/use-onboarding-api.ts
@@ -22,6 +22,7 @@ import type {
   BackstoryChoiceRequest,
   BackstoryPreviewRequest,
   BackstoryPreviewResponse,
+  ConversationProfileResponse,
   LinkCodeResponse,
   OnboardingV2ProfileRequest,
   OnboardingV2ProfileResponse,
@@ -165,6 +166,13 @@ export interface UseOnboardingAPI {
    * reducer's `timeout` action via `AbortSignal.timeout(CONVERSATION_AGENT_TIMEOUT_MS)`).
    */
   converse: (req: ConverseRequest, signal?: AbortSignal) => Promise<ConverseResponse>
+  /**
+   * GET /onboarding/conversation — GH #385 hydration endpoint.
+   *
+   * Returns prior conversation turns for the authenticated user so the wizard
+   * can restore state on page reload. Retryable (GET is idempotent).
+   */
+  getConversation: () => Promise<ConversationProfileResponse>
 }
 
 /**
@@ -205,6 +213,12 @@ export function useOnboardingAPI(): UseOnboardingAPI {
       },
       // GH #321 REQ-2: direct api.post, no withRetry. See interface docstring.
       linkTelegram: () => api.post<LinkCodeResponse>("/portal/link-telegram"),
+      // GH #385: GET is idempotent; safe to retry.
+      getConversation: () =>
+        withRetry(
+          () => api.get<ConversationProfileResponse>("/onboarding/conversation"),
+          { method: "GET" }
+        ),
       // Spec 214 T3.4: direct api.post, no withRetry (server is idempotent
       // via Idempotency-Key header; client retry would race the cache TTL).
       converse: (req, signal) => {

--- a/portal/src/app/onboarding/onboarding-wizard.tsx
+++ b/portal/src/app/onboarding/onboarding-wizard.tsx
@@ -51,6 +51,25 @@ function ChatOnboardingWizard({ userId }: OnboardingWizardProps) {
   const hydratedRef = useRef(false)
   const [linkMintError, setLinkMintError] = useState<string | null>(null)
 
+  // Shared fallback: used when backend returns empty history or fails.
+  const hydrateWithOpener = useCallback(() => {
+    hydrateOnce({
+      turns: [
+        {
+          role: "nikita",
+          content:
+            "hey. building your file. where do i find you on a thursday night?",
+          timestamp: new Date().toISOString(),
+          source: "llm",
+        },
+      ],
+      extractedFields: {},
+      progressPct: 0,
+      awaitingConfirmation: false,
+      currentPromptType: "text",
+    })
+  }, [hydrateOnce])
+
   useEffect(() => {
     if (hydratedRef.current) return
     hydratedRef.current = true
@@ -73,41 +92,13 @@ function ChatOnboardingWizard({ userId }: OnboardingWizardProps) {
           currentPromptType: "text",
         })
       } else {
-        hydrateOnce({
-          turns: [
-            {
-              role: "nikita",
-              content:
-                "hey. building your file. where do i find you on a thursday night?",
-              timestamp: new Date().toISOString(),
-              source: "llm",
-            },
-          ],
-          extractedFields: {},
-          progressPct: 0,
-          awaitingConfirmation: false,
-          currentPromptType: "text",
-        })
+        hydrateWithOpener()
       }
     }).catch(() => {
       // Network failure: fall back to hardcoded opener so wizard still works.
-      hydrateOnce({
-        turns: [
-          {
-            role: "nikita",
-            content:
-              "hey. building your file. where do i find you on a thursday night?",
-            timestamp: new Date().toISOString(),
-            source: "llm",
-          },
-        ],
-        extractedFields: {},
-        progressPct: 0,
-        awaitingConfirmation: false,
-        currentPromptType: "text",
-      })
+      hydrateWithOpener()
     })
-  }, [api, hydrateOnce, userId])
+  }, [api, hydrateOnce, hydrateWithOpener, userId])
 
   const submit = useCallback(
     async (input: string | ControlSelection) => {

--- a/portal/src/app/onboarding/onboarding-wizard.tsx
+++ b/portal/src/app/onboarding/onboarding-wizard.tsx
@@ -54,22 +54,60 @@ function ChatOnboardingWizard({ userId }: OnboardingWizardProps) {
   useEffect(() => {
     if (hydratedRef.current) return
     hydratedRef.current = true
-    hydrateOnce({
-      turns: [
-        {
-          role: "nikita",
-          content:
-            "hey. building your file. where do i find you on a thursday night?",
-          timestamp: new Date().toISOString(),
-          source: "llm",
-        },
-      ],
-      extractedFields: {},
-      progressPct: 0,
-      awaitingConfirmation: false,
-      currentPromptType: "text",
+    // GH #385: fetch prior conversation from backend on every mount so that
+    // a page reload restores the user's progress instead of resetting to the
+    // opener. Falls back to the hardcoded greeting if backend returns empty.
+    api.getConversation().then((data) => {
+      if (data.conversation.length > 0) {
+        hydrateOnce({
+          turns: data.conversation.map((t) => ({
+            role: t.role,
+            content: t.content,
+            timestamp: t.timestamp,
+            source: t.source,
+            extracted: t.extracted,
+          })),
+          extractedFields: data.elided_extracted ?? {},
+          progressPct: data.progress_pct,
+          awaitingConfirmation: false,
+          currentPromptType: "text",
+        })
+      } else {
+        hydrateOnce({
+          turns: [
+            {
+              role: "nikita",
+              content:
+                "hey. building your file. where do i find you on a thursday night?",
+              timestamp: new Date().toISOString(),
+              source: "llm",
+            },
+          ],
+          extractedFields: {},
+          progressPct: 0,
+          awaitingConfirmation: false,
+          currentPromptType: "text",
+        })
+      }
+    }).catch(() => {
+      // Network failure: fall back to hardcoded opener so wizard still works.
+      hydrateOnce({
+        turns: [
+          {
+            role: "nikita",
+            content:
+              "hey. building your file. where do i find you on a thursday night?",
+            timestamp: new Date().toISOString(),
+            source: "llm",
+          },
+        ],
+        extractedFields: {},
+        progressPct: 0,
+        awaitingConfirmation: false,
+        currentPromptType: "text",
+      })
     })
-  }, [hydrateOnce, userId])
+  }, [api, hydrateOnce, userId])
 
   const submit = useCallback(
     async (input: string | ControlSelection) => {

--- a/portal/src/app/onboarding/types/contracts.ts
+++ b/portal/src/app/onboarding/types/contracts.ts
@@ -181,7 +181,7 @@ export interface ConversationProfileResponse {
   }>
   /** Progress percentage (0-100) derived from committed extracted fields. */
   progress_pct: number
-  /** Elided extracted fields (fields committed before this session). */
+  /** All extracted fields committed to the user's profile (across all sessions, not just the current one). */
   elided_extracted: Record<string, unknown>
 }
 

--- a/portal/src/app/onboarding/types/contracts.ts
+++ b/portal/src/app/onboarding/types/contracts.ts
@@ -162,6 +162,30 @@ export interface LinkCodeResponse {
 }
 
 // ---------------------------------------------------------------------------
+// ConversationProfileResponse (GH #385 — GET /onboarding/conversation)
+// ---------------------------------------------------------------------------
+
+/**
+ * Response from GET /onboarding/conversation.
+ * Returns prior conversation turns so the wizard can hydrate on page reload.
+ * Mirror of `ConversationProfileResponse` in portal_onboarding.py.
+ */
+export interface ConversationProfileResponse {
+  /** Prior conversation turns in chronological order. Empty array if none. */
+  conversation: Array<{
+    role: "nikita" | "user"
+    content: string
+    timestamp: string
+    source?: "llm" | "fallback" | "idempotent" | "validation_reject" | null
+    extracted?: Record<string, unknown>
+  }>
+  /** Progress percentage (0-100) derived from committed extracted fields. */
+  progress_pct: number
+  /** Elided extracted fields (fields committed before this session). */
+  elided_extracted: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
 // ErrorResponse — flat shape used by handler-raised errors (403/404/409/429)
 // ---------------------------------------------------------------------------
 

--- a/tests/api/routes/test_converse_endpoint.py
+++ b/tests/api/routes/test_converse_endpoint.py
@@ -812,3 +812,36 @@ class TestConverseEndpointPath:
             f"Check portal_onboarding.py route declaration vs main.py mount prefix "
             f"for #373-class regression."
         )
+
+
+# ---------------------------------------------------------------------------
+# GH #385 — GET /conversation endpoint registration guard
+# ---------------------------------------------------------------------------
+
+
+class TestConversationGetEndpointPath:
+    """GH #385 regression guard — GET /api/v1/onboarding/conversation must be
+    registered so the wizard can restore conversation history on page reload.
+
+    Walk R (2026-04-21) found B4 FAIL: wizard always initialises with
+    hardcoded greeting because no GET endpoint exists to hydrate existing turns.
+    """
+
+    def test_conversation_get_endpoint_registered(self):
+        """GET /api/v1/onboarding/conversation returns non-404.
+
+        Before fix: endpoint does not exist → 404.
+        After fix: 401/403 (auth-rejected, route registered) NOT 404.
+        """
+        from fastapi.testclient import TestClient
+
+        from nikita.api.main import create_app
+
+        app = create_app()
+        client = TestClient(app)
+        response = client.get("/api/v1/onboarding/conversation")
+        assert response.status_code != 404, (
+            f"Route GET /api/v1/onboarding/conversation not registered (got 404). "
+            f"GH #385: wizard needs this endpoint to hydrate conversation on reload. "
+            f"Add GET /conversation handler to portal_onboarding.py router."
+        )


### PR DESCRIPTION
## Summary
- Fixes #385: chat wizard resets to blank opener on page reload, losing all conversation progress
- Adds `GET /onboarding/conversation` backend endpoint reading JSONB conversation history
- Adds `getConversation()` to `UseOnboardingAPI` with GET retry policy
- Wizard mount effect now fetches prior turns and hydrates from backend; falls back to hardcoded opener on failure or empty conversation
- `ConversationProfileResponse` interface added (TypeScript + Pydantic)

## Root cause
`ChatOnboardingWizard` mount `useEffect` always called `hydrateOnce` with a hardcoded opener turn. There was no backend `GET /conversation` endpoint and no fetch call. Every page reload started fresh, discarding all extracted fields and turns stored in `onboarding_profile["conversation"]` JSONB.

## Changes (5 files)
1. `nikita/api/routes/portal_onboarding.py` — `ConversationProfileResponse` model + `GET /conversation` route
2. `portal/src/app/onboarding/types/contracts.ts` — `ConversationProfileResponse` TS interface (source narrowed to Turn union)
3. `portal/src/app/onboarding/hooks/use-onboarding-api.ts` — `getConversation()` in interface + useMemo
4. `portal/src/app/onboarding/onboarding-wizard.tsx` — mount effect now async-fetches, hydrates from backend
5. `portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx` — GH #385 describe block (3 ACs); existing beforeEach blocks updated

## TDD evidence
- RED commit `2bc8a49`: `TestConversationGetEndpointPath` + 3 wizard hydration tests failing
- GREEN commit `9b09a9c`: all tests passing; no new test infrastructure

## Local tests
- `uv run pytest -q`: 6555 passed, 0 failed
- Portal vitest: 15/15 in `onboarding-wizard.test.tsx`; 717/722 overall (5 pre-existing failures in `HandoffStep.test.tsx`, `page-metadata.test.ts`, `god-mode-panel.test.tsx`, `life-event-timeline.test.tsx` confirmed pre-existing on stashed state)
- `npm run lint`: 0 errors (2 pre-existing warnings)
- `npm run build`: PASS

## Pre-PR grep gates
- Zero-assertion shells: empty
- PII in log format strings: empty
- Raw cache_key in logs: line 446 is function call arg (not log), pre-existing