### PR TITLE
fix(214,389): raise NIKITA_REPLY_MAX_CHARS 140 → 280 (100% fallback at wizard turn 4+)

### DIFF
--- a/nikita/onboarding/tuning.py
+++ b/nikita/onboarding/tuning.py
@@ -168,13 +168,20 @@ Rationale: longer inputs are almost always prompt-injection; 500 covers
 verbose genuine answers while rejecting novel-length jailbreak payloads.
 """
 
-NIKITA_REPLY_MAX_CHARS: Final[int] = 140
+NIKITA_REPLY_MAX_CHARS: Final[int] = 280
 """Server-enforced business cap on Nikita's reply text.
 
-Prior values: none (new in Spec 214 FR-11d).
-Rationale: keeps bubble terse + consistent with texting persona. Wire-level
-Pydantic `ConverseResponse.nikita_reply` permits up to 500 chars (schema
-ceiling); server validator downgrades >140 to a fallback.
+Prior values:
+  140 (Spec 214 FR-11d initial) — raised by GH #389 (2026-04-22):
+    Walk S observed 100% fallback at wizard turn 4+ because the model
+    generates contextually-rich replies (>140 chars) when conversation
+    history is ≥6 messages. 140 = one tweet; too tight for natural
+    onboarding dialogue.
+  280 (current, GH #389) — two "tweet segments". Still short/texting-
+    style; aligns with modern SMS segment (160 chars) × 1.75 headroom.
+    Wire-level Pydantic `ConverseResponse.nikita_reply` permits up to
+    500 chars (schema ceiling); server validator downgrades >280 to a
+    fallback.
 """
 
 CONVERSE_PER_USER_RPM: Final[int] = 20

--- a/tests/api/routes/test_converse_endpoint.py
+++ b/tests/api/routes/test_converse_endpoint.py
@@ -136,17 +136,18 @@ class TestConverseRequestSchema:
         with pytest.raises(ValidationError):
             ToggleControl(value="neither")
 
-    def test_reply_over_140_chars_triggers_fallback(self):
-        """AC-T2.4.3: wire ceiling is 500; business cap 140 enforced by
-        server via fallback. Schema level allows up to 500; the server
-        checks ``NIKITA_REPLY_MAX_CHARS`` and substitutes fallback when
-        exceeded. This test asserts the wire-level ceiling.
+    def test_reply_over_max_chars_triggers_fallback(self):
+        """AC-T2.4.3: wire ceiling is 500; business cap enforced by server.
+
+        GH #389: raised from 140 to 280 (Walk S 2026-04-22: 100% fallback
+        at turn 4+ because model generates >140-char contextual replies).
+        280 is still texting-style short but allows full sentences.
         """
         from nikita.onboarding.tuning import NIKITA_REPLY_MAX_CHARS
 
-        # Business cap is exposed as a constant so the endpoint can
-        # enforce it. This test pins both sides of that contract.
-        assert NIKITA_REPLY_MAX_CHARS == 140
+        # Regression guard: pins the tuning constant so silent drift
+        # back to 140 is caught immediately. Driving issue: GH #389.
+        assert NIKITA_REPLY_MAX_CHARS == 280
 
         # Wire ceiling: 500 chars accepted
         safe_reply = "x" * 500

--- a/tests/onboarding/test_tuning_constants.py
+++ b/tests/onboarding/test_tuning_constants.py
@@ -509,8 +509,8 @@ class TestSpec214ConverseConstants:
         assert CHAT_COMPLETION_RATE_GATE_N == 50
         assert isinstance(CHAT_COMPLETION_RATE_GATE_N, int)
 
-    def test_all_19_constants_present_and_typed(self):
-        """AC-T2.1.1: all 19 FR-11d constants exist with ``Final[...]`` types.
+    def test_all_22_constants_present_and_typed(self):
+        """AC-T2.1.1: all 22 FR-11d constants exist with ``Final[...]`` types.
 
         Module-level ``__annotations__`` preserves the ``Final[...]`` types
         per PEP 526; each constant must appear with a concrete type.

--- a/tests/onboarding/test_tuning_constants.py
+++ b/tests/onboarding/test_tuning_constants.py
@@ -434,7 +434,8 @@ class TestSpec214ConverseConstants:
         assert isinstance(ONBOARDING_INPUT_MAX_CHARS, int)
 
     def test_nikita_reply_max_chars(self):
-        assert NIKITA_REPLY_MAX_CHARS == 140
+        # GH #389 (2026-04-22): raised 140 → 280; Walk S observed 100% fallback at turn 4+
+        assert NIKITA_REPLY_MAX_CHARS == 280
         assert isinstance(NIKITA_REPLY_MAX_CHARS, int)
 
     def test_converse_per_user_rpm(self):

--- a/tests/onboarding/test_tuning_constants.py
+++ b/tests/onboarding/test_tuning_constants.py
@@ -434,7 +434,7 @@ class TestSpec214ConverseConstants:
         assert isinstance(ONBOARDING_INPUT_MAX_CHARS, int)
 
     def test_nikita_reply_max_chars(self):
-        # GH #389 (2026-04-22): raised 140 → 280; Walk S observed 100% fallback at turn 4+
+        # GH #389 (2026-04-22): raised 140 to 280; Walk S observed 100% fallback at turn 4+
         assert NIKITA_REPLY_MAX_CHARS == 280
         assert isinstance(NIKITA_REPLY_MAX_CHARS, int)
 


### PR DESCRIPTION
## Summary
- Fixes #389: wizard turn 4+ returned 100% fallback "hold on, let me try that again."
- Root cause: `NIKITA_REPLY_MAX_CHARS = 140` too tight. At turn 4 the conversation history is 6+ messages; the LLM generates contextually rich replies (>140 chars) despite the system-prompt cap instruction.
- Fix: raise to 280 chars (2x SMS segment). Still texting-style; aligns with modern short-message norms while allowing full sentences.

## Root cause (from Walk S, 2026-04-22)
Cloud Run logs confirmed `converse_reply_reject user_id=... reason=length` on 3 consecutive turn-4 attempts (inputs: "cocktails and techno", "cocktails and techno", "techno clubs"). The `validate_reply()` check at `nikita/agents/onboarding/validators.py:169` fires when `len(reply) > NIKITA_REPLY_MAX_CHARS`, returning `(False, "length")`, which triggers the FALLBACK_REPLY path.

## Changes (3 files)
1. `nikita/onboarding/tuning.py`: 140 → 280 with prior-values changelog per tuning-constants rules
2. `tests/api/routes/test_converse_endpoint.py`: regression guard updated (asserts 280, GH #389 reference, test renamed)
3. `tests/onboarding/test_tuning_constants.py`: second regression guard updated (asserts 280, GH #389 comment)

Note: `nikita/platforms/telegram/onboarding/` (empty stale dir, only `__pycache__`) was also removed, fixing a pre-existing `test_wiring.py::test_legacy_onboarding_package_deleted` failure unrelated to this PR's scope.

## Local tests
- `uv run pytest -q` → 6555 passed, 0 failed

## Pre-PR grep gates
- Zero-assertion shells: empty
- PII in log format strings: empty
- Raw cache_key: empty

## Verification post-merge
Auto-dispatched Walk T with email simon.yang.ch+walkt@gmail.com to verify B3 PASS (turn 4 no longer returns fallback).

Refs #389 (Walk S 2026-04-22 B3 FAIL diagnosis)