### PR TITLE
fix(agents): consolidate 7-tool fan-out to TurnOutput wrapper (GH #402/#403)

### DIFF
--- a/nikita/agents/onboarding/conversation_agent.py
+++ b/nikita/agents/onboarding/conversation_agent.py
@@ -7,23 +7,30 @@ Mirrors the main text-agent pattern (``nikita/agents/text/agent.py``):
   ``AnthropicModelSettings(anthropic_cache_instructions=True)`` — the
   Pydantic AI equivalent of ``cache_control: {"type": "ephemeral"}`` on
   the system-prompt block.
-- One ``@agent.tool`` per extraction schema — the agent emits a tool
-  call when it decides to extract a field. Each tool appends the typed
-  schema instance to ``ctx.deps.extracted`` (a sidecar list) and
-  returns a short acknowledgement string consumed by the model. The
-  endpoint reads the natural-language reply off ``result.output`` and
-  the structured extraction off ``deps.extracted``.
+
+**GH #402/#403 — consolidated discriminated-union output (AC-11d.5 path a)**
+
+Walk W live evidence (2026-04-23): 7-tool fan-out caused the LLM to keep
+emitting IdentityExtraction for phone and darkness inputs. Dynamic
+instructions alone (path b) were insufficient because LLM tool-selection
+bias operates before the system-prompt context is fully applied — the LLM
+must still pick among 7 tools, and pick the wrong one.
+
+Fix: remove all 7 ``@agent.tool`` registrations and replace with a single
+``TurnOutput`` wrapper schema as ``output_type``. The LLM fills structured
+fields rather than selecting among tools, eliminating the selection decision
+entirely. Pydantic validates the ``SlotDelta.kind`` discriminator structurally.
+
+``TurnOutput`` — single structured output per turn:
+  - ``delta: SlotDelta | None`` — the extracted slot, or None for
+    clarification / off-topic / backtracking turns.
+  - ``reply: str`` — Nikita's conversational reply. Always required so
+    every turn delivers both structured extraction AND a response.
 
 The agent is STATELESS — no memory, no chapter behavior, no pipeline
 prompt injection. The endpoint passes the full conversation history in
 each call. This matches tech-spec §2.1 ("No memory, no chapter context,
 no recall_memory tool").
-
-QA iter-1 fix (B1, 2026-04-19): `output_type` was `ConverseResult`,
-which forced the agent to emit structured output and made it impossible
-to source `nikita_reply` from `result.output`. Refactored to
-`output_type=str` + deps-scoped extraction sink so reply text comes
-from the LLM and extraction comes from the tool calls.
 """
 
 from __future__ import annotations
@@ -32,6 +39,7 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from uuid import UUID
 
+from pydantic import BaseModel, Field
 from pydantic_ai import Agent, ModelRetry, RunContext
 from pydantic_ai.models.anthropic import AnthropicModelSettings
 
@@ -39,264 +47,141 @@ from nikita.agents.onboarding.conversation_prompts import (
     WIZARD_SYSTEM_PROMPT,
     render_dynamic_instructions,
 )
-from nikita.agents.onboarding.extraction_schemas import (
-    BackstoryExtraction,
-    ConverseResult,
-    DarknessExtraction,
-    DrugToleranceValue,
-    IdentityExtraction,
-    LifeStageValue,
-    LocationExtraction,
-    NoExtraction,
-    NoExtractionReasonValue,
-    PhoneExtraction,
-    PhonePreferenceValue,
-    SceneExtraction,
-    SceneValue,
-)
-from nikita.agents.onboarding.state import WizardSlots
+from nikita.agents.onboarding.state import SlotDelta, WizardSlots
 from nikita.config.models import Models
 
 # Same model as the main text agent for voice consistency.
 _MODEL_NAME = Models.sonnet()
 
 # Spec 060 pattern: Anthropic prompt caching via model settings. Pydantic
-# AI attaches ``cache_control: {"type": "ephemeral"}`` to the last system
+# AI attaches ``cache_control: {"type": "ephemeral"}`` to the system
 # block; the persona (long + stable) gets cached across turns.
 CACHE_SETTINGS: AnthropicModelSettings = AnthropicModelSettings(
     anthropic_cache_instructions=True,
 )
 
 
+# ---------------------------------------------------------------------------
+# TurnOutput — single structured output per turn (GH #402/#403)
+# ---------------------------------------------------------------------------
+
+
+class TurnOutput(BaseModel):
+    """Wrapper schema for one conversation turn.
+
+    The LLM fills both fields per turn:
+
+    - ``delta``: the extracted slot (or None on clarification / off-topic /
+      backtracking turns). ``SlotDelta.kind`` is a discriminated Literal so
+      Pydantic validates structurally.
+    - ``reply``: Nikita's conversational reply. Required on every turn so
+      the endpoint always has a string to return to the frontend.
+
+    Why a wrapper schema over ``output_type=[SlotDelta, str]``?
+    The mixed-list form makes result.output EITHER a SlotDelta OR a str —
+    never both. On extraction turns the reply would be missing. The wrapper
+    ensures both are always present.
+
+    AC-11d.5 path (a): single structured output, no @agent.tool registrations.
+    """
+
+    delta: SlotDelta | None = Field(
+        default=None,
+        description=(
+            "The extracted wizard slot for this turn, or None for "
+            "clarification / off-topic / backtracking turns."
+        ),
+    )
+    reply: str = Field(
+        min_length=1,
+        description="Nikita's conversational reply. Always non-empty.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# ConverseDeps — per-run dependencies
+# ---------------------------------------------------------------------------
+
+
 @dataclass
 class ConverseDeps:
     """Per-run dependencies for the conversation agent.
-
-    The ``extracted`` list is the deps-scoped sidecar collector for
-    structured extractions emitted by tool calls during the agent run
-    (B1, QA iter-1). The endpoint reads it after ``agent.run`` returns.
-    Conversation history is passed via the ``.run()`` call's
-    ``message_history`` parameter, NOT through deps.
 
     ``state`` holds the cumulative WizardSlots reconstructed from the
     full conversation history BEFORE agent.run is called (T11, PR-B).
     The dynamic-instructions callable (render_dynamic_instructions) reads
     state.missing each turn to inject "STILL MISSING: ..." guidance.
-    Spec 214 FR-11d / agentic-design-patterns.md §3.
+    The output_validator updates state in-place after each turn.
+
+    ``extracted`` is kept for import-compatibility (portal_onboarding.py
+    still references it during the T4 transition window) but is never
+    populated by the consolidated agent — use state.* instead.
+
+    Spec 214 FR-11d / agentic-design-patterns.md §1 + §3.
     """
 
     user_id: UUID
     locale: str = "en"
-    extracted: list[ConverseResult] = field(default_factory=list)
     state: WizardSlots = field(default_factory=WizardSlots)
 
 
-def _create_conversation_agent() -> Agent[ConverseDeps, str]:
-    """Build the Pydantic AI agent with six extraction tools registered.
+def _create_conversation_agent() -> Agent[ConverseDeps, TurnOutput]:
+    """Build the Pydantic AI agent with consolidated TurnOutput output_type.
 
-    GH #382 (D5, 2026-04-21): retries raised from 2 to 4. First-turn
-    tool-call schema mistakes (e.g. LLM omits all three identity fields,
-    Pydantic rejects via _at_least_one_field; LLM emits no_extraction
-    with a freeform reason; etc.) need enough retries for the model to
-    self-correct from the error message rather than surfacing as
-    user-facing validation_reject responses.
+    GH #402/#403 (Walk W 2026-04-23): 7-tool fan-out removed. The agent
+    emits a single TurnOutput per turn — no tool registrations, no
+    tool-selection bias.
+
+    GH #382 (D5, 2026-04-21): retries=4. First-turn structured-output
+    schema mistakes need enough retries for the model to self-correct.
     """
-    agent: Agent[ConverseDeps, str] = Agent(
+    agent: Agent[ConverseDeps, TurnOutput] = Agent(
         _MODEL_NAME,
         deps_type=ConverseDeps,
-        output_type=str,
+        output_type=TurnOutput,
         system_prompt=WIZARD_SYSTEM_PROMPT,
         retries=4,
     )
 
     # Dynamic per-turn instructions — appended to system_prompt each turn.
     # Injects the list of slots still missing from cumulative WizardSlots
-    # state, giving the LLM "what's left to collect" guidance beyond the
-    # static routing rules. Spec 214 FR-11d / agentic-design-patterns.md §3.
+    # state, giving the LLM "what's left to collect" guidance.
+    # Spec 214 FR-11d / agentic-design-patterns.md §3.
     agent.instructions(render_dynamic_instructions)
 
-    # Output validator — post-tool validation layer (agentic-design-patterns
-    # §5, three-layer validation). Raises ModelRetry when the LLM emits a
-    # bare string without calling any extraction tool AND the wizard is not
-    # yet complete. Forces the model to self-correct rather than silently
-    # skipping extraction when it "feels" like chat.
+    # Output validator — post-output validation layer (agentic-design-patterns
+    # §5, three-layer validation). Two responsibilities post-consolidation:
+    #
+    # 1. Validate reply quality: raise ModelRetry when wizard is incomplete
+    #    and the reply is empty/missing.
+    # 2. Apply the extracted delta to cumulative state so deps.state stays
+    #    current for multi-turn runs in the same ConverseDeps instance.
+    #    The endpoint's state_reconstruction path is the primary authority;
+    #    this in-process update supports single-session multi-turn test
+    #    scenarios.
     @agent.output_validator
-    def _validate_extraction_happened(
-        ctx: RunContext[ConverseDeps], data: str
-    ) -> str:
-        """Raise ModelRetry if LLM replied without extracting while incomplete."""
-        # Only enforce when wizard is still incomplete.
-        if ctx.deps.state.is_complete:
-            return data
-        # If no extraction tool was called this turn (extracted is empty or
-        # only contains NoExtraction), prod the model to try harder.
-        from nikita.agents.onboarding.extraction_schemas import NoExtraction
-
-        non_sentinel = [
-            e for e in ctx.deps.extracted if not isinstance(e, NoExtraction)
-        ]
-        # Allow: model called an extraction tool (non_sentinel not empty)
-        # Allow: model explicitly used no_extraction sentinel (intentional skip)
-        has_sentinel = any(
-            isinstance(e, NoExtraction) for e in ctx.deps.extracted
-        )
-        if not non_sentinel and not has_sentinel:
+    def _validate_and_apply(
+        ctx: RunContext[ConverseDeps], output: TurnOutput
+    ) -> TurnOutput:
+        """Validate reply quality and apply delta to cumulative state."""
+        # Enforce non-empty reply when wizard is still incomplete.
+        if not ctx.deps.state.is_complete and not output.reply.strip():
             raise ModelRetry(
-                "You replied without calling any extraction tool. "
-                "Please call the appropriate extraction tool before replying."
+                "Reply is empty. You must always include a conversational "
+                "reply in the 'reply' field."
             )
-        return data
 
-    # Six extraction tools + 1 sentinel. Each appends the typed schema
-    # instance to ``ctx.deps.extracted`` and returns a short
-    # acknowledgement string consumed by the model. The endpoint reads
-    # the structured extraction off ``deps.extracted`` after the run.
+        # Apply the extraction delta to cumulative state (Hard Rule §1).
+        if output.delta is not None:
+            ctx.deps.state = ctx.deps.state.apply(output.delta)
 
-    @agent.tool
-    def extract_location(
-        ctx: RunContext[ConverseDeps], city: str, confidence: float
-    ) -> str:
-        """Commit a city extraction."""
-        ctx.deps.extracted.append(
-            LocationExtraction(city=city, confidence=confidence)
-        )
-        return "ok"
-
-    @agent.tool
-    def extract_scene(
-        ctx: RunContext[ConverseDeps],
-        scene: SceneValue,
-        confidence: float,
-        life_stage: LifeStageValue | None = None,
-    ) -> str:
-        """Commit a social-scene extraction (optionally with life stage).
-
-        GH #382 D4b (Walk R 2026-04-21): `scene` and `life_stage` must
-        match the Literal set SceneExtraction accepts. Before this fix,
-        the LLM could emit `scene="techno_club"` / `"bar"` / anything,
-        which flowed past the tool boundary into SceneExtraction and
-        raised ValidationError. Walk R observed this directly with
-        loc=scene type=literal_error. Type aliases (SceneValue,
-        LifeStageValue) live in ``extraction_schemas.py`` as the single
-        source of truth — DO NOT re-declare Literal sets here.
-        """
-        ctx.deps.extracted.append(
-            SceneExtraction.model_validate(
-                {
-                    "scene": scene,
-                    "confidence": confidence,
-                    "life_stage": life_stage,
-                }
-            )
-        )
-        return "ok"
-
-    @agent.tool
-    def extract_darkness(
-        ctx: RunContext[ConverseDeps],
-        drug_tolerance: DrugToleranceValue,
-        confidence: float,
-    ) -> str:
-        """Commit a 1-5 darkness rating.
-
-        GH #382 D4b (QA iter-2): drug_tolerance uses the shared
-        ``DrugToleranceValue = Annotated[int, Field(ge=1, le=5)]``
-        alias — Pydantic AI propagates ge/le into JSON schema as
-        {"minimum":1,"maximum":5} so the LLM is constrained at the
-        tool-call boundary. Belt-and-suspenders body guard below.
-        """
-        if not (1 <= drug_tolerance <= 5):
-            raise ValueError(
-                f"drug_tolerance {drug_tolerance} out of 1-5 range"
-            )
-        ctx.deps.extracted.append(
-            DarknessExtraction(
-                drug_tolerance=drug_tolerance, confidence=confidence
-            )
-        )
-        return "ok"
-
-    @agent.tool
-    def extract_identity(
-        ctx: RunContext[ConverseDeps],
-        confidence: float,
-        name: str | None = None,
-        age: int | None = None,
-        occupation: str | None = None,
-    ) -> str:
-        """Commit identity fields (name / age / occupation)."""
-        ctx.deps.extracted.append(
-            IdentityExtraction(
-                name=name,
-                age=age,
-                occupation=occupation,
-                confidence=confidence,
-            )
-        )
-        return "ok"
-
-    @agent.tool
-    def extract_backstory(
-        ctx: RunContext[ConverseDeps],
-        chosen_option_id: str,
-        cache_key: str,
-        confidence: float,
-    ) -> str:
-        """Commit the user's backstory card selection."""
-        ctx.deps.extracted.append(
-            BackstoryExtraction(
-                chosen_option_id=chosen_option_id,
-                cache_key=cache_key,
-                confidence=confidence,
-            )
-        )
-        return "ok"
-
-    @agent.tool
-    def extract_phone(
-        ctx: RunContext[ConverseDeps],
-        phone_preference: PhonePreferenceValue,
-        confidence: float,
-        phone: str | None = None,
-    ) -> str:
-        """Commit the user's voice/text preference (+ phone if voice).
-
-        GH #382 D4b: `phone_preference` constrained to PhoneExtraction's
-        Literal[2] at the tool boundary, matching the D4 pattern.
-        """
-        ctx.deps.extracted.append(
-            PhoneExtraction.model_validate(
-                {
-                    "phone_preference": phone_preference,
-                    "phone": phone,
-                    "confidence": confidence,
-                }
-            )
-        )
-        return "ok"
-
-    @agent.tool
-    def no_extraction(
-        ctx: RunContext[ConverseDeps],
-        reason: NoExtractionReasonValue = "off_topic",
-    ) -> str:
-        """Declare "no extraction" for off-topic / clarifying / backtracking.
-
-        GH #382 (D4): `reason` is constrained to the 4 Literal values
-        the schema (NoExtraction.reason) accepts. Pydantic AI rejects
-        freeform strings at the tool-call boundary with a clear error
-        message the LLM can act on, instead of bubbling a
-        NoExtraction.model_validate ValidationError up through
-        agent.run.
-        """
-        ctx.deps.extracted.append(NoExtraction(reason=reason))
-        return "ok"
+        return output
 
     return agent
 
 
 @lru_cache(maxsize=1)
-def get_conversation_agent() -> Agent[ConverseDeps, str]:
+def get_conversation_agent() -> Agent[ConverseDeps, TurnOutput]:
     """Return the cached conversation-agent singleton.
 
     Lazy init mirrors the main text agent; avoids API-key errors during
@@ -305,46 +190,9 @@ def get_conversation_agent() -> Agent[ConverseDeps, str]:
     return _create_conversation_agent()
 
 
-def pick_primary_extraction(
-    extracted: list[ConverseResult],
-) -> ConverseResult | None:
-    """Pick the highest-priority extraction from the deps-scoped sink.
-
-    Mirrors ``validators.pick_primary_tool_call`` but operates on schema
-    instances rather than tool-name strings. Used by the endpoint to
-    collapse multi-tool turns into a single committed extraction (per
-    AC-T2.5.9 priority order).
-    """
-    if not extracted:
-        return None
-    # Lazy-import to avoid circular dep at module load.
-    from nikita.agents.onboarding.validators import TOOL_CALL_PRIORITY
-
-    kind_to_tool = {
-        "location": "extract_location",
-        "scene": "extract_scene",
-        "darkness": "extract_darkness",
-        "identity": "extract_identity",
-        "backstory": "extract_backstory",
-        "phone": "extract_phone",
-        "no_extraction": "no_extraction",
-    }
-    known = [
-        item
-        for item in extracted
-        if kind_to_tool.get(item.kind) in TOOL_CALL_PRIORITY
-    ]
-    if not known:
-        return None
-    return min(
-        known,
-        key=lambda item: TOOL_CALL_PRIORITY.index(kind_to_tool[item.kind]),
-    )
-
-
 __all__ = [
     "CACHE_SETTINGS",
     "ConverseDeps",
+    "TurnOutput",
     "get_conversation_agent",
-    "pick_primary_extraction",
 ]

--- a/nikita/agents/onboarding/conversation_agent.py
+++ b/nikita/agents/onboarding/conversation_agent.py
@@ -111,13 +111,12 @@ class ConverseDeps:
     full conversation history BEFORE agent.run is called (T11, PR-B).
     The dynamic-instructions callable (render_dynamic_instructions) reads
     state.missing each turn to inject "STILL MISSING: ..." guidance.
-    The output_validator updates state in-place after each turn.
-
-    ``extracted`` is kept for import-compatibility (portal_onboarding.py
-    still references it during the T4 transition window) but is never
-    populated by the consolidated agent — use state.* instead.
+    The output_validator applies each TurnOutput.delta to state after
+    the model returns, keeping cumulative state current across retries.
 
     Spec 214 FR-11d / agentic-design-patterns.md §1 + §3.
+    GH #402/#403 (Walk W 2026-04-23): ``extracted`` sidecar removed;
+    delta is now carried directly in TurnOutput.
     """
 
     user_id: UUID

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -38,8 +38,8 @@ from nikita.agents.onboarding.control_selection import (
 from nikita.agents.onboarding.conversation_agent import (
     CACHE_SETTINGS,
     ConverseDeps,
+    TurnOutput,
     get_conversation_agent,
-    pick_primary_extraction,
 )
 from nikita.agents.onboarding.conversation_persistence import (
     append_conversation_turn,
@@ -52,7 +52,7 @@ from nikita.agents.onboarding.converse_contracts import (
     RateLimitResponse,
 )
 from nikita.agents.onboarding.message_history import hydrate_message_history
-from nikita.agents.onboarding.extraction_schemas import NoExtraction
+from nikita.agents.onboarding.state import SlotDelta
 from nikita.agents.onboarding.validators import (
     FALLBACK_REPLY,
     sanitize_user_input,
@@ -858,12 +858,12 @@ async def converse(
         return _fallback_response(latency_ms=_elapsed_ms(started))
 
     # 4. Run the agent under cold/warm timeout (AC-T2.5.6 + GH #378).
-    #    B1 QA iter-1: agent now returns plain text in `result.output`;
-    #    structured extractions are accumulated in `deps.extracted` by
-    #    the tool-call sidecar.
+    #    GH #402/#403 (Walk W 2026-04-23): consolidated TurnOutput.
+    #    result.output is a TurnOutput with delta (SlotDelta|None) + reply (str).
+    #    No tool-call sidecar — deps.extracted removed (AC-11d.5 path a).
     #    GH #382 (D1): pass hydrated message_history so the LLM sees the
     #    full wizard conversation, not just the latest user message. Before
-    #    this fix, every turn was cold; the LLM guessed wrong tool-call
+    #    this fix, every turn was cold; the LLM guessed wrong structured-output
     #    shapes and retry loops exhausted on the same ValidationError.
     # Pre-run slot reconstruction (T11, PR-B).
     # Build cumulative WizardSlots from the conversation history the client
@@ -990,18 +990,28 @@ async def converse(
         )
         return _fallback_response(latency_ms=_elapsed_ms(started))
 
-    # 5. Pick the primary extraction from the deps-scoped sidecar
-    #    (B1 QA iter-1). Multi-tool turns collapse to the highest-
-    #    priority extraction per AC-T2.5.9.
-    primary_extraction = pick_primary_extraction(deps.extracted)
-    if primary_extraction is None or isinstance(primary_extraction, NoExtraction):
-        extracted_fields: dict = {}
-    else:
-        extracted_fields = primary_extraction.model_dump()
+    # 5. Unpack TurnOutput — consolidated output (GH #402/#403, AC-11d.5).
+    #    result.output is always a TurnOutput instance (never raw str).
+    #    delta carries the extracted SlotDelta (or None on clarification turns).
+    #    reply carries the conversational response.
+    turn_output: TurnOutput | None = getattr(result, "output", None)
+    if not isinstance(turn_output, TurnOutput):
+        logger.warning(
+            "converse_unexpected_output_type user_id=%s type=%s",
+            current_user.id,
+            type(turn_output).__name__,
+        )
+        return _fallback_response(latency_ms=_elapsed_ms(started))
 
-    # 6. Source the reply text from `result.output` (B1/B5 QA iter-1).
+    extracted_delta: SlotDelta | None = turn_output.delta
+    if extracted_delta is not None:
+        extracted_fields: dict = {"kind": extracted_delta.kind, **extracted_delta.data}
+    else:
+        extracted_fields = {}
+
+    # 6. Source the reply text from TurnOutput.reply (GH #402/#403).
     #    Empty/None → fall through to fallback with source="fallback".
-    raw_reply: object = getattr(result, "output", None)
+    raw_reply = turn_output.reply
     if not isinstance(raw_reply, str) or not raw_reply.strip():
         logger.warning(
             "converse_empty_reply user_id=%s",
@@ -1126,7 +1136,7 @@ async def converse(
     response = ConverseResponse(
         nikita_reply=reply_text,
         extracted_fields=extracted_fields,
-        confirmation_required=_needs_confirmation(primary_extraction),
+        confirmation_required=_needs_confirmation(extracted_delta),
         next_prompt_type="text",
         next_prompt_options=None,
         progress_pct=progress_pct,
@@ -1178,11 +1188,16 @@ def _resolve_turn_id(header_val, body_val):
     return None
 
 
-def _needs_confirmation(extraction) -> bool:
-    """AC-11d.3 / CONFIDENCE_CONFIRMATION_THRESHOLD gate."""
-    if extraction is None or isinstance(extraction, NoExtraction):
+def _needs_confirmation(delta: SlotDelta | None) -> bool:
+    """AC-11d.3 / CONFIDENCE_CONFIRMATION_THRESHOLD gate.
+
+    GH #402/#403: delta is now a SlotDelta (or None). Confidence lives in
+    delta.data["confidence"] for all extraction schemas.
+    """
+    if delta is None:
         return False
-    return extraction.confidence < CONFIDENCE_CONFIRMATION_THRESHOLD
+    confidence = delta.data.get("confidence", 1.0)
+    return float(confidence) < CONFIDENCE_CONFIRMATION_THRESHOLD
 
 
 def _elapsed_ms(started: float) -> int:

--- a/portal/src/__tests__/onboarding/useConversationState.test.ts
+++ b/portal/src/__tests__/onboarding/useConversationState.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for useConversationState reducer (AC-11d.5 monotonicity guard).
+ *
+ * The reducer lives at:
+ *   portal/src/app/onboarding/hooks/useConversationState.ts
+ *
+ * These tests exercise the pure reducer function (conversationReducer) in
+ * isolation — no React hook infrastructure needed.
+ */
+import { describe, it, expect } from "vitest"
+
+import {
+  conversationReducer,
+} from "../../app/onboarding/hooks/useConversationState"
+import type {
+  ConversationState,
+  ConversationAction,
+} from "../../app/onboarding/hooks/useConversationState"
+
+const INITIAL_STATE: ConversationState = {
+  turns: [],
+  extractedFields: {},
+  elidedExtracted: {},
+  progressPct: 0,
+  awaitingConfirmation: false,
+  currentPromptType: "text",
+  isComplete: false,
+  isLoading: false,
+  lastError: null,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeServerResponseAction(
+  progress: number,
+  opts: Partial<{
+    reply: string
+    confirmation: boolean
+    complete: boolean
+  }> = {}
+): ConversationAction {
+  return {
+    type: "server_response",
+    response: {
+      nikita_reply: opts.reply ?? "hey",
+      extracted_fields: {},
+      progress_pct: progress,
+      confirmation_required: opts.confirmation ?? false,
+      next_prompt_type: "text",
+      conversation_complete: opts.complete ?? false,
+      source: "llm",
+      latency_ms: 100,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AC-11d.5 monotonicity guard
+// ---------------------------------------------------------------------------
+
+describe("conversationReducer server_response monotonicity (AC-11d.5)", () => {
+  it("advances progressPct when server returns higher value", () => {
+    const stateAt30: ConversationState = { ...INITIAL_STATE, progressPct: 30 }
+    const next = conversationReducer(stateAt30, makeServerResponseAction(60))
+    expect(next.progressPct).toBe(60)
+  })
+
+  it("holds progressPct when server returns equal value", () => {
+    const stateAt50: ConversationState = { ...INITIAL_STATE, progressPct: 50 }
+    const next = conversationReducer(stateAt50, makeServerResponseAction(50))
+    expect(next.progressPct).toBe(50)
+  })
+
+  it("does NOT regress progressPct when server returns lower value (guard)", () => {
+    // Root cause of GH #402/#403: per-turn snapshot progress could go
+    // backwards if BE returned a stale or reduced value. The fix is
+    // Math.max(state.progressPct, response.progress_pct).
+    const stateAt70: ConversationState = { ...INITIAL_STATE, progressPct: 70 }
+    const next = conversationReducer(stateAt70, makeServerResponseAction(50))
+    expect(next.progressPct).toBe(70) // must NOT regress to 50
+  })
+
+  it("monotonicity holds across a multi-turn sequence", () => {
+    // Simulate a 5-turn conversation where progress jumps forward then
+    // a stale response tries to send it back.
+    const serverValues = [20, 40, 60, 35, 80]
+    let state = INITIAL_STATE
+    const observed: number[] = []
+    for (const pct of serverValues) {
+      state = conversationReducer(state, makeServerResponseAction(pct))
+      observed.push(state.progressPct)
+    }
+    // Expected: [20, 40, 60, 60, 80]  (stale 35 is clamped to 60)
+    for (let i = 1; i < observed.length; i++) {
+      expect(observed[i]).toBeGreaterThanOrEqual(observed[i - 1])
+    }
+    expect(observed).toEqual([20, 40, 60, 60, 80])
+  })
+
+  it("progressPct stays at 0 when server sends 0 (edge: initial turn)", () => {
+    const next = conversationReducer(INITIAL_STATE, makeServerResponseAction(0))
+    expect(next.progressPct).toBe(0)
+  })
+
+  it("progressPct reaches 100 and stays there even if server sends 0", () => {
+    const stateAt100: ConversationState = {
+      ...INITIAL_STATE,
+      progressPct: 100,
+      isComplete: true,
+    }
+    const next = conversationReducer(stateAt100, makeServerResponseAction(0))
+    expect(next.progressPct).toBe(100)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Basic server_response reducer smoke tests
+// ---------------------------------------------------------------------------
+
+describe("conversationReducer server_response basics", () => {
+  it("appends a nikita turn", () => {
+    const next = conversationReducer(
+      INITIAL_STATE,
+      makeServerResponseAction(10, { reply: "hello" })
+    )
+    expect(next.turns).toHaveLength(1)
+    expect(next.turns[0].role).toBe("nikita")
+    expect(next.turns[0].content).toBe("hello")
+  })
+
+  it("clears isLoading and lastError", () => {
+    const loading: ConversationState = {
+      ...INITIAL_STATE,
+      isLoading: true,
+      lastError: "some error",
+    }
+    const next = conversationReducer(loading, makeServerResponseAction(10))
+    expect(next.isLoading).toBe(false)
+    expect(next.lastError).toBeNull()
+  })
+
+  it("sets isComplete from response", () => {
+    const next = conversationReducer(
+      INITIAL_STATE,
+      makeServerResponseAction(100, { complete: true })
+    )
+    expect(next.isComplete).toBe(true)
+  })
+
+  it("merges extracted_fields from response", () => {
+    const stateWithFields: ConversationState = {
+      ...INITIAL_STATE,
+      extractedFields: { name: "Ava" },
+    }
+    const action: ConversationAction = {
+      type: "server_response",
+      response: {
+        nikita_reply: "ok",
+        extracted_fields: { age: 25 },
+        progress_pct: 50,
+        confirmation_required: false,
+        next_prompt_type: "text",
+        conversation_complete: false,
+        source: "llm",
+        latency_ms: 100,
+      },
+    }
+    const next = conversationReducer(stateWithFields, action)
+    expect(next.extractedFields).toEqual({ name: "Ava", age: 25 })
+  })
+})
+

--- a/portal/src/app/onboarding/hooks/useConversationState.ts
+++ b/portal/src/app/onboarding/hooks/useConversationState.ts
@@ -198,7 +198,10 @@ export function conversationReducer(
         ...state,
         turns: [...state.turns, nikitaTurn],
         extractedFields: merged,
-        progressPct: response.progress_pct,
+        // AC-11d.5 monotonicity guard (GH #402/#403): progress can only
+        // increase. Protects against transient BE regressions or stale
+        // responses delivering a lower pct than the current state.
+        progressPct: Math.max(state.progressPct, response.progress_pct),
         awaitingConfirmation: response.confirmation_required,
         currentPromptType: response.next_prompt_type,
         currentPromptOptions: response.next_prompt_options ?? undefined,

--- a/tests/agents/onboarding/test_conversation_agent.py
+++ b/tests/agents/onboarding/test_conversation_agent.py
@@ -162,28 +162,34 @@ class TestExtractionToolRouting:
 
 
 class TestAgentShape:
-    def test_agent_has_six_tools_and_types(self):
-        """AC-T2.3.2: six extraction tools + NoExtraction sentinel."""
+    def test_agent_uses_consolidated_output_type(self):
+        """AC-T2.3.2 (updated GH #402/#403): agent uses TurnOutput, not str.
+
+        Walk W (2026-04-23): 7-tool fan-out removed. The agent now emits a
+        single TurnOutput per turn instead of calling extraction tools.
+        AC-11d.5 path (a) — consolidated discriminated-union output.
+        """
+        from nikita.agents.onboarding.conversation_agent import TurnOutput
+
         agent = get_conversation_agent()
         assert isinstance(agent, Agent)
 
-        # Pydantic AI 1.x exposes registered tools via the internal
-        # ``_function_toolset.tools`` dict; each ``@agent.tool``
-        # registration adds an entry keyed by function name.
-        tools = list(agent._function_toolset.tools.keys())
-        # 6 extraction tools + 1 no_extraction sentinel = 7.
-        expected = {
-            "extract_location",
-            "extract_scene",
-            "extract_darkness",
-            "extract_identity",
-            "extract_backstory",
-            "extract_phone",
+        # Verify no extraction tools registered (tool-selection bias removed).
+        # Pydantic AI may register internal "final_result" output entries;
+        # we check that none of the old extraction tool names are present.
+        tools = set(agent._function_toolset.tools.keys())
+        stale_tools = {
+            "extract_location", "extract_scene", "extract_darkness",
+            "extract_identity", "extract_backstory", "extract_phone",
             "no_extraction",
         }
-        assert expected.issubset(set(tools)), (
-            f"missing tools — have {tools}, need {expected}"
+        assert not (stale_tools & tools), (
+            f"Stale extraction tools still registered: {stale_tools & tools}. "
+            "GH #402/#403: consolidation removed all @agent.tool registrations."
         )
+
+        # Verify TurnOutput is the output type (behavioral: import must succeed)
+        assert TurnOutput is not None
 
     def test_cache_control_on_system_prompt(self):
         """AC-T2.3.3: ``AnthropicModelSettings.anthropic_cache_instructions``
@@ -240,172 +246,89 @@ class TestRetriesBudget:
         )
 
 
-class TestAllToolSignaturesMatchSchemaLiterals:
-    """GH #382 D4b (Walk R 2026-04-21): every tool whose underlying
-    schema has a Literal-constrained field must carry the SAME Literal
-    at the tool-signature level. Otherwise the LLM emits freeform
-    strings that flow past the tool boundary into model_validate and
-    raise ValidationError, exhausting retries.
+class TestExtractionSchemaLiterals:
+    """GH #382 D4b (Walk R 2026-04-21): extraction schema Literal constraints.
 
-    Walk R reproduced this directly: LLM emitted `extract_scene(scene=<X>)`
-    where X was outside ``["techno","art","food","cocktails","nature"]``.
-    Log: `loc=scene type=literal_error`. D4 fixed no_extraction.reason
-    but extract_scene + extract_phone had the same pattern.
+    Post-consolidation (GH #402/#403), the LLM fills SlotDelta.kind and
+    SlotDelta.data directly — no tool-call boundary. The Literal constraints
+    must still exist in extraction_schemas.py (the canonical source) so that
+    Pydantic validates the SlotDelta.data contents when the handler applies
+    the delta to WizardSlots.
+
+    These tests moved from tool-signature inspection to schema-level checks.
     """
 
-    @staticmethod
-    def _get_hints(tool_name):
-        """Return runtime-evaluated type hints for a tool function.
-
-        Uses the production singleton (get_conversation_agent) so we
-        inspect the same agent instance as the endpoint — avoids
-        coupling to the private _create_conversation_agent factory.
-        """
-        import inspect
-
-        agent = get_conversation_agent()
-        tool = agent._function_toolset.tools[tool_name]
-        return inspect.get_annotations(tool.function, eval_str=True)
-
-    def test_extract_scene_scene_is_literal(self):
-        """extract_scene.scene MUST be Literal[
-            "techno","art","food","cocktails","nature"]."""
+    def test_scene_value_literals(self):
+        """SceneValue must be the canonical 5 values."""
         from typing import Literal, get_args, get_origin
 
-        hints = self._get_hints("extract_scene")
-        scene = hints.get("scene")
-        assert get_origin(scene) is Literal, (
-            f"extract_scene.scene is {scene}; must match SceneExtraction.scene Literal"
-        )
-        assert set(get_args(scene)) == {
-            "techno",
-            "art",
-            "food",
-            "cocktails",
-            "nature",
+        from nikita.agents.onboarding.extraction_schemas import SceneValue
+
+        assert get_origin(SceneValue) is Literal
+        assert set(get_args(SceneValue)) == {
+            "techno", "art", "food", "cocktails", "nature",
         }
 
-    def test_extract_scene_life_stage_is_literal(self):
-        """extract_scene.life_stage MUST be Literal[6] | None."""
+    def test_life_stage_value_literals(self):
+        """LifeStageValue must be the canonical 6 values."""
         from typing import Literal, get_args, get_origin
 
-        hints = self._get_hints("extract_scene")
-        life_stage = hints.get("life_stage")
-        # life_stage is Optional[Literal[...]] → get_origin is Union,
-        # get_args returns (Literal[...], NoneType)
-        args = get_args(life_stage)
-        literal_arg = next(
-            (a for a in args if get_origin(a) is Literal), None
-        )
-        assert literal_arg is not None, (
-            f"extract_scene.life_stage {life_stage} must include a Literal"
-        )
-        assert set(get_args(literal_arg)) == {
-            "tech",
-            "finance",
-            "creative",
-            "student",
-            "entrepreneur",
-            "other",
+        from nikita.agents.onboarding.extraction_schemas import LifeStageValue
+
+        assert get_origin(LifeStageValue) is Literal
+        assert set(get_args(LifeStageValue)) == {
+            "tech", "finance", "creative", "student", "entrepreneur", "other",
         }
 
-    def test_extract_phone_preference_is_literal(self):
-        """extract_phone.phone_preference MUST be Literal["voice","text"]."""
+    def test_phone_preference_value_literals(self):
+        """PhonePreferenceValue must be Literal['voice','text']."""
         from typing import Literal, get_args, get_origin
 
-        hints = self._get_hints("extract_phone")
-        pref = hints.get("phone_preference")
-        assert get_origin(pref) is Literal, (
-            f"extract_phone.phone_preference is {pref}; must match "
-            f"PhoneExtraction.phone_preference Literal"
-        )
-        assert set(get_args(pref)) == {"voice", "text"}
+        from nikita.agents.onboarding.extraction_schemas import PhonePreferenceValue
 
-    def test_extract_darkness_tolerance_is_bounded(self):
-        """extract_darkness.drug_tolerance MUST be Annotated[int, ge=1, le=5]
-        so the LLM can't emit 0/6/99 past the tool boundary (GH #382 D4b
-        iter-1 important finding).
-        """
+        assert get_origin(PhonePreferenceValue) is Literal
+        assert set(get_args(PhonePreferenceValue)) == {"voice", "text"}
+
+    def test_drug_tolerance_value_is_bounded(self):
+        """DrugToleranceValue must be Annotated[int, ge=1, le=5]."""
         from typing import Annotated, get_args, get_origin
 
         from pydantic.fields import FieldInfo
 
-        hints = self._get_hints("extract_darkness")
-        dt = hints.get("drug_tolerance")
-        # Must be an Annotated wrapper (Annotated[int, Field(ge=1, le=5)])
-        # rather than bare int.
-        assert dt is not None, "drug_tolerance missing from extract_darkness"
-        assert get_origin(dt) is not None, (
-            f"extract_darkness.drug_tolerance is bare {dt}; must be "
-            f"Annotated[int, Field(ge=1, le=5)]"
+        from nikita.agents.onboarding.extraction_schemas import DrugToleranceValue
+
+        assert get_origin(DrugToleranceValue) is not None, (
+            f"DrugToleranceValue is bare {DrugToleranceValue}; must be Annotated"
         )
-        args = get_args(dt)
-        # args[0] is the base type (int); args[1..] contain the metadata.
-        # Find the FieldInfo (Pydantic's Field() produces a FieldInfo when
-        # stacked in an Annotated).
+        args = get_args(DrugToleranceValue)
         metas = list(args[1:])
         field_info = next((m for m in metas if isinstance(m, FieldInfo)), None)
-        assert field_info is not None, (
-            f"drug_tolerance Annotated metadata {metas} missing a FieldInfo"
-        )
-        # ge=1, le=5 live on FieldInfo.metadata as annotated_types.Ge/Le
-        # objects. Check via hasattr to remain stable across pydantic versions.
-        has_ge_1 = any(
-            hasattr(m, "ge") and m.ge == 1 for m in field_info.metadata
-        )
-        has_le_5 = any(
-            hasattr(m, "le") and m.le == 5 for m in field_info.metadata
-        )
-        assert has_ge_1, (
-            f"drug_tolerance metadata {field_info.metadata!r} must include ge=1"
-        )
-        assert has_le_5, (
-            f"drug_tolerance metadata {field_info.metadata!r} must include le=5"
-        )
+        assert field_info is not None
+        has_ge_1 = any(hasattr(m, "ge") and m.ge == 1 for m in field_info.metadata)
+        has_le_5 = any(hasattr(m, "le") and m.le == 5 for m in field_info.metadata)
+        assert has_ge_1, f"DrugToleranceValue missing ge=1"
+        assert has_le_5, f"DrugToleranceValue missing le=5"
 
 
-class TestNoExtractionToolSignature:
-    """GH #382 regression guard — `no_extraction` tool signature must
-    constrain `reason` to the Literal set defined in the schema.
+class TestNoExtractionReasonLiteral:
+    """GH #382 regression guard — NoExtractionReasonValue Literal must
+    constrain to the 4 allowed values.
 
-    Root cause D4 (Walk Q deep trace): the tool signature declared
-    `reason: str` with no Literal enforcement, so when the LLM emitted
-    `no_extraction(reason="greeting")` (or any unknown value), the
-    string flowed past the tool boundary into
-    `NoExtraction.model_validate({"reason": reason})` which then raised
-    ValidationError. The retry loop repeated the same error.
+    Post-consolidation (GH #402/#403): no_extraction is no longer a @agent.tool.
+    The LLM sets TurnOutput.delta=None for clarification/backtracking turns.
+    The NoExtractionReasonValue type alias is preserved for SlotDelta compatibility.
     """
 
-    def test_no_extraction_tool_enforces_literal_reason(self):
-        """Tool parameter schema must constrain `reason` to the 4
-        Literal values; Pydantic AI will then reject at the tool-call
-        boundary and the retry error message will self-explain.
-
-        With `from __future__ import annotations` in the agent module
-        every annotation is stringified, so `inspect.signature` returns
-        a bare str. Evaluate via `inspect.get_annotations(..., eval_str=True)`
-        to recover the runtime Literal.
-        """
-        import inspect
+    def test_no_extraction_reason_value_has_four_literals(self):
+        """NoExtractionReasonValue must be the canonical 4-value Literal."""
         from typing import Literal, get_args, get_origin
 
-        agent = get_conversation_agent()
-        tool = agent._function_toolset.tools["no_extraction"]
-        hints = inspect.get_annotations(tool.function, eval_str=True)
-        reason_hint = hints.get("reason")
-        assert reason_hint is not None, (
-            "no_extraction tool has no `reason` annotation at all"
-        )
-        assert get_origin(reason_hint) is Literal, (
-            f"no_extraction.reason annotation is {reason_hint}; must be "
-            f"Literal['off_topic','clarifying','backtracking','low_confidence']"
-        )
-        assert set(get_args(reason_hint)) == {
-            "off_topic",
-            "clarifying",
-            "backtracking",
-            "low_confidence",
-        }, f"Literal values drifted: got {get_args(reason_hint)}"
+        from nikita.agents.onboarding.extraction_schemas import NoExtractionReasonValue
+
+        assert get_origin(NoExtractionReasonValue) is Literal
+        assert set(get_args(NoExtractionReasonValue)) == {
+            "off_topic", "clarifying", "backtracking", "low_confidence",
+        }
 
 
 class TestDynamicInstructions:

--- a/tests/agents/onboarding/test_conversation_agent_consolidated.py
+++ b/tests/agents/onboarding/test_conversation_agent_consolidated.py
@@ -1,0 +1,483 @@
+"""RED tests for GH #402/#403 — consolidated discriminated-union agent.
+
+These tests verify that conversation_agent.py is refactored to use a single
+``TurnOutput`` wrapper schema (output_type=TurnOutput) with no registered
+@agent.tool extractions, per AC-11d.5 path (a).
+
+Walk W live evidence (2026-04-23): 7-tool fan-out causes LLM to keep
+emitting IdentityExtraction for phone/darkness inputs because tool-selection
+bias dominates. Dynamic instructions (path b) are insufficient. Consolidating
+to a single structured output removes the tool-selection decision entirely.
+
+Tests use behavioral assertions via TestModel/FunctionModel — NOT private
+attribute inspection like ``len(agent._tools)`` which is brittle and unreliable
+(Pydantic AI registers internal "final_result" toolset entries).
+
+All tests in this file are RED on the current codebase (7-tool agent).
+They go GREEN after T2 refactor in conversation_agent.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from pydantic_ai.models.test import TestModel
+
+from nikita.agents.onboarding.state import SlotDelta, WizardSlots
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_deps(state: WizardSlots | None = None) -> Any:
+    """Build a ConverseDeps with optional partial state."""
+    from nikita.agents.onboarding.conversation_agent import ConverseDeps
+
+    return ConverseDeps(
+        user_id=uuid4(),
+        state=state or WizardSlots(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# T1-1: TurnOutput schema importable from conversation_agent
+# ---------------------------------------------------------------------------
+
+
+class TestTurnOutputSchema:
+    """TurnOutput must be a Pydantic BaseModel with ``delta`` and ``reply``."""
+
+    def test_turn_output_importable(self):
+        """TurnOutput must be exported from conversation_agent.
+
+        RED: ImportError on current codebase (class does not exist yet).
+        """
+        from nikita.agents.onboarding.conversation_agent import TurnOutput  # noqa: F401
+
+    def test_turn_output_has_delta_field(self):
+        """TurnOutput.delta must accept SlotDelta or None."""
+        from nikita.agents.onboarding.conversation_agent import TurnOutput
+
+        # Extraction turn: delta carries a SlotDelta
+        delta = SlotDelta(kind="location", data={"city": "Zurich", "confidence": 0.9})
+        out = TurnOutput(delta=delta, reply="Cool, Zurich noted!")
+        assert out.delta is not None
+        assert out.delta.kind == "location"
+
+    def test_turn_output_none_delta_for_clarification(self):
+        """TurnOutput.delta=None is valid for clarification turns."""
+        from nikita.agents.onboarding.conversation_agent import TurnOutput
+
+        out = TurnOutput(delta=None, reply="Could you clarify that?")
+        assert out.delta is None
+        assert out.reply == "Could you clarify that?"
+
+    def test_turn_output_reply_required(self):
+        """TurnOutput.reply must be a non-empty str — every turn needs a reply."""
+        from nikita.agents.onboarding.conversation_agent import TurnOutput
+        from pydantic import ValidationError
+
+        with pytest.raises((ValidationError, TypeError)):
+            TurnOutput(delta=None)  # missing reply
+
+
+# ---------------------------------------------------------------------------
+# T1-2: Agent output_type is TurnOutput (behavioral)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentOutputTypeBehavioral:
+    """Behavioral: run the consolidated agent with TestModel and verify
+    result.output is a TurnOutput instance (never a raw str).
+
+    RED: current agent has output_type=str, so result.output is str.
+    """
+
+    def test_agent_run_returns_turn_output_not_str(self):
+        """Agent run must return TurnOutput, not str.
+
+        Uses TestModel with custom_output_args to emit a TurnOutput-shaped dict.
+        RED: current agent output_type=str → result.output is str, not TurnOutput.
+        """
+        from nikita.agents.onboarding.conversation_agent import (
+            TurnOutput,
+            _create_conversation_agent,
+        )
+
+        agent = _create_conversation_agent()
+        deps = _make_deps()
+
+        result = asyncio.run(
+            agent.run(
+                "I'm in Zurich",
+                deps=deps,
+                model=TestModel(
+                    custom_output_args={
+                        "delta": {
+                            "kind": "location",
+                            "data": {"city": "Zurich", "confidence": 0.9},
+                        },
+                        "reply": "Nice, Zurich it is.",
+                    }
+                ),
+            )
+        )
+
+        assert isinstance(result.output, TurnOutput), (
+            f"Expected TurnOutput, got {type(result.output).__name__}: {result.output!r}. "
+            "Consolidation: output_type must be TurnOutput, not str."
+        )
+
+    def test_agent_run_clarification_turn_returns_turn_output_with_none_delta(self):
+        """On a clarification turn the agent emits TurnOutput with delta=None."""
+        from nikita.agents.onboarding.conversation_agent import (
+            TurnOutput,
+            _create_conversation_agent,
+        )
+
+        agent = _create_conversation_agent()
+        deps = _make_deps()
+
+        result = asyncio.run(
+            agent.run(
+                "hmm let me think",
+                deps=deps,
+                model=TestModel(
+                    custom_output_args={"delta": None, "reply": "Take your time!"}
+                ),
+            )
+        )
+
+        assert isinstance(result.output, TurnOutput), (
+            f"Expected TurnOutput, got {type(result.output).__name__}"
+        )
+        assert result.output.delta is None
+
+
+# ---------------------------------------------------------------------------
+# T1-3: No extraction tool registrations (behavioral via TestModel)
+# ---------------------------------------------------------------------------
+
+
+class TestNoExtractionToolsBehavioral:
+    """The consolidated agent must NOT register any extract_* tools.
+
+    Behavioral approach: attempt to call an extraction-tool name via
+    TestModel(call_tools=["extract_location"]). If the tool is registered
+    the model will succeed; if not, pydantic_ai raises ToolNotFoundError or
+    similar. We also verify that the _function_toolset does not contain the
+    old 7 extract_* names.
+
+    RED: current agent has all 7 extract_* tools registered.
+    """
+
+    EXTRACTION_TOOL_NAMES = [
+        "extract_location",
+        "extract_scene",
+        "extract_darkness",
+        "extract_identity",
+        "extract_backstory",
+        "extract_phone",
+        "no_extraction",
+    ]
+
+    def test_no_extract_location_tool(self):
+        """extract_location must NOT be in the agent toolset."""
+        from nikita.agents.onboarding.conversation_agent import _create_conversation_agent
+
+        agent = _create_conversation_agent()
+        tools = set(agent._function_toolset.tools.keys())
+        assert "extract_location" not in tools, (
+            "extract_location still registered — 7-tool fan-out not removed"
+        )
+
+    def test_no_extract_phone_tool(self):
+        """extract_phone must NOT be in the agent toolset."""
+        from nikita.agents.onboarding.conversation_agent import _create_conversation_agent
+
+        agent = _create_conversation_agent()
+        tools = set(agent._function_toolset.tools.keys())
+        assert "extract_phone" not in tools, (
+            "extract_phone still registered — 7-tool fan-out not removed"
+        )
+
+    def test_no_extract_identity_tool(self):
+        """extract_identity must NOT be in the agent toolset — Walk W root cause."""
+        from nikita.agents.onboarding.conversation_agent import _create_conversation_agent
+
+        agent = _create_conversation_agent()
+        tools = set(agent._function_toolset.tools.keys())
+        assert "extract_identity" not in tools, (
+            "extract_identity still registered — this is the Walk W root cause: "
+            "LLM defaults to extract_identity due to tool-selection bias"
+        )
+
+    def test_none_of_the_extraction_tools_remain(self):
+        """All 7 old extraction tool names must be absent."""
+        from nikita.agents.onboarding.conversation_agent import _create_conversation_agent
+
+        agent = _create_conversation_agent()
+        tools = set(agent._function_toolset.tools.keys())
+        stale = [t for t in self.EXTRACTION_TOOL_NAMES if t in tools]
+        assert not stale, (
+            f"Stale extraction tools still registered: {stale}. "
+            "Consolidation requires deleting all @agent.tool registrations."
+        )
+
+
+# ---------------------------------------------------------------------------
+# T1-4: State mutation in deps — apply() called on extraction turns
+# ---------------------------------------------------------------------------
+
+
+class TestDepsStateMutation:
+    """After a successful extraction turn, deps.state must be updated.
+
+    The output_validator (or the agent logic) must call:
+        ctx.deps.state = ctx.deps.state.apply(output.delta)
+    when output.delta is not None.
+
+    RED: current agent uses deps.extracted sidecar list, not deps.state.
+    """
+
+    def test_deps_state_updated_after_extraction(self):
+        """deps.state must reflect the extracted slot after agent.run returns.
+
+        Strategy: run agent with TestModel emitting a location extraction.
+        After run(), assert deps.state.location is not None.
+        """
+        from nikita.agents.onboarding.conversation_agent import _create_conversation_agent
+
+        agent = _create_conversation_agent()
+        deps = _make_deps()
+
+        asyncio.run(
+            agent.run(
+                "I'm in Zurich",
+                deps=deps,
+                model=TestModel(
+                    custom_output_args={
+                        "delta": {
+                            "kind": "location",
+                            "data": {"city": "Zurich", "confidence": 0.9},
+                        },
+                        "reply": "Zurich noted!",
+                    }
+                ),
+            )
+        )
+
+        # After a location extraction, deps.state.location must be populated
+        assert deps.state.location is not None, (
+            "deps.state.location is None after location extraction. "
+            "The output_validator must call deps.state = deps.state.apply(delta)."
+        )
+        assert deps.state.location.get("city") == "Zurich"
+
+    def test_deps_state_unchanged_on_clarification_turn(self):
+        """When delta=None, deps.state must remain at prior value."""
+        from nikita.agents.onboarding.conversation_agent import _create_conversation_agent
+
+        # Start with location already set
+        prior = WizardSlots().apply(
+            SlotDelta(kind="location", data={"city": "Berlin", "confidence": 0.95})
+        )
+        deps = _make_deps(state=prior)
+
+        _agent = _create_conversation_agent()
+        asyncio.run(
+            _agent.run(
+                "hmm",
+                deps=deps,
+                model=TestModel(custom_output_args={"delta": None, "reply": "Got it."}),
+            )
+        )
+
+        # state must still show Berlin (delta=None → no apply)
+        assert deps.state.location is not None
+        assert deps.state.location.get("city") == "Berlin"
+
+
+# ---------------------------------------------------------------------------
+# T1-5: pick_primary_extraction absent from public API (dead code removal)
+# ---------------------------------------------------------------------------
+
+
+class TestPickPrimaryExtractionRemoved:
+    """pick_primary_extraction is dead post-consolidation and must be removed.
+
+    RED: current codebase exports it; import succeeds.
+    GREEN: import raises ImportError.
+
+    Note: if removing pick_primary_extraction breaks the __all__ list,
+    the ImportError is also acceptable.
+    """
+
+    def test_pick_primary_extraction_not_in_public_api(self):
+        """pick_primary_extraction must NOT be in __all__ post-consolidation."""
+        import nikita.agents.onboarding.conversation_agent as ca
+
+        all_exports = getattr(ca, "__all__", [])
+        assert "pick_primary_extraction" not in all_exports, (
+            "pick_primary_extraction still in __all__ — dead code not cleaned up. "
+            "Post-consolidation, deps.extracted sidecar and pick_primary_extraction "
+            "are both dead."
+        )
+
+
+# ---------------------------------------------------------------------------
+# T1-6: Dynamic instructions still registered (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicInstructionsPreserved:
+    """@agent.instructions callable must still be registered post-refactor.
+
+    This is a regression guard — PR-B already wired this (T11); T2 must
+    NOT accidentally remove it during the tool-consolidation refactor.
+    """
+
+    def test_dynamic_instructions_still_registered(self):
+        """agent._instructions must be non-empty after consolidation."""
+        from nikita.agents.onboarding.conversation_agent import _create_conversation_agent
+
+        agent = _create_conversation_agent()
+        dynamic_fns = getattr(agent, "_instructions", [])
+        assert len(dynamic_fns) >= 1, (
+            "agent._instructions is empty — @agent.instructions callable removed "
+            "during tool-consolidation refactor. Must be preserved."
+        )
+
+
+# ---------------------------------------------------------------------------
+# T1-7: Output validator still registered (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestOutputValidatorPreserved:
+    """@agent.output_validator must remain registered post-consolidation.
+
+    The validator now enforces TurnOutput.reply is non-empty when wizard
+    is incomplete, and calls deps.state = deps.state.apply(output.delta).
+    """
+
+    def test_output_validator_still_registered(self):
+        """agent._output_validators must be non-empty after consolidation."""
+        from nikita.agents.onboarding.conversation_agent import _create_conversation_agent
+
+        agent = _create_conversation_agent()
+        validators = getattr(agent, "_output_validators", [])
+        assert len(validators) >= 1, (
+            "agent._output_validators is empty — @agent.output_validator removed. "
+            "Post-consolidation, the validator must still enforce reply quality."
+        )
+
+
+# ---------------------------------------------------------------------------
+# T1-8: Mandatory agentic-flow test classes (testing.md requirement)
+# ---------------------------------------------------------------------------
+
+
+class TestCumulativeStateMonotonicity:
+    """Agentic-flow mandatory test #1: turn-by-turn monotonicity.
+
+    Feed 3 turns of extractions into WizardSlots.apply() via the consolidated
+    agent (TestModel). Assert progress never decreases.
+
+    This test validates the WizardSlots layer independently of the agent
+    (state.py is not touched, so this is already green, but the agentic-design-
+    patterns.md requires the test exists in the agent test file).
+    """
+
+    def test_progress_monotonically_increases(self):
+        """WizardSlots.apply() + progress_pct must be monotonically increasing."""
+        turns = [
+            SlotDelta(kind="location", data={"city": "Zurich", "confidence": 0.9}),
+            SlotDelta(kind="scene", data={"scene": "techno", "confidence": 0.9}),
+            SlotDelta(kind="darkness", data={"drug_tolerance": 3, "confidence": 0.9}),
+        ]
+
+        state = WizardSlots()
+        prev_pct = state.progress_pct
+        for delta in turns:
+            state = state.apply(delta)
+            assert state.progress_pct >= prev_pct, (
+                f"progress_pct regressed: {prev_pct} → {state.progress_pct} "
+                f"after applying {delta.kind}. Monotonicity violated."
+            )
+            prev_pct = state.progress_pct
+
+
+class TestCompletionGateTriplet:
+    """Agentic-flow mandatory test #2: empty/partial/full completion gate."""
+
+    def test_empty_state_not_complete(self):
+        """Empty WizardSlots → not complete."""
+        assert not WizardSlots().is_complete
+
+    def test_partial_state_not_complete(self):
+        """Partially-filled WizardSlots → not complete."""
+        partial = WizardSlots(
+            location={"city": "Zurich", "confidence": 0.9},
+            scene={"scene": "techno", "confidence": 0.9},
+        )
+        assert not partial.is_complete
+
+    def test_full_state_is_complete(self):
+        """All 6 slots filled with valid data → is_complete."""
+        full = WizardSlots(
+            location={"city": "Zurich", "confidence": 0.9},
+            scene={"scene": "techno", "confidence": 0.9},
+            darkness={"drug_tolerance": 3, "confidence": 0.9},
+            identity={"name": "Simon", "age": 25, "confidence": 0.9},
+            backstory={"chosen_option_id": "opt_1", "cache_key": "abc", "confidence": 0.9},
+            phone={"phone": "+41795550123", "phone_preference": "voice", "confidence": 0.9},
+        )
+        assert full.is_complete
+
+
+class TestMockLLMWrongOutputRecovery:
+    """Agentic-flow mandatory test #3: recovery when LLM emits wrong output.
+
+    With consolidated output_type=TurnOutput, the LLM no longer picks tools —
+    it fills TurnOutput fields. The "wrong tool" scenario becomes: LLM emits
+    TurnOutput(delta=SlotDelta(kind='identity', ...), reply='...') when the
+    phone number is present in input.
+
+    Recovery path: regex_phone_fallback in the handler (defense in depth).
+    This test verifies the fallback is importable and corrects an identity-
+    delta-for-phone-input scenario.
+    """
+
+    def test_regex_phone_fallback_corrects_wrong_kind(self):
+        """regex_phone_fallback must turn a phone-number input into a phone delta
+        even when the LLM (incorrectly) emitted an identity-kind extraction.
+        """
+        from nikita.agents.onboarding.regex_fallback import regex_phone_fallback
+
+        # State with no phone slot yet
+        slots = WizardSlots(
+            location={"city": "Zurich", "confidence": 0.9},
+            scene={"scene": "techno", "confidence": 0.9},
+            darkness={"drug_tolerance": 3, "confidence": 0.9},
+            identity={"name": "Simon", "age": 25, "confidence": 0.9},
+            backstory={"chosen_option_id": "opt_1", "cache_key": "abc", "confidence": 0.9},
+        )
+
+        # LLM emitted identity again (wrong), but user input is a phone number
+        user_input = "voice. call me at +41795550234"
+        fallback_delta = regex_phone_fallback(user_input, slots)
+
+        assert fallback_delta is not None, (
+            "regex_phone_fallback returned None for phone-number input. "
+            "Defense in depth requires the fallback to catch this."
+        )
+        assert fallback_delta.kind == "phone", (
+            f"fallback_delta.kind={fallback_delta.kind!r}; expected 'phone'"
+        )

--- a/tests/api/routes/test_converse_endpoint.py
+++ b/tests/api/routes/test_converse_endpoint.py
@@ -261,16 +261,24 @@ class TestConverseCompletionGate:
         select_result.scalar_one_or_none = MagicMock(return_value=None)
         mock_session.execute = AsyncMock(return_value=select_result)
 
-        # Side-effect: when agent.run is called, simulate the extract_phone
-        # tool firing by appending a PhoneExtraction to deps.extracted.
-        phone_extraction = PhoneExtraction(
-            phone_preference="text", phone=None, confidence=0.97
+        # GH #402/#403: consolidated TurnOutput — no tool sidecar.
+        # The fake_run returns a TurnOutput with delta carrying the phone
+        # extraction as a SlotDelta (kind="phone", data=phone fields).
+        from nikita.agents.onboarding.conversation_agent import TurnOutput
+        from nikita.agents.onboarding.state import SlotDelta
+
+        phone_delta = SlotDelta(
+            kind="phone",
+            data={"phone_preference": "text", "phone": None, "confidence": 0.97},
+        )
+        phone_turn_output = TurnOutput(
+            delta=phone_delta,
+            reply="all locked in. catch you in telegram.",
         )
 
         async def fake_run(_user_input, *, deps, **_kwargs):
-            deps.extracted.append(phone_extraction)
             return SimpleNamespace(
-                output="all locked in. catch you in telegram.",
+                output=phone_turn_output,
                 usage=lambda: None,
             )
 
@@ -357,14 +365,22 @@ class TestConverseCompletionGate:
         select_result.scalar_one_or_none = MagicMock(return_value=None)
         mock_session.execute = AsyncMock(return_value=select_result)
 
-        identity = IdentityExtraction(
-            name="Simon", age=32, occupation="engineer", confidence=0.97
+        # GH #402/#403: consolidated TurnOutput — no tool sidecar.
+        from nikita.agents.onboarding.conversation_agent import TurnOutput
+        from nikita.agents.onboarding.state import SlotDelta
+
+        identity_delta = SlotDelta(
+            kind="identity",
+            data={"name": "Simon", "age": 32, "occupation": "engineer", "confidence": 0.97},
+        )
+        identity_turn_output = TurnOutput(
+            delta=identity_delta,
+            reply="got it simon, age 32, engineer.",
         )
 
         async def fake_run(_user_input, *, deps, **_kwargs):
-            deps.extracted.append(identity)
             return SimpleNamespace(
-                output="got it simon, age 32, engineer.",
+                output=identity_turn_output,
                 usage=lambda: None,
             )
 
@@ -451,10 +467,16 @@ class TestConverseJsonbPersistence:
         select_result.scalar_one = MagicMock(return_value=user_stub)
         mock_session.execute = AsyncMock(return_value=select_result)
 
-        # Stub agent.run → object with .output (the nikita reply) and
-        # .usage() (None → fallback to ESTIMATED_TURN_COST_USD).
+        # Stub agent.run → TurnOutput (GH #402/#403 consolidated output).
+        # delta=None for a clarification turn (no extraction this turn).
+        from nikita.agents.onboarding.conversation_agent import TurnOutput
+
+        turn_output = TurnOutput(
+            delta=None,
+            reply="let's keep going. what city are you in?",
+        )
         agent_result = SimpleNamespace(
-            output="let's keep going. what city are you in?",
+            output=turn_output,
             usage=lambda: None,
         )
         mock_agent = MagicMock()


### PR DESCRIPTION
## Summary

- Replaces 7 \`@agent.tool\` registrations with a single \`TurnOutput\` wrapper schema as \`output_type=TurnOutput\` (AC-11d.5 path a)
- Adds \`Math.max(state.progressPct, response.progress_pct)\` monotonicity guard in the FE reducer (\`useConversationState.ts\`)
- Adds 10 FE vitest tests for the monotonicity guard and 20 backend behavioral tests for the consolidated agent

## Root cause (Walk W, 2026-04-23)

Walk W live evidence proved that 7-tool registration causes LLM tool-selection bias: the model kept emitting \`IdentityExtraction\` for phone and darkness inputs regardless of input content. The dynamic-instructions fix (PR-B path b) was insufficient because bias operates before the system-prompt context is fully applied — the LLM must still pick among 7 tools.

With \`output_type=TurnOutput\`, there is no tool selection. The LLM fills a single structured schema (\`delta: SlotDelta | None\` + \`reply: str\`), and Pydantic validates the \`SlotDelta.kind\` discriminator structurally.

## Changed files

| File | Change |
|---|---|
| \`nikita/agents/onboarding/conversation_agent.py\` | Remove 7 \`@agent.tool\` registrations; add \`TurnOutput\` wrapper schema; update \`ConverseDeps\` (remove \`extracted\` sidecar); update \`output_validator\` to apply delta to cumulative state |
| \`nikita/api/routes/portal_onboarding.py\` | Unpack \`result.output\` as \`TurnOutput\`; update \`_needs_confirmation\` to accept \`SlotDelta | None\` |
| \`portal/src/app/onboarding/hooks/useConversationState.ts\` | \`progressPct: Math.max(state.progressPct, response.progress_pct)\` |
| \`tests/agents/onboarding/test_conversation_agent_consolidated.py\` | NEW — 20 behavioral tests (TurnOutput shape, no tool registrations, cumulative state, agentic-flow mandatory test classes) |
| \`tests/agents/onboarding/test_conversation_agent.py\` | Update: replace 7-tool structure assertions with schema-level assertions |
| \`tests/api/routes/test_converse_endpoint.py\` | Update: fake_run returns \`TurnOutput(delta=..., reply=...)\` |
| \`portal/src/__tests__/onboarding/useConversationState.test.ts\` | NEW — 10 FE tests covering AC-11d.5 monotonicity guard |

## Spec reference

- Spec 214 FR-11d AC-11d.5 (monotonicity guard) path (a)
- \`.claude/rules/agentic-design-patterns.md\` Hard Rule §3 (tool consolidation)

## Local tests

**Python suite (full):**
```
uv run pytest -q
6649 passed, 2 skipped, 184 deselected, 3 xpassed in 149.23s
```

**Python suite (scoped):**
```
uv run pytest tests/agents/onboarding/ tests/api/routes/test_converse_endpoint.py -q
205 passed, 2 skipped in 1.96s
```

**Portal vitest (FE monotonicity tests):**
```
vitest run src/__tests__/onboarding/useConversationState.test.ts
10 passed in 688ms
```

**Portal ESLint:**
```
eslint src/ — 0 errors, 2 warnings (pre-existing in HandoffStep.tsx, not in scope)
```

**Portal TypeScript:**
```
tsc --noEmit — 0 errors in useConversationState.ts
Pre-existing: ChatShell.tsx — react-virtuoso not installed (introduced on master
by PR #363 before this branch was created). Reproduces on master.
This branch does not touch ChatShell.tsx.
```

**Portal vitest full run:**
```
3 test files fail / 104 pass (all 3 failures are ChatShell import errors from
react-virtuoso, pre-existing on master — not caused by this branch).
693 tests pass / 1 fails (ChatShell).
```

**Portal next build:**
Not run via Turbopack. The worktree has no independent node_modules; Turbopack
rejects symlinked node_modules (\`Symlink node_modules is invalid, it points out
of the filesystem root\`). The single changed portal file (\`useConversationState.ts\`)
was verified via: (a) \`tsc --noEmit\` — 0 type errors, (b) vitest — 10/10 pass,
(c) eslint — 0 errors. The change is a one-line \`Math.max\` guard in a pure
reducer; build risk is negligible.