### PR TITLE
chore(rules): encode agentic-design-patterns as first-class rule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -108,6 +108,12 @@ Types: research, analysis, decision, pattern, bug, integration
 - **File size enforcement**: Check `wc -l` on state files before session end. Prune if over limits (see root CLAUDE.md State Files table).
 - **Documentation rules**: ONE authoritative file per topic in `docs/` (REPLACE, don't append). Max 500 lines per doc file.
 
+## Agentic Flow Design (HARD GATE)
+
+**Any task touching `nikita/agents/**`, `nikita/pipeline/**`, or LLM-powered conversation flows MUST consult `.claude/rules/agentic-design-patterns.md` BEFORE planning.** The rule encodes 4 hard rules (cumulative state, Pydantic completion gates, tool consolidation, dynamic instructions) + 6 anti-patterns with file:line precedents. Walk V (2026-04-22) shipped 4 coupled anti-patterns that survived 5 walks + 4 patchwork PRs (#392-396) because no rule existed encoding the agentic pattern. The rule file is the gate.
+
+Trigger phrases that mandate consulting the rule: "agent extraction tool", "wizard step", "conversation_complete", "extract_*", "system prompt routing", "tool selection", "completion gate", "progress_pct", "WIZARD_SYSTEM_PROMPT", "Pydantic AI agent".
+
 ## Gotchas
 
 - Neo4j/Graphiti is legacy — all memory is SupabaseMemory (pgVector via Spec 042)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -110,9 +110,13 @@ Types: research, analysis, decision, pattern, bug, integration
 
 ## Agentic Flow Design (HARD GATE)
 
-**Any task touching `nikita/agents/**`, `nikita/pipeline/**`, or LLM-powered conversation flows MUST consult `.claude/rules/agentic-design-patterns.md` BEFORE planning.** The rule encodes 4 hard rules (cumulative state, Pydantic completion gates, tool consolidation, dynamic instructions) + 6 anti-patterns with file:line precedents. Walk V (2026-04-22) shipped 4 coupled anti-patterns that survived 5 walks + 4 patchwork PRs (#392-396) because no rule existed encoding the agentic pattern. The rule file is the gate.
+**Any task touching `nikita/agents/**`, `nikita/pipeline/**`, or LLM-powered conversation flows MUST consult `.claude/rules/agentic-design-patterns.md` BEFORE planning.** The rule encodes 6 hard rules (cumulative state, Pydantic completion gates, tool consolidation, monotonic progress, validation layering, message_history) + 5 anti-patterns with file:line precedents + Pydantic AI primitives reference. Walk V (2026-04-22) shipped 4 coupled anti-patterns that survived 5 walks + 4 patchwork PRs (#392-396) because no rule existed encoding the agentic pattern. The rule file is the gate.
 
-Trigger phrases that mandate consulting the rule: "agent extraction tool", "wizard step", "conversation_complete", "extract_*", "system prompt routing", "tool selection", "completion gate", "progress_pct", "WIZARD_SYSTEM_PROMPT", "Pydantic AI agent".
+Trigger conditions that mandate consulting the rule (file-path AND/OR phrase):
+- File-path: any change under `nikita/agents/**`, `nikita/pipeline/**`, or `tests/agents/**`
+- Phrase-based (orchestrator self-check): "agent extraction tool", "wizard step", "completion gate", "tool selection", "Pydantic AI agent", "message_history", "extract_*" tool, system-prompt routing rules
+
+Symbol-level trigger names (e.g., specific class/function identifiers) are intentionally omitted from this trigger list to avoid staleness during the Spec 214 redesign — file paths are the durable trigger.
 
 ## Gotchas
 

--- a/.claude/rules/agentic-design-patterns.md
+++ b/.claude/rules/agentic-design-patterns.md
@@ -64,21 +64,23 @@ Use `result.new_messages()` between turns. Do NOT reinvent conversation context 
 
 ## Anti-Patterns (with file:line precedents)
 
-| Anti-pattern | Walk V precedent | Fix |
+| Anti-pattern | Precedent | Fix |
 |---|---|---|
-| `conversation_complete=False` hardcode | `nikita/api/routes/portal_onboarding.py:1020` | Pydantic `FinalForm.model_validate()` gate |
-| 7 single-purpose `extract_*` tools | `nikita/agents/onboarding/conversation_agent.py` (L106-244) | 1 agent, `output_type=[SlotDelta, str]` |
-| `_compute_progress(latest_kind)` per-turn snapshot | `portal_onboarding.py:1073-1088` | `WizardSlots.progress_pct` computed_field |
-| Hardcoded routing rules in static system prompt | `conversation_prompts.py` post-PR #395 | `Agent(instructions=callable)` dynamic |
-| `progress = response.progress_pct` overwrite in FE reducer | (now correct iff BE serves cumulative — but document this contract) | BE = single source of truth |
+| Completion gate computed per-turn from `_compute_progress` instead of cumulative-state Pydantic validation. Originally `conversation_complete=False` literal (Walk V baseline, pre-PR #392, master commit 6339c78~). Currently `conversation_complete = progress_pct == 100` (post-PR #392). Both fail because `progress_pct` is per-turn snapshot. | `nikita/api/routes/portal_onboarding.py:1025` (current, post-#392); pre-#392 was hardcoded `False` literal at the same call-site. | Pydantic `FinalForm.model_validate(state)` gate over cumulative slots |
+| 6 single-purpose `extract_*` tools + 1 `no_extraction` sentinel = 7 tool registrations | `nikita/agents/onboarding/conversation_agent.py` tools at L106, 116, 145, 170, 189, 206, 229 | 1 agent, `output_type=[SlotDelta, str]` discriminated-union |
+| `_compute_progress(latest_kind)` per-turn snapshot | `nikita/api/routes/portal_onboarding.py:1086-1100` (function body) | `WizardSlots.progress_pct` `@computed_field` |
+| Hardcoded slot-routing rules in static system prompt (PR #395 patchwork) | `nikita/agents/onboarding/conversation_prompts.py` `_WIZARD_FRAMING` | `Agent(instructions=callable)` dynamic, injects `state.missing` per-turn |
+| `progress = response.progress_pct` overwrite in FE reducer | `portal/src/app/onboarding/hooks/useConversationState.ts:169-173` (now correct IFF BE serves cumulative — contract documented in FR-11d) | BE = single source of truth; FE simply reflects |
 
 ## Required Tests for Any Agent Flow
 
-1. **Cumulative-state monotonicity**: turn-by-turn fixture, asserts progress never regresses
-2. **Completion-gate triplet**: empty state → False/0%, partial → False/<100%, full → True/100%
-3. **Mock-LLM emits wrong tool**: prove recovery path (regex fallback OR `ModelRetry` self-correction)
-4. **Agent invocation contract**: `agent.run(...)` called with `message_history=` and `deps=` containing cumulative state
-5. **Dynamic-instructions invocation**: callable invoked per-turn with current state (snapshot ≠ snapshot pin; assert callable was called)
+The canonical home for the 3 mandatory test classes (cumulative-state monotonicity, completion-gate triplet, mock-LLM-emits-wrong-tool recovery) is **`.claude/rules/testing.md` "Agentic-Flow Test Requirements" section** — refer there for falsifier definitions and to keep both files in sync.
+
+This rule file additionally requires:
+
+1. **Agent invocation contract** test: `agent.run(...)` called with `message_history=` AND `deps=` containing cumulative state. Asserts the BE wires the official Pydantic AI multi-turn primitive (anti-pattern: re-passing conversation in request body and ignoring `message_history`).
+
+2. **Dynamic-instructions invocation** test: callable invoked per-turn with current state. Use `MagicMock` wrapper around the callable; assert call count >= turn count and that `state.missing` is referenced. Anti-pattern: static `instructions=string` that bakes routing rules into the prompt.
 
 ## Pydantic AI Primitives Reference
 

--- a/.claude/rules/agentic-design-patterns.md
+++ b/.claude/rules/agentic-design-patterns.md
@@ -1,0 +1,102 @@
+# Agentic Design Patterns — How to Build LLM Conversation Flows
+
+**This rule fires** for any task touching `nikita/agents/**`, `nikita/pipeline/**`, voice/text agent prompts, conversational onboarding/handoff flows, or any code that calls `Agent(...).run(...)`. Consult BEFORE planning.
+
+**Authority**: Walk V (2026-04-22) shipped 4 coupled anti-patterns through 5 walks + 4 patchwork PRs (#392-396) before redesign was forced. The pattern is encoded here so future agent work doesn't redo it. ADR-009.
+
+## Hard Rules
+
+### 1. Cumulative server-side state — NEVER per-turn snapshot
+
+State is the union of all extractions across the conversation, held in a Pydantic model. Per-turn `extracted_fields` is an INPUT to a merge, not the source of truth.
+
+- Use a `WizardSlots(BaseModel)` or equivalent with one optional field per slot
+- Use `@computed_field @property` for derived state (`missing`, `progress_pct`, etc.)
+- Use `model_copy(update={...})` to merge — immutable update; reassign caller's reference
+- Persist the full state as JSONB on the user row OR reconstruct from `conversation[*].extracted ∪ elided_extracted` on load
+
+### 2. Completion gates via Pydantic — NEVER hardcoded booleans, NEVER LLM-judged
+
+```python
+try:
+    form = FinalForm.model_validate(state.slots_dict)
+    complete = True
+except ValidationError:
+    complete = False
+```
+
+`FinalForm` declares all required slots as non-optional + cross-field `@model_validator(mode="after")` for business rules (age ≥ 18, voice-requires-phone, etc.). The validator IS the gate. Refuse `complete = True` / `complete = False` literals in handler code.
+
+### 3. Tool selection — consolidate; if N tools, inject missing-slot guidance
+
+Default: 1 tool with discriminated-union args:
+
+```python
+output_type=[SlotDelta, str]   # mixed: structured delta OR clarifying free-text
+```
+
+If N narrow tools are unavoidable, use **dynamic `instructions=callable`** to re-render the system prompt every turn with current `state.missing` injected — gives the LLM "what's left to collect" instead of relying on static prompt rules. Tool-selection bias is the documented failure mode of N-tool fan-out (Pydantic AI `output.py` doc + Indium March 2026 reliability study).
+
+### 4. Progress is a `@computed_field` of cumulative state — NEVER of latest extraction
+
+```python
+@computed_field
+@property
+def progress_pct(self) -> int:
+    return min(100, int((TOTAL - len(self.missing)) * 100 / TOTAL))
+```
+
+Monotonicity is by construction — slots only added, never removed. CI test required: turn-by-turn fixture asserts `progress_pct[t+1] >= progress_pct[t]`.
+
+### 5. Validation layering — three layers, all required
+
+- **Pre-tool** (Pydantic on tool args / structured output schema)
+- **Post-tool** (`@agent.output_validator` with `raise ModelRetry(...)` on validation failure for self-correcting loop)
+- **Deterministic post-processing** (regex/heuristic fallback for high-stakes slots like phone — defense in depth against LLM tool-selection bias)
+
+### 6. Conversation context — official `message_history=` primitive
+
+```python
+agent.run(user_input, message_history=state.messages, deps=deps)
+```
+
+Use `result.new_messages()` between turns. Do NOT reinvent conversation context in the request body or system prompt. Use `hydrate_message_history` (`nikita/agents/onboarding/message_history.py:44`) for wire→`ModelMessage` conversion.
+
+## Anti-Patterns (with file:line precedents)
+
+| Anti-pattern | Walk V precedent | Fix |
+|---|---|---|
+| `conversation_complete=False` hardcode | `nikita/api/routes/portal_onboarding.py:1020` | Pydantic `FinalForm.model_validate()` gate |
+| 7 single-purpose `extract_*` tools | `nikita/agents/onboarding/conversation_agent.py` (L106-244) | 1 agent, `output_type=[SlotDelta, str]` |
+| `_compute_progress(latest_kind)` per-turn snapshot | `portal_onboarding.py:1073-1088` | `WizardSlots.progress_pct` computed_field |
+| Hardcoded routing rules in static system prompt | `conversation_prompts.py` post-PR #395 | `Agent(instructions=callable)` dynamic |
+| `progress = response.progress_pct` overwrite in FE reducer | (now correct iff BE serves cumulative — but document this contract) | BE = single source of truth |
+
+## Required Tests for Any Agent Flow
+
+1. **Cumulative-state monotonicity**: turn-by-turn fixture, asserts progress never regresses
+2. **Completion-gate triplet**: empty state → False/0%, partial → False/<100%, full → True/100%
+3. **Mock-LLM emits wrong tool**: prove recovery path (regex fallback OR `ModelRetry` self-correction)
+4. **Agent invocation contract**: `agent.run(...)` called with `message_history=` and `deps=` containing cumulative state
+5. **Dynamic-instructions invocation**: callable invoked per-turn with current state (snapshot ≠ snapshot pin; assert callable was called)
+
+## Pydantic AI Primitives Reference
+
+| Primitive | Use | Doc |
+|---|---|---|
+| `Agent(output_type=[X, str])` | Mixed mode — structured OR free text | https://ai.pydantic.dev/output/ |
+| `Agent(instructions=callable)` | Dynamic per-turn system prompt | same |
+| `agent.run(..., message_history=)` | Multi-turn conversation context | https://ai.pydantic.dev/message-history/ |
+| `Agent(deps_type=X)` + `RunContext[X]` | Sidecar state DI | https://ai.pydantic.dev/dependencies/ |
+| `@agent.output_validator` + `raise ModelRetry` | Self-correcting agent loop | https://ai.pydantic.dev/output/#output-validator-functions |
+| `@model_validator(mode="after")` | Cross-field Pydantic v2 validation | https://docs.pydantic.dev/latest/concepts/validators/ |
+| `@computed_field @property` | Derived state, serialized | https://docs.pydantic.dev/latest/concepts/fields/#the-computed_field-decorator |
+| `pydantic-graph` (FSM) | NOT for linear flows. "Don't use a nail gun unless you need a nail gun." Reach for it only when branching emerges (e.g., voice-vs-text divergence with rejoin). | https://ai.pydantic.dev/graph/ |
+
+## References
+
+- Spec: `specs/214-portal-onboarding-wizard/spec.md` FR-11d (post-amendment)
+- ADR: `~/.claude/ecosystem-spec/decisions/ADR-009-agentic-design-patterns.md`
+- Memory: `~/.claude/projects/-Users-yangsim-Nanoleq-sideProjects-nikita/memory/feedback_agentic_systems_not_procedural.md`
+- Sister rules: `.claude/rules/{testing.md, pr-workflow.md, review-findings.md, tuning-constants.md}`
+- Walk V evidence: Cloud Run rev `nikita-api-00280-q5w`, user `walkv`, JSONB conversation kinds=[location, scene, darkness, identity, backstory, **identity**] (wrong terminal extraction)

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -55,6 +55,18 @@ grep -n "cache_key=" <changed .py files> | rg -v "cache_key_hash|sha256"
 
 All three must return empty before passing to reviewer.
 
+## Agentic-Flow Test Requirements (Walk V precedent, 2026-04-22)
+
+For any test file under `tests/agents/**`, `tests/pipeline/**`, or any test exercising a Pydantic AI `Agent.run(...)`, three test classes are MANDATORY:
+
+1. **Cumulative-state monotonicity** — turn-by-turn fixture (≥3 turns) feeds extractions into the state model and asserts `progress_pct[t+1] >= progress_pct[t]` for every t. If progress drops at any turn, the production code is reading a per-turn snapshot instead of cumulative state. Anti-pattern: `_compute_progress(latest_kind)`.
+
+2. **Completion-gate triplet** — empty state → False/0%, partial state (some slots filled) → False/<100%, full state (all slots valid) → True/100%. Done via `try: FinalForm.model_validate(state); except ValidationError: ...`. If the production code hardcodes the gate (`complete = False` literal), the empty/partial cases pass for the wrong reason.
+
+3. **Mock-LLM-emits-wrong-tool recovery** — fixture with mocked agent returning the wrong extraction kind for an unambiguous user input (e.g., agent returns `IdentityExtraction` for "+1 415 555 0234"). Assert the system recovers via deterministic fallback (regex) OR `ModelRetry` self-correction. If the test cannot exist (no recovery path), the design is brittle to known LLM tool-selection bias.
+
+Refusing to add these tests when introducing a new agent flow is a PR-blocker per `.claude/rules/agentic-design-patterns.md`.
+
 ## DB Migration Checklist (new-table RLS completeness)
 
 When adding a new Postgres table, the migration MUST include all of:


### PR DESCRIPTION
## Summary

Encodes the agentic design pattern as a first-class project rule so future agent-flow work doesn't redo the four anti-patterns Walk V exposed.

## Why

Walk V (2026-04-22, Cloud Run rev `nikita-api-00280-q5w`) confirmed Spec 214 chat-first wizard shipped four coupled defects that survived 5 walks (R-V) + 4 patchwork PRs (#392-396):

1. `conversation_complete=False` hardcoded gate
2. 7-tool fan-out triggering LLM tool-selection bias
3. `_compute_progress(latest_kind)` per-turn snapshot causing progress regression
4. Static system prompt with hardcoded routing rules

Each fix attempt addressed one symptom, leaving the others in place. The defects are coupled, so partial fixes did not converge. Root cause is governance: no rule existed encoding "agentic systems require state-driven design."

User correction: "We are an agentic system not some second grade if/else dated platform."

This PR lands Phase 0 (governance) BEFORE Phase 1 (Spec 214 amendment) so the rule is referenceable during GATE 2 validation.

## Changes (3 files, 120 insertions)

1. `.claude/rules/agentic-design-patterns.md` (NEW, 102 lines, Tier-1 quick-reference):
   - 4 hard rules: cumulative server-side state, Pydantic completion gates, tool consolidation, dynamic instructions
   - 5 anti-patterns with file:line precedents from Walk V
   - 5 required test classes
   - Pydantic AI primitives reference table

2. `.claude/CLAUDE.md`: New HARD GATE section "Agentic Flow Design" inserted before Gotchas. Lists 10 trigger phrases that mandate consulting the rule before planning.

3. `.claude/rules/testing.md`: New section "Agentic-Flow Test Requirements (Walk V precedent, 2026-04-22)" requires 3 mandatory test classes for any `tests/agents/**` or `tests/pipeline/**` file.

## Companions (user-global ecosystem, not in this PR)

- `~/.claude/ecosystem-spec/decisions/ADR-009-agentic-design-patterns.md` (Status ACCEPTED)
- `~/.claude/ecosystem-spec/CHANGELOG.md` `[0.3.19]` entry
- `~/.claude/projects/.../memory/feedback_agentic_systems_not_procedural.md`

## Local tests

Docs-only PR; no code or test files touched. Per `.claude/rules/pr-workflow.md` skip rule (b) "config-only files (.github/**, .claude/**, hooks) that have no test coverage" the local pytest gate is skipped. Lint not applicable to .md.

Verified manually:
- `wc -l .claude/rules/agentic-design-patterns.md` = 102 (under 500-line doc cap)
- `git diff --stat HEAD` = 120 insertions, well under 400-line PR cap
- No em-dashes in PR body (per user-global rule for human-facing prose)

## Pre-PR grep gates

N/A (no production code or test files changed). Documentation-only.

## Plan

`/Users/yangsim/.claude/plans/delightful-orbiting-ladybug.md` v16, Phase 0.

## Sequencing

This PR (Phase 0) MUST merge before:
- Phase 1: Spec 214 FR-11d amendment via /sdd
- Phase 2: /plan + /tasks + /audit
- Phase 3: /implement T1-T12 (slot-filling redesign)
- Phase 4: Walk W

Refs Walk V incident