### PR TITLE
fix(214,391): wizard completion gate — flip on phone extraction

### DIFF
--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -1010,14 +1010,23 @@ async def converse(
         },
     )
 
+    # GH #391 (Walk T 2026-04-22): completion gate.
+    # PhoneExtraction (kind="phone") is the terminal extraction in the
+    # wizard flow per spec FR-11d / FR-1 step 9. When it commits, the
+    # frontend (onboarding-wizard.tsx:131) reads conversation_complete=true
+    # and mints the Telegram link code → ClearanceGrantedCeremony renders.
+    # Without this flag flip, the wizard is permanently stuck at
+    # progress=70 / status=pending.
+    progress_pct = _compute_progress(extracted_fields)
+    conversation_complete = extracted_fields.get("kind") == "phone"
     response = ConverseResponse(
         nikita_reply=reply_text,
         extracted_fields=extracted_fields,
         confirmation_required=_needs_confirmation(primary_extraction),
         next_prompt_type="text",
         next_prompt_options=None,
-        progress_pct=_compute_progress(extracted_fields),
-        conversation_complete=False,
+        progress_pct=progress_pct,
+        conversation_complete=conversation_complete,
         source="llm",
         latency_ms=_elapsed_ms(started),
     )

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -1011,14 +1011,18 @@ async def converse(
     )
 
     # GH #391 (Walk T 2026-04-22): completion gate.
-    # PhoneExtraction (kind="phone") is the terminal extraction in the
-    # wizard flow per spec FR-11d / FR-1 step 9. When it commits, the
-    # frontend (onboarding-wizard.tsx:131) reads conversation_complete=true
-    # and mints the Telegram link code → ClearanceGrantedCeremony renders.
-    # Without this flag flip, the wizard is permanently stuck at
-    # progress=70 / status=pending.
+    # The terminal extraction in the wizard flow is PhoneExtraction
+    # (kind="phone"; see nikita/agents/onboarding/extraction_schemas.py:159).
+    # _compute_progress is the single source of truth for which kinds are
+    # terminal — the kind that maps to 100 IS the completion kind. Gating
+    # off progress_pct keeps that definition in one place; if a future
+    # spec adds a new terminal extraction, only the progress map changes.
+    # When complete, the frontend (onboarding-wizard.tsx:131) reads
+    # conversation_complete=true and mints the Telegram link code →
+    # ClearanceGrantedCeremony renders. Without this flag flip the wizard
+    # is permanently stuck at progress=70 / status=pending.
     progress_pct = _compute_progress(extracted_fields)
-    conversation_complete = extracted_fields.get("kind") == "phone"
+    conversation_complete = progress_pct == 100
     response = ConverseResponse(
         nikita_reply=reply_text,
         extracted_fields=extracted_fields,

--- a/tests/api/routes/test_converse_endpoint.py
+++ b/tests/api/routes/test_converse_endpoint.py
@@ -206,6 +206,169 @@ class TestConverseRequestSchema:
 
 
 # ---------------------------------------------------------------------------
+# GH #391 — wizard completion gate (Walk T finding)
+# ---------------------------------------------------------------------------
+
+
+class TestConverseCompletionGate:
+    """GH #391 (Walk T 2026-04-22): /converse must return
+    ``conversation_complete=True`` when the LLM commits a phone-kind
+    extraction (PhoneExtraction) so the chat wizard can advance to the
+    ClearanceGrantedCeremony.
+
+    Before this fix, the success branch hardcoded ``conversation_complete=False``
+    and the wizard was permanently stuck at progress=70 / status=pending after
+    5 turns. The completion-gate rule mirrors the spec FR-11d intent + the
+    ``_compute_progress`` map: phone is the terminal extraction kind."""
+
+    @pytest.mark.asyncio
+    async def test_phone_extraction_sets_conversation_complete_true(self):
+        """When the agent commits a PhoneExtraction (kind=phone), the
+        endpoint MUST return conversation_complete=True so the wizard
+        advances to ceremony. Pairs with progress_pct=100."""
+        from nikita.agents.onboarding.converse_contracts import ConverseRequest
+        from nikita.agents.onboarding.extraction_schemas import PhoneExtraction
+        from nikita.api.dependencies.auth import AuthenticatedUser
+        from nikita.api.routes.portal_onboarding import converse
+
+        user_id = uuid4()
+        user_stub = SimpleNamespace(id=user_id, onboarding_profile=None)
+
+        mock_session = AsyncMock()
+        select_result = MagicMock()
+        select_result.scalar_one = MagicMock(return_value=user_stub)
+        mock_session.execute = AsyncMock(return_value=select_result)
+
+        # Side-effect: when agent.run is called, simulate the extract_phone
+        # tool firing by appending a PhoneExtraction to deps.extracted.
+        phone_extraction = PhoneExtraction(
+            phone_preference="text", phone=None, confidence=0.97
+        )
+
+        async def fake_run(_user_input, *, deps, **_kwargs):
+            deps.extracted.append(phone_extraction)
+            return SimpleNamespace(
+                output="all locked in. catch you in telegram.",
+                usage=lambda: None,
+            )
+
+        mock_agent = MagicMock()
+        mock_agent.run = fake_run
+
+        req = ConverseRequest(
+            conversation_history=[], user_input="text. always text."
+        )
+        auth_user = AuthenticatedUser(id=user_id, email="t@e.com")
+
+        with patch(
+            "nikita.api.routes.portal_onboarding.get_conversation_agent",
+            return_value=mock_agent,
+        ), patch(
+            "nikita.api.routes.portal_onboarding.IdempotencyStore"
+        ) as mock_idem_cls, patch(
+            "nikita.api.routes.portal_onboarding.LLMSpendLedger"
+        ) as mock_ledger_cls:
+            mock_idem = MagicMock()
+            mock_idem.get = AsyncMock(return_value=None)
+            mock_idem.put = AsyncMock(return_value=None)
+            mock_idem_cls.return_value = mock_idem
+            mock_ledger = MagicMock()
+            mock_ledger.get_today = AsyncMock(return_value=0)
+            mock_ledger.add_spend = AsyncMock(return_value=None)
+            mock_ledger_cls.return_value = mock_ledger
+
+            response = await converse(
+                req=req,
+                current_user=auth_user,
+                session=mock_session,
+                _rate_limit=None,
+                idempotency_key_header=None,
+            )
+
+        assert isinstance(response, ConverseResponse)
+        assert response.source == "llm"
+        assert response.progress_pct == 100, (
+            f"PhoneExtraction must map to progress=100; got {response.progress_pct}"
+        )
+        assert response.conversation_complete is True, (
+            "GH #391: phone extraction MUST set conversation_complete=True so "
+            "the wizard advances to ClearanceGrantedCeremony. Currently False "
+            "is hardcoded which leaves every new user stuck."
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_phone_extraction_keeps_conversation_complete_false(self):
+        """Identity (or any non-phone kind) extraction MUST NOT prematurely
+        set conversation_complete=True. Discriminating-power check for the
+        completion gate."""
+        from nikita.agents.onboarding.converse_contracts import ConverseRequest
+        from nikita.agents.onboarding.extraction_schemas import IdentityExtraction
+        from nikita.api.dependencies.auth import AuthenticatedUser
+        from nikita.api.routes.portal_onboarding import converse
+
+        user_id = uuid4()
+        user_stub = SimpleNamespace(id=user_id, onboarding_profile=None)
+
+        mock_session = AsyncMock()
+        select_result = MagicMock()
+        select_result.scalar_one = MagicMock(return_value=user_stub)
+        mock_session.execute = AsyncMock(return_value=select_result)
+
+        identity = IdentityExtraction(
+            name="Simon", age=32, occupation="engineer", confidence=0.97
+        )
+
+        async def fake_run(_user_input, *, deps, **_kwargs):
+            deps.extracted.append(identity)
+            return SimpleNamespace(
+                output="got it simon, age 32, engineer.",
+                usage=lambda: None,
+            )
+
+        mock_agent = MagicMock()
+        mock_agent.run = fake_run
+
+        req = ConverseRequest(
+            conversation_history=[], user_input="i'm simon, 32, engineer"
+        )
+        auth_user = AuthenticatedUser(id=user_id, email="t@e.com")
+
+        with patch(
+            "nikita.api.routes.portal_onboarding.get_conversation_agent",
+            return_value=mock_agent,
+        ), patch(
+            "nikita.api.routes.portal_onboarding.IdempotencyStore"
+        ) as mock_idem_cls, patch(
+            "nikita.api.routes.portal_onboarding.LLMSpendLedger"
+        ) as mock_ledger_cls:
+            mock_idem = MagicMock()
+            mock_idem.get = AsyncMock(return_value=None)
+            mock_idem.put = AsyncMock(return_value=None)
+            mock_idem_cls.return_value = mock_idem
+            mock_ledger = MagicMock()
+            mock_ledger.get_today = AsyncMock(return_value=0)
+            mock_ledger.add_spend = AsyncMock(return_value=None)
+            mock_ledger_cls.return_value = mock_ledger
+
+            response = await converse(
+                req=req,
+                current_user=auth_user,
+                session=mock_session,
+                _rate_limit=None,
+                idempotency_key_header=None,
+            )
+
+        assert isinstance(response, ConverseResponse)
+        assert response.progress_pct == 70, (
+            f"IdentityExtraction maps to progress=70; got {response.progress_pct}"
+        )
+        assert response.conversation_complete is False, (
+            "Non-phone extractions MUST NOT trigger completion. Identity "
+            "must keep the wizard chatting until phone is collected."
+        )
+
+
+# ---------------------------------------------------------------------------
 # T2.8 AC-T2.8.1/2/3 — success-path wires append_conversation_turn
 # ---------------------------------------------------------------------------
 

--- a/tests/api/routes/test_converse_endpoint.py
+++ b/tests/api/routes/test_converse_endpoint.py
@@ -253,7 +253,10 @@ class TestConverseCompletionGate:
             )
 
         mock_agent = MagicMock()
-        mock_agent.run = fake_run
+        # MagicMock(side_effect=fake_run) preserves call-recording so we can
+        # assert agent.run was actually invoked — guards against a future
+        # refactor that silently bypasses the agent.
+        mock_agent.run = MagicMock(side_effect=fake_run)
 
         req = ConverseRequest(
             conversation_history=[], user_input="text. always text."
@@ -287,6 +290,7 @@ class TestConverseCompletionGate:
 
         assert isinstance(response, ConverseResponse)
         assert response.source == "llm"
+        assert mock_agent.run.called, "agent.run must be invoked on each turn"
         assert response.progress_pct == 100, (
             f"PhoneExtraction must map to progress=100; got {response.progress_pct}"
         )
@@ -326,7 +330,7 @@ class TestConverseCompletionGate:
             )
 
         mock_agent = MagicMock()
-        mock_agent.run = fake_run
+        mock_agent.run = MagicMock(side_effect=fake_run)
 
         req = ConverseRequest(
             conversation_history=[], user_input="i'm simon, 32, engineer"
@@ -359,6 +363,7 @@ class TestConverseCompletionGate:
             )
 
         assert isinstance(response, ConverseResponse)
+        assert mock_agent.run.called, "agent.run must be invoked on each turn"
         assert response.progress_pct == 70, (
             f"IdentityExtraction maps to progress=70; got {response.progress_pct}"
         )


### PR DESCRIPTION
## Summary

Walk T (2026-04-22) caught the chat wizard permanently stuck after 5 turns of natural dialogue. progress=70, onboarding_status=pending forever. Nikita's reply says "all locked in" but UI provides no progression — user trapped.

## Root cause

`/converse` (nikita/api/routes/portal_onboarding.py:1020) hardcodes `conversation_complete=False` on the success path. `rg "conversation_complete=True" nikita/` returns 0 hits — the flag could never flip true. Portal wizard reducer (useConversationState.ts:173) reads `isComplete: response.conversation_complete`, so isComplete stayed false → ClearanceGrantedCeremony never painted → Telegram link code never minted.

## Fix

Gate completion on the extracted kind. PhoneExtraction (extraction_schemas.py:159) emits `kind="phone"`; `_compute_progress` maps it to 100 and is the only terminal extraction in the wizard flow per spec FR-11d / FR-1 step 9.

```python
progress_pct = _compute_progress(extracted_fields)
conversation_complete = extracted_fields.get("kind") == "phone"
```

## Tests (TDD)

Two new tests in `TestConverseCompletionGate`:

1. `test_phone_extraction_sets_conversation_complete_true` — RED before fix, GREEN after. Mocks the agent so deps.extracted accrues a PhoneExtraction; asserts `conversation_complete=True` + `progress_pct=100`.
2. `test_non_phone_extraction_keeps_conversation_complete_false` — discriminating-power check. IdentityExtraction must NOT prematurely complete.

## Local tests

- `uv run pytest -q` → 6557 passed, 2 skipped, 184 deselected, 0 failed (~3 min)
- Portal E2E mocks (`portal/e2e/onboarding-chat.spec.ts:142`) already align with new contract

## Pre-PR grep gates

- Zero-assertion shells: empty
- PII in log format strings: empty
- Raw cache_key: empty

## Out of scope (separate fix)

GH #391 also identifies a SECOND bug: the LLM is calling extract_identity instead of extract_phone for literal phone numbers (Walk T turn 5: "+41 79 555 0123" → kind=identity). That is a prompt-engineering fix in `WIZARD_SYSTEM_PROMPT` and will be a follow-up PR. With this PR, when extract_phone DOES fire (via correct prompt or button affordance), the wizard correctly advances. Without the prompt fix, the wizard still won't auto-complete from chat alone — but the structural completion gate is now correct.

Closes #391