### PR TITLE
feat(onboarding): Spec 214 FR-11d PR-B — dynamic instructions + output validator + FE wire-up

### DIFF
--- a/nikita/agents/onboarding/conversation_agent.py
+++ b/nikita/agents/onboarding/conversation_agent.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from uuid import UUID
 
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, ModelRetry, RunContext
 from pydantic_ai.models.anthropic import AnthropicModelSettings
 
 from nikita.agents.onboarding.conversation_prompts import (
@@ -125,8 +125,6 @@ def _create_conversation_agent() -> Agent[ConverseDeps, str]:
         ctx: RunContext[ConverseDeps], data: str
     ) -> str:
         """Raise ModelRetry if LLM replied without extracting while incomplete."""
-        from pydantic_ai import ModelRetry
-
         # Only enforce when wizard is still incomplete.
         if ctx.deps.state.is_complete:
             return data

--- a/nikita/agents/onboarding/conversation_agent.py
+++ b/nikita/agents/onboarding/conversation_agent.py
@@ -35,7 +35,10 @@ from uuid import UUID
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.models.anthropic import AnthropicModelSettings
 
-from nikita.agents.onboarding.conversation_prompts import WIZARD_SYSTEM_PROMPT
+from nikita.agents.onboarding.conversation_prompts import (
+    WIZARD_SYSTEM_PROMPT,
+    render_dynamic_instructions,
+)
 from nikita.agents.onboarding.extraction_schemas import (
     BackstoryExtraction,
     ConverseResult,
@@ -51,6 +54,7 @@ from nikita.agents.onboarding.extraction_schemas import (
     SceneExtraction,
     SceneValue,
 )
+from nikita.agents.onboarding.state import WizardSlots
 from nikita.config.models import Models
 
 # Same model as the main text agent for voice consistency.
@@ -73,11 +77,18 @@ class ConverseDeps:
     (B1, QA iter-1). The endpoint reads it after ``agent.run`` returns.
     Conversation history is passed via the ``.run()`` call's
     ``message_history`` parameter, NOT through deps.
+
+    ``state`` holds the cumulative WizardSlots reconstructed from the
+    full conversation history BEFORE agent.run is called (T11, PR-B).
+    The dynamic-instructions callable (render_dynamic_instructions) reads
+    state.missing each turn to inject "STILL MISSING: ..." guidance.
+    Spec 214 FR-11d / agentic-design-patterns.md §3.
     """
 
     user_id: UUID
     locale: str = "en"
     extracted: list[ConverseResult] = field(default_factory=list)
+    state: WizardSlots = field(default_factory=WizardSlots)
 
 
 def _create_conversation_agent() -> Agent[ConverseDeps, str]:
@@ -97,6 +108,46 @@ def _create_conversation_agent() -> Agent[ConverseDeps, str]:
         system_prompt=WIZARD_SYSTEM_PROMPT,
         retries=4,
     )
+
+    # Dynamic per-turn instructions — appended to system_prompt each turn.
+    # Injects the list of slots still missing from cumulative WizardSlots
+    # state, giving the LLM "what's left to collect" guidance beyond the
+    # static routing rules. Spec 214 FR-11d / agentic-design-patterns.md §3.
+    agent.instructions(render_dynamic_instructions)
+
+    # Output validator — post-tool validation layer (agentic-design-patterns
+    # §5, three-layer validation). Raises ModelRetry when the LLM emits a
+    # bare string without calling any extraction tool AND the wizard is not
+    # yet complete. Forces the model to self-correct rather than silently
+    # skipping extraction when it "feels" like chat.
+    @agent.output_validator
+    def _validate_extraction_happened(
+        ctx: RunContext[ConverseDeps], data: str
+    ) -> str:
+        """Raise ModelRetry if LLM replied without extracting while incomplete."""
+        from pydantic_ai import ModelRetry
+
+        # Only enforce when wizard is still incomplete.
+        if ctx.deps.state.is_complete:
+            return data
+        # If no extraction tool was called this turn (extracted is empty or
+        # only contains NoExtraction), prod the model to try harder.
+        from nikita.agents.onboarding.extraction_schemas import NoExtraction
+
+        non_sentinel = [
+            e for e in ctx.deps.extracted if not isinstance(e, NoExtraction)
+        ]
+        # Allow: model called an extraction tool (non_sentinel not empty)
+        # Allow: model explicitly used no_extraction sentinel (intentional skip)
+        has_sentinel = any(
+            isinstance(e, NoExtraction) for e in ctx.deps.extracted
+        )
+        if not non_sentinel and not has_sentinel:
+            raise ModelRetry(
+                "You replied without calling any extraction tool. "
+                "Please call the appropriate extraction tool before replying."
+            )
+        return data
 
     # Six extraction tools + 1 sentinel. Each appends the typed schema
     # instance to ``ctx.deps.extracted`` and returns a short

--- a/nikita/agents/onboarding/conversation_prompts.py
+++ b/nikita/agents/onboarding/conversation_prompts.py
@@ -15,8 +15,13 @@ Framing layer adds ONLY:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from nikita.agents.text.persona import NIKITA_PERSONA
 from nikita.onboarding.tuning import NIKITA_REPLY_MAX_CHARS
+
+if TYPE_CHECKING:
+    from pydantic_ai import RunContext
 
 
 # Wizard-specific framing. Kept short — the token budget for this agent
@@ -118,4 +123,28 @@ persona-drift baseline (ADR-001).
 """
 
 
-__all__ = ["NIKITA_PERSONA", "WIZARD_SYSTEM_PROMPT"]
+def render_dynamic_instructions(ctx: RunContext) -> str:  # type: ignore[type-arg]
+    """Dynamic per-turn instructions injected via @agent.instructions.
+
+    Appended to WIZARD_SYSTEM_PROMPT each turn (Pydantic AI appends, does
+    not replace the static system_prompt). Returns a short guidance string
+    naming the slots still missing from the cumulative WizardSlots state.
+
+    When all slots are filled (wizard complete) returns empty string so the
+    agent receives no spurious instruction text.
+
+    Spec 214 FR-11d PR-B — agentic-design-patterns.md §3: "If N narrow tools
+    are unavoidable, use dynamic instructions=callable to inject missing-slot
+    guidance per turn."
+    """
+    # Lazy import avoids circular dep at module load (agent imports this
+    # module; this function accesses ConverseDeps which imports the agent).
+    # TYPE_CHECKING guard above keeps the type annotation import-safe.
+    missing: list[str] = getattr(ctx.deps, "state", None) and ctx.deps.state.missing  # type: ignore[union-attr]
+    if not missing:
+        return ""
+    slots_text = ", ".join(missing)
+    return f"\n\nSTILL MISSING (collect these before completing): {slots_text}"
+
+
+__all__ = ["NIKITA_PERSONA", "WIZARD_SYSTEM_PROMPT", "render_dynamic_instructions"]

--- a/nikita/agents/onboarding/conversation_prompts.py
+++ b/nikita/agents/onboarding/conversation_prompts.py
@@ -22,6 +22,7 @@ from nikita.onboarding.tuning import NIKITA_REPLY_MAX_CHARS
 
 if TYPE_CHECKING:
     from pydantic_ai import RunContext
+    from nikita.agents.onboarding.conversation_agent import ConverseDeps
 
 
 # Wizard-specific framing. Kept short — the token budget for this agent
@@ -123,7 +124,7 @@ persona-drift baseline (ADR-001).
 """
 
 
-def render_dynamic_instructions(ctx: RunContext) -> str:  # type: ignore[type-arg]
+def render_dynamic_instructions(ctx: "RunContext[ConverseDeps]") -> str:
     """Dynamic per-turn instructions injected via @agent.instructions.
 
     Appended to WIZARD_SYSTEM_PROMPT each turn (Pydantic AI appends, does
@@ -140,7 +141,8 @@ def render_dynamic_instructions(ctx: RunContext) -> str:  # type: ignore[type-ar
     # Lazy import avoids circular dep at module load (agent imports this
     # module; this function accesses ConverseDeps which imports the agent).
     # TYPE_CHECKING guard above keeps the type annotation import-safe.
-    missing: list[str] = getattr(ctx.deps, "state", None) and ctx.deps.state.missing  # type: ignore[union-attr]
+    state = getattr(ctx.deps, "state", None)
+    missing: list[str] = state.missing if state is not None else []
     if not missing:
         return ""
     slots_text = ", ".join(missing)

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -865,7 +865,19 @@ async def converse(
     #    full wizard conversation, not just the latest user message. Before
     #    this fix, every turn was cold; the LLM guessed wrong tool-call
     #    shapes and retry loops exhausted on the same ValidationError.
-    deps = ConverseDeps(user_id=current_user.id, locale=req.locale)
+    # Pre-run slot reconstruction (T11, PR-B).
+    # Build cumulative WizardSlots from the conversation history the client
+    # sent — each Turn carries its prior extracted dict. This gives the
+    # dynamic-instructions callable (render_dynamic_instructions) the
+    # missing-slot list it needs BEFORE agent.run begins.
+    _pre_profile: dict = {
+        "conversation": [t.model_dump() for t in req.conversation_history]
+    }
+    _pre_state = build_state_from_conversation(_pre_profile)
+
+    deps = ConverseDeps(
+        user_id=current_user.id, locale=req.locale, state=_pre_state
+    )
     agent = get_conversation_agent()
     timeout_ms = get_converse_timeout_ms()
 

--- a/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
+++ b/portal/src/app/onboarding/__tests__/onboarding-wizard.test.tsx
@@ -85,12 +85,10 @@ describe("OnboardingWizard — AC-T3.9.1 completion mounts ceremony", () => {
     expect(screen.getByLabelText("chat input")).toBeInTheDocument()
   })
 
-  it("AC-T3.9.1: on conversation_complete → ClearanceGrantedCeremony paints", async () => {
-    mockConverseOnce({ conversation_complete: true, progress_pct: 100 })
-    linkTelegramMock.mockResolvedValueOnce({
-      code: "ABC123",
-      expires_at: "2026-04-20T00:00:00Z",
-    })
+  it("AC-T3.9.1: on conversation_complete + link_code → ClearanceGrantedCeremony paints", async () => {
+    // PR-B: link_code is returned inline by /converse on the terminal turn.
+    // No separate api.linkTelegram() call is made.
+    mockConverseOnce({ conversation_complete: true, progress_pct: 100, link_code: "ABC123", link_expires_at: "2026-04-20T00:00:00Z" })
     render(<OnboardingWizard userId="u1" />)
     const input = screen.getByLabelText("chat input") as HTMLInputElement
     fireEvent.change(input, { target: { value: "finish" } })
@@ -100,26 +98,23 @@ describe("OnboardingWizard — AC-T3.9.1 completion mounts ceremony", () => {
     )
   })
 
-  it("AC-T3.9.4: linkTelegram fires BEFORE ceremony mounts (ordering guarantee)", async () => {
-    mockConverseOnce({ conversation_complete: true, progress_pct: 100 })
-    // Resolution-order array: immune to sub-millisecond Date.now() collisions.
-    const order: string[] = []
-    linkTelegramMock.mockImplementationOnce(async () => {
-      order.push("link")
-      return { code: "XYZ789", expires_at: "2026-04-20T00:00:00Z" }
-    })
+  it("AC-T3.9.4: link_code in terminal /converse response → ceremony CTA contains the code (no separate linkTelegram call)", async () => {
+    // PR-B new flow: link_code is embedded in the terminal ConverseResponse.
+    // The old ordering guarantee (linkTelegram fires BEFORE ceremony) is now
+    // subsumed by the server contract: the reducer reads link_code synchronously
+    // from the response before dispatching isComplete=true, so the code is
+    // always available when the ceremony first renders.
+    mockConverseOnce({ conversation_complete: true, progress_pct: 100, link_code: "XYZ789", link_expires_at: "2026-04-20T00:00:00Z" })
     render(<OnboardingWizard userId="u1" />)
     const input = screen.getByLabelText("chat input") as HTMLInputElement
     fireEvent.change(input, { target: { value: "finish" } })
     fireEvent.submit(input.closest("form")!)
-    await waitFor(() => {
+    await waitFor(() =>
       expect(screen.getByTestId("clearance-granted-ceremony")).toBeInTheDocument()
-      order.push("ceremony")
-    })
-    // linkTelegram resolved before ceremony mounted.
-    expect(linkTelegramMock).toHaveBeenCalledTimes(1)
-    expect(order).toEqual(["link", "ceremony"])
-    // CTA href includes the minted code (ensures state.linkCode was set).
+    )
+    // linkTelegram is never called in the new flow.
+    expect(linkTelegramMock).not.toHaveBeenCalled()
+    // CTA href includes the inline code from the /converse response.
     const cta = screen.getByTestId("ceremony-cta") as HTMLAnchorElement
     expect(cta.href).toContain("start=XYZ789")
   })
@@ -196,35 +191,32 @@ describe("OnboardingWizard — PR #363 QA iter-1 fixes", () => {
     expect(screen.getByRole("button", { name: "jazz" })).toBeInTheDocument()
   })
 
-  it("I4: conversation_complete + linkCode unresolved → neutral loading interstitial (not ceremony)", async () => {
-    mockConverseOnce({ conversation_complete: true, progress_pct: 100 })
-    // linkTelegram pending forever for this test (never resolves).
-    linkTelegramMock.mockImplementationOnce(
-      () => new Promise(() => {})
-    )
+  it("I4: conversation_complete + link_code present → ClearanceGrantedCeremony paints (no separate linkTelegram call)", async () => {
+    // PR-B new flow: link_code arrives inline in the terminal /converse
+    // response. No separate api.linkTelegram() POST is needed.
+    mockConverseOnce({ conversation_complete: true, progress_pct: 100, link_code: "INLINE123", link_expires_at: "2026-05-01T00:00:00Z" })
     render(<OnboardingWizard userId="u1" />)
     const input = screen.getByLabelText("chat input") as HTMLInputElement
     fireEvent.change(input, { target: { value: "finish" } })
     fireEvent.submit(input.closest("form")!)
 
-    // While the link code is being minted, we should see the loading state
-    // (NOT the ceremony) and NOT the "link token missing" error.
+    // Ceremony should mount directly — no loading interstitial needed.
     await waitFor(() =>
-      expect(screen.getByTestId("ceremony-loading")).toBeInTheDocument()
+      expect(screen.getByTestId("clearance-granted-ceremony")).toBeInTheDocument()
     )
-    expect(screen.queryByTestId("clearance-granted-ceremony")).toBeNull()
-    expect(screen.queryByText(/link mint failed/i)).toBeNull()
+    // linkTelegram is never called in the new flow.
+    expect(linkTelegramMock).not.toHaveBeenCalled()
+    // CTA href includes the inline code.
+    const cta = screen.getByTestId("ceremony-cta") as HTMLAnchorElement
+    expect(cta.href).toContain("start=INLINE123")
   })
 
-  it("I4: conversation_complete + linkMintError → shows link-mint error state (NOT ceremony)", async () => {
-    // Spec 214 T4.1 / AC-T4.1.3 (FR-11e): the ceremony hard-throws on a
-    // null linkCode. The wizard MUST detect the link-mint failure and
-    // surface a recoverable error UI instead of mounting the ceremony
-    // (which would otherwise produce a silent-strand CTA pointing at
-    // `t.me/...?start=`). PR-3 had a stub that allowed this fallthrough;
-    // PR-4 hardens both halves.
-    mockConverseOnce({ conversation_complete: true, progress_pct: 100 })
-    linkTelegramMock.mockRejectedValueOnce(new Error("boom"))
+  it("I4: conversation_complete + null link_code → shows link-mint error state (FR-11d Wire-Format guard)", async () => {
+    // Spec 214 FR-11d Wire-Format Extension: FE MUST reject responses where
+    // conversation_complete=true but link_code is null/absent. The wizard
+    // detects this server-side omission and surfaces a recoverable error UI
+    // instead of mounting the ceremony (which hard-throws on null linkCode).
+    mockConverseOnce({ conversation_complete: true, progress_pct: 100, link_code: null })
     render(<OnboardingWizard userId="u1" />)
     const input = screen.getByLabelText("chat input") as HTMLInputElement
     fireEvent.change(input, { target: { value: "finish" } })

--- a/portal/src/app/onboarding/__tests__/useConversationState.test.ts
+++ b/portal/src/app/onboarding/__tests__/useConversationState.test.ts
@@ -66,6 +66,30 @@ describe("conversationReducer — AC-T3.1.1 each action transitions as documente
     expect(next.currentPromptOptions).toEqual(["a", "b"])
   })
 
+  it("hydrate prepends a late opener without dropping an active reply", () => {
+    const opener: Turn = { role: "nikita", content: "hey. building your file.", timestamp: "t0" }
+    const userTurn: Turn = { role: "user", content: "zurich", timestamp: "t1" }
+    const reply: Turn = { role: "nikita", content: "zurich. nice.", timestamp: "t2" }
+    const next = apply(
+      freshState({
+        turns: [userTurn, reply],
+        extractedFields: { location_city: "Zurich" },
+        progressPct: 20,
+      }),
+      {
+        type: "hydrate",
+        turns: [opener],
+        extractedFields: {},
+        progressPct: 0,
+        awaitingConfirmation: false,
+        currentPromptType: "text",
+      }
+    )
+    expect(next.turns).toEqual([opener, userTurn, reply])
+    expect(next.progressPct).toBe(20)
+    expect(next.extractedFields).toEqual({ location_city: "Zurich" })
+  })
+
   it("user_input appends user turn + flips isLoading", () => {
     const next = apply(freshState(), {
       type: "user_input",

--- a/portal/src/app/onboarding/hooks/useConversationState.ts
+++ b/portal/src/app/onboarding/hooks/useConversationState.ts
@@ -118,14 +118,21 @@ export function conversationReducer(
 ): ConversationState {
   switch (action.type) {
     case "hydrate":
-      // AC-T3.10.1 fix: if the user has already submitted a turn (e.g. typed
-      // before the GET /onboarding/conversation retry loop resolved), do NOT
-      // overwrite existing turns. The opener-fallback hydrate fires ~1.5s
-      // after mount (3 retries × backoff), by which time the user may have
-      // submitted input and received a nikita_reply via server_response. A
-      // blind overwrite would reset `turns` to [opener] and discard the reply,
-      // producing the "only 1 nikita bubble" failure (AC-T3.10.1 line 98).
-      if (state.turns.length > 0) return state
+      // AC-T3.10.1 guard: block hydrate only when a nikita turn already exists
+      // in state (either the opener or a server reply). This prevents a late-
+      // resolving fallback from overwriting a conversation that is already in
+      // progress.
+      //
+      // History:
+      //   - Commit ebf06fb used `turns.length > 0` to block overwrites, but
+      //     that was too broad: it also suppressed the opener when the user had
+      //     only submitted a user_input turn (no nikita reply yet). Race:
+      //     user fills + sends before getConversation() completes → turns=[user]
+      //     → guard fired → opener never inserted → test saw 1 nikita bubble.
+      //   - Correct invariant: hydrate is safe if NO nikita turn exists yet.
+      //     A user-only turn array still needs the opener prepended; a turn
+      //     array that already has a nikita turn must not be overwritten.
+      if (state.turns.some((t) => t.role === "nikita")) return state
       return {
         ...state,
         turns: action.turns,

--- a/portal/src/app/onboarding/hooks/useConversationState.ts
+++ b/portal/src/app/onboarding/hooks/useConversationState.ts
@@ -118,10 +118,9 @@ export function conversationReducer(
 ): ConversationState {
   switch (action.type) {
     case "hydrate":
-      // AC-T3.10.1 guard: block hydrate only when a nikita turn already exists
-      // in state (either the opener or a server reply). This prevents a late-
-      // resolving fallback from overwriting a conversation that is already in
-      // progress.
+      // AC-T3.10.1 guard: when a Nikita turn already exists, do not let a late
+      // hydrate overwrite active progress. Merge any missing hydrated turns
+      // ahead of the active conversation instead.
       //
       // History:
       //   - Commit ebf06fb used `turns.length > 0` to block overwrites, but
@@ -129,10 +128,20 @@ export function conversationReducer(
       //     only submitted a user_input turn (no nikita reply yet). Race:
       //     user fills + sends before getConversation() completes → turns=[user]
       //     → guard fired → opener never inserted → test saw 1 nikita bubble.
-      //   - Correct invariant: hydrate is safe if NO nikita turn exists yet.
-      //     A user-only turn array still needs the opener prepended; a turn
-      //     array that already has a nikita turn must not be overwritten.
-      if (state.turns.some((t) => t.role === "nikita")) return state
+      //   - Correct invariant: hydrate must not overwrite active turns. A
+      //     missing opener still needs to be prepended even after the reply won
+      //     the race.
+      if (state.turns.some((t) => t.role === "nikita")) {
+        const missingHydratedTurns = action.turns.filter(
+          (incoming) =>
+            !state.turns.some(
+              (existing) =>
+                existing.role === incoming.role && existing.content === incoming.content
+            )
+        )
+        if (missingHydratedTurns.length === 0) return state
+        return { ...state, turns: [...missingHydratedTurns, ...state.turns] }
+      }
       return {
         ...state,
         turns: action.turns,

--- a/portal/src/app/onboarding/hooks/useConversationState.ts
+++ b/portal/src/app/onboarding/hooks/useConversationState.ts
@@ -118,6 +118,14 @@ export function conversationReducer(
 ): ConversationState {
   switch (action.type) {
     case "hydrate":
+      // AC-T3.10.1 fix: if the user has already submitted a turn (e.g. typed
+      // before the GET /onboarding/conversation retry loop resolved), do NOT
+      // overwrite existing turns. The opener-fallback hydrate fires ~1.5s
+      // after mount (3 retries × backoff), by which time the user may have
+      // submitted input and received a nikita_reply via server_response. A
+      // blind overwrite would reset `turns` to [opener] and discard the reply,
+      // producing the "only 1 nikita bubble" failure (AC-T3.10.1 line 98).
+      if (state.turns.length > 0) return state
       return {
         ...state,
         turns: action.turns,

--- a/portal/src/app/onboarding/hooks/useConversationState.ts
+++ b/portal/src/app/onboarding/hooks/useConversationState.ts
@@ -162,6 +162,14 @@ export function conversationReducer(
         ...state.extractedFields,
         ...response.extracted_fields,
       }
+      // AC-11d.7: if the terminal turn carries a link code, store it in state
+      // so ClearanceGrantedCeremony can read the deep-link without a separate
+      // POST /portal/link-telegram call. The code is minted server-side on the
+      // same turn that sets conversation_complete=true (Spec 214 PR-B T12).
+      const linkCodeUpdate =
+        response.link_code != null
+          ? { linkCode: response.link_code, linkCodeExpiresAt: response.link_expires_at ?? undefined }
+          : {}
       return {
         ...state,
         turns: [...state.turns, nikitaTurn],
@@ -173,6 +181,7 @@ export function conversationReducer(
         isComplete: response.conversation_complete,
         isLoading: false,
         lastError: null,
+        ...linkCodeUpdate,
       }
     }
 

--- a/portal/src/app/onboarding/onboarding-wizard.tsx
+++ b/portal/src/app/onboarding/onboarding-wizard.tsx
@@ -49,7 +49,7 @@ function ChatOnboardingWizard({ userId }: OnboardingWizardProps) {
   const { state, dispatch, hydrateOnce } = useConversationState()
   const api = useOnboardingAPI()
   const hydratedRef = useRef(false)
-  const [linkMintError, setLinkMintError] = useState<string | null>(null)
+  const [linkMintError] = useState<string | null>(null)
 
   // Shared fallback: used when backend returns empty history or fails.
   const hydrateWithOpener = useCallback(() => {
@@ -90,7 +90,20 @@ function ChatOnboardingWizard({ userId }: OnboardingWizardProps) {
           progressPct: data.progress_pct,
           awaitingConfirmation: false,
           currentPromptType: "text",
+          isComplete: data.progress_pct === 100,
         })
+        // AC-11d.7 PR-B: restore active link code from GET response so a page
+        // reload on the ceremony screen shows the deep-link immediately.
+        // If link_code_expired=true: don't dispatch the stale code — the wizard
+        // will re-mint a fresh one when the user next reaches the terminal turn
+        // (the POST /converse terminal response always carries a fresh link_code).
+        if (data.link_code && !data.link_code_expired) {
+          dispatch({
+            type: "link_code",
+            code: data.link_code,
+            expiresAt: data.link_expires_at ?? new Date().toISOString(),
+          })
+        }
       } else {
         hydrateWithOpener()
       }
@@ -98,7 +111,7 @@ function ChatOnboardingWizard({ userId }: OnboardingWizardProps) {
       // Network failure: fall back to hardcoded opener so wizard still works.
       hydrateWithOpener()
     })
-  }, [api, hydrateOnce, hydrateWithOpener, userId])
+  }, [api, dispatch, hydrateOnce, hydrateWithOpener, userId])
 
   const submit = useCallback(
     async (input: string | ControlSelection) => {
@@ -128,19 +141,10 @@ function ChatOnboardingWizard({ userId }: OnboardingWizardProps) {
           AbortSignal.timeout(CONVERSATION_AGENT_TIMEOUT_MS)
         )
         dispatch({ type: "server_response", response })
-        if (response.conversation_complete) {
-          try {
-            const link = await api.linkTelegram()
-            dispatch({
-              type: "link_code",
-              code: link.code,
-              expiresAt: link.expires_at,
-            })
-          } catch (err) {
-            setLinkMintError("link mint failed")
-            console.error("[onboarding] link_telegram mint failed", err)
-          }
-        }
+        // AC-11d.7 PR-B: link_code is minted server-side on the terminal turn
+        // and returned in the ConverseResponse. The server_response reducer case
+        // reads response.link_code and stores it in state.linkCode.
+        // No separate api.linkTelegram() call needed.
       } catch (err) {
         // AbortSignal.timeout → AbortError (name === "AbortError") or
         // DOMException("TimeoutError"). Both route to the in-character
@@ -168,7 +172,10 @@ function ChatOnboardingWizard({ userId }: OnboardingWizardProps) {
               next_prompt_type: state.currentPromptType,
               next_prompt_options: state.currentPromptOptions ?? null,
               progress_pct: state.progressPct,
-              conversation_complete: false,
+              // PR-B fix: preserve prior completion state on 429. The
+              // hardcoded `false` would clobber `isComplete=true` when the
+              // user retries after rate-limit on the terminal turn.
+              conversation_complete: state.isComplete,
               source: "fallback",
               latency_ms: 0,
             },
@@ -183,6 +190,7 @@ function ChatOnboardingWizard({ userId }: OnboardingWizardProps) {
       dispatch,
       state.turns,
       state.progressPct,
+      state.isComplete,
       state.currentPromptType,
       state.currentPromptOptions,
     ]

--- a/portal/src/app/onboarding/onboarding-wizard.tsx
+++ b/portal/src/app/onboarding/onboarding-wizard.tsx
@@ -49,7 +49,7 @@ function ChatOnboardingWizard({ userId }: OnboardingWizardProps) {
   const { state, dispatch, hydrateOnce } = useConversationState()
   const api = useOnboardingAPI()
   const hydratedRef = useRef(false)
-  const [linkMintError] = useState<string | null>(null)
+  const [linkMintError, setLinkMintError] = useState<string | null>(null)
 
   // Shared fallback: used when backend returns empty history or fails.
   const hydrateWithOpener = useCallback(() => {
@@ -145,6 +145,11 @@ function ChatOnboardingWizard({ userId }: OnboardingWizardProps) {
         // and returned in the ConverseResponse. The server_response reducer case
         // reads response.link_code and stores it in state.linkCode.
         // No separate api.linkTelegram() call needed.
+        // FR-11d Wire-Format guard: if the terminal turn arrives without a
+        // link_code, treat it as a mint failure (the server MUST include one).
+        if (response.conversation_complete && !response.link_code) {
+          setLinkMintError("link code missing in server response")
+        }
       } catch (err) {
         // AbortSignal.timeout → AbortError (name === "AbortError") or
         // DOMException("TimeoutError"). Both route to the in-character

--- a/portal/src/app/onboarding/types/contracts.ts
+++ b/portal/src/app/onboarding/types/contracts.ts
@@ -183,6 +183,12 @@ export interface ConversationProfileResponse {
   progress_pct: number
   /** All extracted fields committed to the user's profile (across all sessions, not just the current one). */
   elided_extracted: Record<string, unknown>
+  /** Active link code if one exists for the user (AC-11d.7). Null if not yet minted. */
+  link_code?: string | null
+  /** ISO-8601 expiry timestamp for the active link code. */
+  link_expires_at?: string | null
+  /** True if the link code exists but has expired — wizard should re-mint on next complete. */
+  link_code_expired?: boolean
 }
 
 // ---------------------------------------------------------------------------

--- a/portal/src/app/onboarding/types/contracts.ts
+++ b/portal/src/app/onboarding/types/contracts.ts
@@ -188,7 +188,7 @@ export interface ConversationProfileResponse {
   /** ISO-8601 expiry timestamp for the active link code. */
   link_expires_at?: string | null
   /** True if the link code exists but has expired — wizard should re-mint on next complete. */
-  link_code_expired?: boolean
+  link_code_expired?: boolean | null
 }
 
 // ---------------------------------------------------------------------------

--- a/portal/src/app/onboarding/types/converse.ts
+++ b/portal/src/app/onboarding/types/converse.ts
@@ -37,4 +37,8 @@ export interface ConverseResponse {
   conversation_complete: boolean
   source: "llm" | "fallback" | "idempotent" | "validation_reject"
   latency_ms: number
+  /** Present only on terminal turn (conversation_complete=true). Spec 214 AC-11d.7. */
+  link_code?: string | null
+  /** ISO-8601 expiry for the link code. Present only on terminal turn. */
+  link_expires_at?: string | null
 }

--- a/tests/agents/onboarding/test_conversation_agent.py
+++ b/tests/agents/onboarding/test_conversation_agent.py
@@ -457,7 +457,7 @@ class TestDynamicInstructions:
         from nikita.agents.onboarding.state import WizardSlots
 
         # location filled, everything else empty
-        partial_state = WizardSlots(location="Zurich")
+        partial_state = WizardSlots(location={"city": "Zurich", "confidence": 0.9})
         deps = ConverseDeps(user_id=uuid4(), state=partial_state)
         ctx = MagicMock()
         ctx.deps = deps
@@ -490,15 +490,12 @@ class TestDynamicInstructions:
         from nikita.agents.onboarding.state import WizardSlots
 
         full_state = WizardSlots(
-            location="Zurich",
-            scene="techno",
-            drug_tolerance=3,
-            name="Simon",
-            age=32,
-            occupation="tech",
-            backstory="Some backstory text",
-            phone="+41795550123",
-            phone_preference="voice",
+            location={"city": "Zurich", "confidence": 0.9},
+            scene={"scene": "techno", "confidence": 0.9},
+            darkness={"drug_tolerance": 3, "confidence": 0.9},
+            identity={"name": "Simon", "age": 32, "occupation": "tech", "confidence": 0.9},
+            backstory={"chosen_option_id": "opt_1", "cache_key": "abc123", "confidence": 0.9},
+            phone={"phone": "+41795550123", "phone_preference": "voice", "confidence": 0.9},
         )
         assert full_state.is_complete, "test fixture must be complete"
 

--- a/tests/agents/onboarding/test_conversation_agent.py
+++ b/tests/agents/onboarding/test_conversation_agent.py
@@ -408,6 +408,210 @@ class TestNoExtractionToolSignature:
         }, f"Literal values drifted: got {get_args(reason_hint)}"
 
 
+class TestDynamicInstructions:
+    """T10 RED — Spec 214 FR-11d PR-B: @agent.instructions callable for
+    dynamic missing-slot injection.
+
+    These tests are GENUINELY RED on the current codebase (pre-T11):
+    - ConverseDeps does NOT have a ``state`` field
+    - render_dynamic_instructions does NOT exist in conversation_prompts
+    - @agent.instructions is NOT registered on the singleton
+
+    After T11 GREEN they must all pass.
+    """
+
+    def test_converse_deps_has_state_field(self):
+        """ConverseDeps must carry a ``state: WizardSlots`` field so the
+        dynamic-instructions callable can inspect cumulative slot state
+        and inject missing-slot guidance per turn.
+
+        RED: ConverseDeps(user_id=uuid4()) will raise TypeError or
+        AttributeError because the field does not exist yet.
+        """
+        from nikita.agents.onboarding.state import WizardSlots
+
+        deps = ConverseDeps(user_id=uuid4())
+        assert hasattr(deps, "state"), (
+            "ConverseDeps must have a 'state' field of type WizardSlots; "
+            "the dynamic-instructions callable uses it each turn"
+        )
+        assert isinstance(deps.state, WizardSlots), (
+            f"deps.state expected WizardSlots, got {type(deps.state)}"
+        )
+
+    def test_render_dynamic_instructions_lists_missing_slots(self):
+        """render_dynamic_instructions must return a non-empty string that
+        mentions the missing slots when wizard is incomplete.
+
+        Strategy: build a mock RunContext with partially-filled WizardSlots
+        (location set, rest empty) and assert the returned string names at
+        least one missing slot.
+
+        RED: ImportError — function does not exist yet.
+        """
+        from unittest.mock import MagicMock
+
+        from nikita.agents.onboarding.conversation_prompts import (
+            render_dynamic_instructions,
+        )
+        from nikita.agents.onboarding.state import WizardSlots
+
+        # location filled, everything else empty
+        partial_state = WizardSlots(location="Zurich")
+        deps = ConverseDeps(user_id=uuid4(), state=partial_state)
+        ctx = MagicMock()
+        ctx.deps = deps
+
+        result = render_dynamic_instructions(ctx)
+
+        assert isinstance(result, str), (
+            f"render_dynamic_instructions must return str, got {type(result)}"
+        )
+        assert len(result) > 0, "must return non-empty string when slots missing"
+        # At least one of the remaining slot names must appear
+        remaining = partial_state.missing
+        assert remaining, "partial_state should have missing slots"
+        assert any(slot in result for slot in remaining), (
+            f"render_dynamic_instructions returned '{result}' but missing "
+            f"slots {remaining} are not mentioned"
+        )
+
+    def test_render_dynamic_instructions_omits_filled_slots(self):
+        """When all slots are filled, render_dynamic_instructions should
+        return a short string (no slots left to collect).
+
+        RED: same ImportError as sibling test.
+        """
+        from unittest.mock import MagicMock
+
+        from nikita.agents.onboarding.conversation_prompts import (
+            render_dynamic_instructions,
+        )
+        from nikita.agents.onboarding.state import WizardSlots
+
+        full_state = WizardSlots(
+            location="Zurich",
+            scene="techno",
+            drug_tolerance=3,
+            name="Simon",
+            age=32,
+            occupation="tech",
+            backstory="Some backstory text",
+            phone="+41795550123",
+            phone_preference="voice",
+        )
+        assert full_state.is_complete, "test fixture must be complete"
+
+        deps = ConverseDeps(user_id=uuid4(), state=full_state)
+        ctx = MagicMock()
+        ctx.deps = deps
+
+        result = render_dynamic_instructions(ctx)
+
+        assert isinstance(result, str), "must always return str"
+        # When complete, the callable may return empty string or a
+        # completion acknowledgement — it must NOT list slot names.
+        for slot in [
+            "location",
+            "scene",
+            "darkness",
+            "identity",
+            "backstory",
+            "phone",
+        ]:
+            assert slot not in result.lower(), (
+                f"render_dynamic_instructions returned '{result}' but slot "
+                f"'{slot}' appears even though slots are all filled"
+            )
+
+    def test_dynamic_instructions_registered_on_agent(self):
+        """The agent singleton must have at least one registered dynamic
+        instruction callable (set via @agent.instructions decorator).
+
+        RED: agent._instructions is empty list on current codebase.
+        """
+        agent = get_conversation_agent()
+        # Pydantic AI stores @agent.instructions registrations in
+        # agent._instructions (confirmed via dir(agent) in session).
+        dynamic_fns = getattr(agent, "_instructions", [])
+        assert len(dynamic_fns) >= 1, (
+            f"agent._instructions is empty — @agent.instructions callable "
+            f"(render_dynamic_instructions) not registered. Have: {dynamic_fns}"
+        )
+
+
+class TestOutputValidator:
+    """T10 RED — @agent.output_validator registration guard.
+
+    RED: agent._output_validators is empty list on current codebase.
+    GREEN after T11 wires the validator.
+    """
+
+    def test_output_validator_registered(self):
+        """The conversation agent must have at least one output validator
+        registered via @agent.output_validator. The validator raises
+        ModelRetry when the LLM emits a string reply that contains no
+        extraction content (i.e. the LLM skipped calling a tool).
+
+        Pydantic AI stores validators in agent._output_validators.
+        """
+        agent = get_conversation_agent()
+        validators = getattr(agent, "_output_validators", [])
+        assert len(validators) >= 1, (
+            f"agent._output_validators is empty — @agent.output_validator "
+            f"not registered. Per spec 214 FR-11d validation-layering rule "
+            f"(agentic-design-patterns.md §5), the post-tool layer is "
+            f"MANDATORY. Have validators: {validators}"
+        )
+
+
+class TestRegressionGuards:
+    """Regression guards for PR-A wiring that MUST survive the PR-B
+    refactor untouched.
+
+    These tests are already GREEN (PR-A wired both primitives). They are
+    committed in the T10 RED commit to lock the contract: if T11 accidentally
+    breaks message_history wiring or regex_phone_fallback, CI catches it
+    on the same commit that introduces the regression.
+    """
+
+    def test_agent_run_uses_message_history_primitive(self):
+        """Confirm message_history= is accepted by the agent's run()
+        signature — the official Pydantic AI multi-turn primitive.
+
+        Strategy: verify via inspect that agent.run / agent.run_sync has
+        a 'message_history' parameter (or that the underlying method
+        accepts it via **kwargs). This is a contract-shape test, not an
+        integration test — no live model call needed.
+        """
+        import inspect
+
+        agent = get_conversation_agent()
+        sig = inspect.signature(agent.run)
+        params = set(sig.parameters.keys())
+        assert "message_history" in params, (
+            f"agent.run() does not accept message_history= parameter. "
+            f"Params: {params}. PR-A must wire this — do NOT remove."
+        )
+
+    def test_regex_phone_fallback_module_importable(self):
+        """regex_phone_fallback must remain importable from the portal_onboarding
+        route module. It is wired post-agent.run in PR-A to recover from
+        LLM tool-selection bias on phone numbers.
+
+        This is a smoke-import guard — it does NOT run the fallback function.
+        """
+        # The fallback lives inside the route module as a local helper.
+        # Verify the module imports without error (covers any breakage
+        # from T11 refactor).
+        try:
+            import nikita.api.routes.portal_onboarding  # noqa: F401
+        except ImportError as exc:
+            pytest.fail(
+                f"portal_onboarding route failed to import after T11 refactor: {exc}"
+            )
+
+
 class TestPersonaDriftScaffolding:
     """AC-T2.9.* scaffolding.
 


### PR DESCRIPTION
## Summary

Spec 214 FR-11d PR-B. PR-A (WizardSlots + FinalForm gate + link_code mint + regex_phone_fallback) merged at master commit f896364.

**Backend (T10 RED + T11 GREEN):**
- `ConverseDeps` gains `state: WizardSlots` — cumulative slots reconstructed from `req.conversation_history` BEFORE `agent.run`
- `render_dynamic_instructions(ctx)` added to `conversation_prompts.py` — appended per-turn via `@agent.instructions`, injects "STILL MISSING: ..." guidance when slots are incomplete
- `@agent.output_validator` registered — raises `ModelRetry` when LLM replies without calling any tool while wizard is incomplete (validation-layering §5, agentic-design-patterns.md)
- All 7 existing extraction tools preserved (path (b) per advisor guidance — 8 existing tests deeply couple to tool shape)
- `regex_phone_fallback` wiring from PR-A preserved untouched

**Frontend (T12 GREEN):**
- `ConverseResponse` TS type gains `link_code?: string|null` + `link_expires_at?: string|null` (mirrors Pydantic model)
- `ConversationProfileResponse` TS type gains link_code fields (mirrors GET /onboarding/conversation)
- `server_response` reducer case reads `response.link_code` → stores in state (eliminates separate `api.linkTelegram()` call)
- 429 fallback: `conversation_complete: false` → `state.isComplete` (prevents clobbering on terminal-turn rate-limit hit)
- Hydrate effect: dispatches `link_code` from GET response when not expired; `link_code_expired=true` skips (fresh code minted on next complete turn)

## Local tests

```
Backend:  6629 passed, 2 skipped (uv run pytest -q, 166s)
Portal:   useConversationState.test.ts 13 passed; eslint 0 errors on changed files
Pre-existing failures (react-virtuoso not installed): ChatShell.test.tsx, onboarding-wizard.test.tsx, page-metadata.test.ts — NOT caused by this PR (pre-existing missing dep)
```

## Commit log

- `db1a822` test(onboarding): T10 RED — dynamic-instructions + output-validator tests
- `97a2a07` feat(onboarding): T11 GREEN — dynamic instructions + output validator + pre-run slot reconstruction
- `500288b` feat(portal): T12 — ConverseResponse link_code types + reducer wiring + wizard fix-ups

## References

- Spec 214 FR-11d: `specs/214-portal-onboarding-wizard/spec.md`
- Tasks: `specs/214-portal-onboarding-wizard/tasks-v2.md` T10, T11, T12, T-B-Push
- agentic-design-patterns.md §3 (dynamic instructions) + §5 (validation layering)