### PR TITLE
fix(214,406,407): Walk X HIGHs — ModelRetry wedge + DB persistence

### DIFF
--- a/nikita/agents/onboarding/extraction_schemas.py
+++ b/nikita/agents/onboarding/extraction_schemas.py
@@ -152,8 +152,19 @@ class BackstoryExtraction(_ConfidenceMixin):
 class PhoneExtraction(_ConfidenceMixin):
     """Agent emits this when the user has chosen voice or text.
 
-    Voice requires a phone number that parses as E.164 via
-    ``phonenumbers.parse``. Text is valid with ``phone=None``.
+    Per-turn schema: allows voice preference with phone=None so the two-step
+    flow works correctly.  Step 1: user declares 'voice' → LLM emits
+    PhoneExtraction(phone_preference='voice', phone=None).  Step 2: user
+    provides phone number → LLM emits PhoneExtraction(phone_preference='voice',
+    phone='+14155552671').
+
+    The requirement that voice preference MUST have a phone number is enforced
+    at the FinalForm completion gate (state.py FinalForm._voice_requires_phone),
+    NOT here.  Enforcing it here caused the Walk X H1 wedge (GH #406): the
+    preference-only turn triggered retries=4 → UnexpectedModelBehavior →
+    FALLBACK_REPLY, blocking wizard completion.
+
+    Text is valid with phone=None (no phone needed for text-only contact).
     """
 
     kind: Literal["phone"] = "phone"
@@ -197,11 +208,9 @@ class PhoneExtraction(_ConfidenceMixin):
             parsed, phonenumbers.PhoneNumberFormat.E164
         )
 
-    @model_validator(mode="after")
-    def _voice_requires_phone(self) -> "PhoneExtraction":
-        if self.phone_preference == "voice" and not self.phone:
-            raise ValueError("phone_preference='voice' requires a phone number")
-        return self
+    # GH #406 fix: _voice_requires_phone removed from per-turn schema.
+    # Constraint moved to FinalForm._voice_requires_phone (state.py) where
+    # it belongs — completion gate, not per-turn extraction gate.
 
 
 # ---------------------------------------------------------------------------

--- a/nikita/agents/onboarding/state.py
+++ b/nikita/agents/onboarding/state.py
@@ -237,6 +237,22 @@ class FinalForm(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def _voice_requires_phone(self) -> "FinalForm":
+        """At completion, voice preference requires a phone number (GH #406 fix).
+
+        Moved from PhoneExtraction per-turn schema to FinalForm completion gate
+        so the two-step voice flow works: declare preference → provide number.
+        Per-turn validation no longer blocks the preference-only turn.
+        """
+        phone_preference = self.phone.get("phone_preference")
+        phone = self.phone.get("phone")
+        if phone_preference == "voice" and not phone:
+            raise ValueError(
+                "phone_preference='voice' requires a phone number at completion"
+            )
+        return self
+
 
 # ---------------------------------------------------------------------------
 # WizardState — envelope used by the endpoint (slots + messages)

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -1122,16 +1122,17 @@ async def converse(
     # Applied AFTER slot reconstruction + fallback, BEFORE the completion gate.
     if extracted_delta is not None and extracted_delta.kind == "identity":
         from nikita.db.repositories.profile_repository import ProfileRepository  # local per module policy
-        _profile_repo = ProfileRepository(session)
+        profile_repo = ProfileRepository(session)
         try:
-            await _profile_repo.upsert_identity_slots(
+            await profile_repo.upsert_identity_slots(
                 user_id=current_user.id,
                 name=extracted_delta.data.get("name"),
                 age=extracted_delta.data.get("age"),
                 occupation=extracted_delta.data.get("occupation"),
             )
         except Exception:  # pragma: no cover — defensive; slot still committed to JSONB
-            logger.warning(
+            # logger.exception captures stack trace so failures surface in Cloud Run.
+            logger.exception(
                 "converse_identity_upsert_failed user_id=%s",
                 current_user.id,
             )

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -1121,6 +1121,8 @@ async def converse(
     # extractions (name-only) do not overwrite existing age/occupation with None.
     # Applied AFTER slot reconstruction + fallback, BEFORE the completion gate.
     if extracted_delta is not None and extracted_delta.kind == "identity":
+        from sqlalchemy.exc import SQLAlchemyError  # local per module policy
+
         from nikita.db.repositories.profile_repository import ProfileRepository  # local per module policy
         profile_repo = ProfileRepository(session)
         try:
@@ -1130,8 +1132,9 @@ async def converse(
                 age=extracted_delta.data.get("age"),
                 occupation=extracted_delta.data.get("occupation"),
             )
-        except Exception:  # pragma: no cover — defensive; slot still committed to JSONB
-            # logger.exception captures stack trace so failures surface in Cloud Run.
+        except SQLAlchemyError:  # pragma: no cover — defensive; slot still committed to JSONB
+            # Narrow to DB errors so programmer errors (TypeError, AttributeError)
+            # still fail loudly in dev/test. logger.exception captures stack trace.
             logger.exception(
                 "converse_identity_upsert_failed user_id=%s",
                 current_user.id,

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -1114,6 +1114,28 @@ async def converse(
         slots_after = slots_after.apply(_fallback_delta)
         logger.info("converse_regex_phone_fallback_applied user_id=%s", current_user.id)
 
+    # GH #407 fix: write-through identity slots to user_profiles structured columns.
+    # Triggered whenever the current turn extracted an identity delta (or the
+    # regex fallback provided one).  Only non-None fields are written so partial
+    # extractions (name-only) do not overwrite existing age/occupation with None.
+    # Applied AFTER slot reconstruction + fallback, BEFORE the completion gate.
+    _identity_slot = slots_after.identity
+    if _identity_slot is not None:
+        from nikita.db.repositories.profile_repository import ProfileRepository  # local per module policy
+        _profile_repo = ProfileRepository(session)
+        try:
+            await _profile_repo.upsert_identity_slots(
+                user_id=current_user.id,
+                name=_identity_slot.get("name"),
+                age=_identity_slot.get("age"),
+                occupation=_identity_slot.get("occupation"),
+            )
+        except Exception:  # pragma: no cover — defensive; slot still committed to JSONB
+            logger.warning(
+                "converse_identity_upsert_failed user_id=%s",
+                current_user.id,
+            )
+
     progress_pct = slots_after.progress_pct
 
     conversation_complete = slots_after.is_complete

--- a/nikita/api/routes/portal_onboarding.py
+++ b/nikita/api/routes/portal_onboarding.py
@@ -1115,20 +1115,20 @@ async def converse(
         logger.info("converse_regex_phone_fallback_applied user_id=%s", current_user.id)
 
     # GH #407 fix: write-through identity slots to user_profiles structured columns.
-    # Triggered whenever the current turn extracted an identity delta (or the
-    # regex fallback provided one).  Only non-None fields are written so partial
+    # Triggered on the CURRENT TURN's delta only (not cumulative state) so the
+    # upsert fires exactly once per identity extraction, not on every subsequent
+    # turn after identity is set.  Only non-None fields are written so partial
     # extractions (name-only) do not overwrite existing age/occupation with None.
     # Applied AFTER slot reconstruction + fallback, BEFORE the completion gate.
-    _identity_slot = slots_after.identity
-    if _identity_slot is not None:
+    if extracted_delta is not None and extracted_delta.kind == "identity":
         from nikita.db.repositories.profile_repository import ProfileRepository  # local per module policy
         _profile_repo = ProfileRepository(session)
         try:
             await _profile_repo.upsert_identity_slots(
                 user_id=current_user.id,
-                name=_identity_slot.get("name"),
-                age=_identity_slot.get("age"),
-                occupation=_identity_slot.get("occupation"),
+                name=extracted_delta.data.get("name"),
+                age=extracted_delta.data.get("age"),
+                occupation=extracted_delta.data.get("occupation"),
             )
         except Exception:  # pragma: no cover — defensive; slot still committed to JSONB
             logger.warning(

--- a/nikita/db/repositories/profile_repository.py
+++ b/nikita/db/repositories/profile_repository.py
@@ -196,8 +196,9 @@ class ProfileRepository(BaseRepository[UserProfile]):
         if occupation is not None:
             profile.occupation = occupation
 
-        await self.session.flush()
-        return profile
+        # Use BaseRepository.update() for consistency with update_from_onboarding
+        # and other profile mutators in this module.
+        return await self.update(profile)
 
 
 class BackstoryRepository(BaseRepository[UserBackstory]):

--- a/nikita/db/repositories/profile_repository.py
+++ b/nikita/db/repositories/profile_repository.py
@@ -138,6 +138,53 @@ class ProfileRepository(BaseRepository[UserProfile]):
 
         return await self.update(profile)
 
+    async def upsert_identity_slots(
+        self,
+        user_id: UUID,
+        name: str | None = None,
+        age: int | None = None,
+        occupation: str | None = None,
+    ) -> UserProfile:
+        """Write identity slots (name, age, occupation) to user_profiles.
+
+        GH #407 fix: write-through from WizardSlots identity slot to the
+        structured columns added in Spec 213 PR 213-2 (FR-1b).
+
+        Only writes fields that are non-None — partial identity extractions
+        (e.g. name-only) must not overwrite existing age/occupation with None.
+
+        Upserts: creates the profile row if it does not exist; updates
+        identity columns on an existing row. Other profile fields (location,
+        social_scene, etc.) are NOT touched by this method.
+
+        Args:
+            user_id: The user's UUID (user_profiles.id FK).
+            name: User's name (nullable, max 100 chars).
+            age: User's age (nullable, 18-99 per CHECK constraint).
+            occupation: User's occupation (nullable, max 100 chars).
+
+        Returns:
+            The updated (or newly created) UserProfile entity.
+        """
+        profile = await self.get_by_user_id(user_id)
+        if profile is None:
+            profile = await self.create_profile(
+                user_id=user_id,
+                # Only set the identity fields; leave all others at defaults.
+            )
+
+        # Only write fields that are explicitly provided (non-None).
+        # This preserves existing values for partial extraction turns.
+        if name is not None:
+            profile.name = name
+        if age is not None:
+            profile.age = age
+        if occupation is not None:
+            profile.occupation = occupation
+
+        await self.session.flush()
+        return profile
+
 
 class BackstoryRepository(BaseRepository[UserBackstory]):
     """Repository for UserBackstory operations.

--- a/nikita/db/repositories/profile_repository.py
+++ b/nikita/db/repositories/profile_repository.py
@@ -67,6 +67,9 @@ class ProfileRepository(BaseRepository[UserProfile]):
         social_scene: str | None = None,
         primary_interest: str | None = None,
         drug_tolerance: int = 3,
+        name: str | None = None,
+        age: int | None = None,
+        occupation: str | None = None,
     ) -> UserProfile:
         """Create a new user profile.
 
@@ -78,6 +81,9 @@ class ProfileRepository(BaseRepository[UserProfile]):
             social_scene: Social scene preference (e.g., "techno", "art").
             primary_interest: Main hobby/interest.
             drug_tolerance: Content intensity 1-5 (default 3).
+            name: User's name (nullable, max 100 chars).
+            age: User's age (nullable, 18-99 per CHECK constraint).
+            occupation: User's occupation (nullable, max 100 chars).
 
         Returns:
             Created UserProfile entity.
@@ -90,6 +96,9 @@ class ProfileRepository(BaseRepository[UserProfile]):
             social_scene=social_scene,
             primary_interest=primary_interest,
             drug_tolerance=drug_tolerance,
+            name=name,
+            age=age,
+            occupation=occupation,
         )
         return await self.create(profile)
 
@@ -168,10 +177,15 @@ class ProfileRepository(BaseRepository[UserProfile]):
         """
         profile = await self.get_by_user_id(user_id)
         if profile is None:
+            # Pass identity fields directly into create_profile so the row is
+            # populated at insert time (no reliance on dirty-tracking after).
             profile = await self.create_profile(
                 user_id=user_id,
-                # Only set the identity fields; leave all others at defaults.
+                name=name,
+                age=age,
+                occupation=occupation,
             )
+            return profile
 
         # Only write fields that are explicitly provided (non-None).
         # This preserves existing values for partial extraction turns.

--- a/tests/agents/onboarding/test_extraction_schemas.py
+++ b/tests/agents/onboarding/test_extraction_schemas.py
@@ -97,9 +97,18 @@ class TestPhoneValidation:
                 confidence=0.95,
             )
 
-    def test_phone_missing_on_voice_rejected(self):
-        with pytest.raises(ValidationError):
-            PhoneExtraction(phone_preference="voice", confidence=0.95)
+    def test_phone_missing_on_voice_allowed_at_extraction_level(self):
+        """GH #406 fix: voice+no-phone is now VALID at per-turn extraction level.
+
+        The two-step flow requires it: user declares 'voice' on the preference
+        turn (phone=None), then provides the number on the next turn.
+        The voice-requires-phone constraint moved to FinalForm (state.py)
+        where it belongs — completion gate, not per-turn extraction gate.
+        """
+        # Must NOT raise ValidationError after GH #406 fix.
+        model = PhoneExtraction(phone_preference="voice", confidence=0.95)
+        assert model.phone_preference == "voice"
+        assert model.phone is None
 
     def test_phone_text_no_phone_valid(self):
         model = PhoneExtraction(phone_preference="text", confidence=0.95)

--- a/tests/agents/onboarding/test_walkx_h1.py
+++ b/tests/agents/onboarding/test_walkx_h1.py
@@ -1,0 +1,158 @@
+"""Walk X H1 regression tests — GH #406.
+
+Bug: contact_preference="voice" input on turn 5 triggers unrecoverable wedge.
+Root cause: PhoneExtraction._voice_requires_phone model_validator requires
+phone when phone_preference="voice", even on a preference-only turn before
+the user has provided their phone number.  LLM emits
+PhoneExtraction(phone_preference="voice", phone=None) -> Pydantic internal
+ValidationError -> retries=4 exhausted -> UnexpectedModelBehavior ->
+FALLBACK_REPLY ("hold on, let me try that again.") -> wizard wedged.
+
+Fix direction: relax PhoneExtraction to allow phone_preference="voice" with
+phone=None.  The phone-number requirement must only fire at the FinalForm
+completion gate (state.py), not at the per-turn extraction schema level.
+
+TDD: T1 tests written BEFORE implementation (RED phase).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from nikita.agents.onboarding.extraction_schemas import PhoneExtraction
+
+
+# ---------------------------------------------------------------------------
+# T1-A: PhoneExtraction allows voice preference with no phone (per-turn turn)
+# ---------------------------------------------------------------------------
+
+
+class TestPhoneExtractionVoicePreference:
+    """PhoneExtraction schema must NOT require phone on preference-only turns.
+
+    The schema is used per-turn: when the user says 'voice', the LLM emits
+    PhoneExtraction(phone_preference='voice', phone=None).  This is a valid
+    two-step flow: first the user declares preference, then provides the number.
+
+    The FinalForm completion gate (state.py) is responsible for requiring phone
+    when preference is 'voice' — not the per-turn extraction schema.
+    """
+
+    def test_voice_preference_with_no_phone_is_valid(self):
+        """T1-A-1: PhoneExtraction(phone_preference='voice', phone=None)
+        must validate successfully.
+
+        This test FAILS on master (before fix) because _voice_requires_phone
+        model_validator raises ValueError when phone is None.
+        """
+        # This should NOT raise ValidationError after the fix.
+        extraction = PhoneExtraction(phone_preference="voice", phone=None, confidence=0.9)
+        assert extraction.phone_preference == "voice"
+        assert extraction.phone is None
+
+    def test_text_preference_with_no_phone_is_valid(self):
+        """T1-A-2: text preference with no phone is valid (unchanged behavior)."""
+        extraction = PhoneExtraction(phone_preference="text", phone=None, confidence=0.9)
+        assert extraction.phone_preference == "text"
+        assert extraction.phone is None
+
+    def test_voice_preference_with_phone_is_valid(self):
+        """T1-A-3: voice + phone provided is valid (unchanged behavior)."""
+        extraction = PhoneExtraction(
+            phone_preference="voice",
+            phone="+14155552671",
+            confidence=0.9,
+        )
+        assert extraction.phone_preference == "voice"
+        assert extraction.phone == "+14155552671"
+
+    def test_text_preference_with_phone_still_valid(self):
+        """T1-A-4: text + phone is valid edge case (user changed mind, no harm)."""
+        extraction = PhoneExtraction(
+            phone_preference="text",
+            phone="+14155552671",
+            confidence=0.9,
+        )
+        assert extraction.phone_preference == "text"
+        assert extraction.phone == "+14155552671"
+
+    def test_invalid_phone_format_still_rejected(self):
+        """T1-A-5: E.164 format validation on phone field is unchanged.
+
+        The fix must NOT remove the E.164 validator on the phone field itself.
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            PhoneExtraction(phone_preference="voice", phone="not-a-phone", confidence=0.9)
+        errors = exc_info.value.errors()
+        assert any("phone" in str(err["loc"]) for err in errors)
+
+    def test_voice_preference_confidence_bounds_preserved(self):
+        """T1-A-6: confidence validation unaffected by the fix."""
+        with pytest.raises(ValidationError):
+            PhoneExtraction(phone_preference="voice", phone=None, confidence=1.5)
+        with pytest.raises(ValidationError):
+            PhoneExtraction(phone_preference="voice", phone=None, confidence=-0.1)
+
+
+# ---------------------------------------------------------------------------
+# T1-B: FinalForm still requires phone when voice preference is declared
+# ---------------------------------------------------------------------------
+
+
+class TestFinalFormVoiceRequiresPhone:
+    """FinalForm completion gate must still enforce voice->phone requirement.
+
+    After relaxing PhoneExtraction, the phone requirement for voice must
+    be enforced at the FinalForm level (state.py), not at the extraction level.
+    """
+
+    def test_final_form_rejects_voice_with_no_phone(self):
+        """T1-B-1: FinalForm.model_validate() raises if voice+no-phone.
+
+        This verifies the constraint moved from extraction schema to FinalForm.
+        """
+        from nikita.agents.onboarding.state import FinalForm
+
+        with pytest.raises(ValidationError) as exc_info:
+            FinalForm.model_validate({
+                "location": {"city": "Berlin", "confidence": 0.9},
+                "scene": {"scene": "techno", "confidence": 0.9},
+                "darkness": {"drug_tolerance": 3, "confidence": 0.9},
+                "identity": {"name": "Max", "age": 28, "occupation": "designer", "confidence": 0.9},
+                "backstory": {"chosen_option_id": "aabbccddeeff", "cache_key": "berlin-techno", "confidence": 0.9},
+                "phone": {"phone_preference": "voice", "phone": None, "confidence": 0.9},
+            })
+        # ValidationError must reference phone/voice constraint
+        errors = exc_info.value.errors()
+        error_msgs = " ".join(str(e) for e in errors)
+        assert "voice" in error_msgs.lower() or "phone" in error_msgs.lower()
+
+    def test_final_form_accepts_voice_with_phone(self):
+        """T1-B-2: FinalForm.model_validate() succeeds if voice+phone provided."""
+        from nikita.agents.onboarding.state import FinalForm
+
+        form = FinalForm.model_validate({
+            "location": {"city": "Berlin", "confidence": 0.9},
+            "scene": {"scene": "techno", "confidence": 0.9},
+            "darkness": {"drug_tolerance": 3, "confidence": 0.9},
+            "identity": {"name": "Max", "age": 28, "occupation": "designer", "confidence": 0.9},
+            "backstory": {"chosen_option_id": "aabbccddeeff", "cache_key": "berlin-techno", "confidence": 0.9},
+            "phone": {"phone_preference": "voice", "phone": "+14155552671", "confidence": 0.9},
+        })
+        assert form.phone["phone_preference"] == "voice"
+        assert form.phone["phone"] == "+14155552671"
+
+    def test_final_form_accepts_text_with_no_phone(self):
+        """T1-B-3: FinalForm.model_validate() succeeds if text+no-phone."""
+        from nikita.agents.onboarding.state import FinalForm
+
+        form = FinalForm.model_validate({
+            "location": {"city": "Berlin", "confidence": 0.9},
+            "scene": {"scene": "techno", "confidence": 0.9},
+            "darkness": {"drug_tolerance": 3, "confidence": 0.9},
+            "identity": {"name": "Max", "age": 28, "occupation": "designer", "confidence": 0.9},
+            "backstory": {"chosen_option_id": "aabbccddeeff", "cache_key": "berlin-techno", "confidence": 0.9},
+            "phone": {"phone_preference": "text", "phone": None, "confidence": 0.9},
+        })
+        assert form.phone["phone_preference"] == "text"

--- a/tests/agents/onboarding/test_wizard_state.py
+++ b/tests/agents/onboarding/test_wizard_state.py
@@ -307,6 +307,62 @@ class TestFinalForm:
             complete = False
         assert complete is True
 
+    # ---------------------------------------------------------------------
+    # GH #406: voice-requires-phone moved from PhoneExtraction (per-turn)
+    # to FinalForm (completion gate) — eliminates the ModelRetry wedge.
+    # Triplet: voice+None → reject; voice+E.164 → accept; text+None → accept.
+    # ---------------------------------------------------------------------
+    def test_final_form_rejects_voice_preference_without_phone(self):
+        """Voice preference at the completion gate REQUIRES a phone number."""
+        FinalForm, _, _, _ = _import_state()
+        raw = {
+            "location": {"city": "Berlin"},
+            "scene": {"scene": "techno"},
+            "darkness": {"drug_tolerance": 3},
+            "identity": {"name": "Sam", "age": 28, "occupation": "artist"},
+            "backstory": {
+                "chosen_option_id": "aabbccddeeff",
+                "cache_key": "berlin|techno|3",
+            },
+            "phone": {"phone_preference": "voice", "phone": None},
+        }
+        with pytest.raises(ValidationError):
+            FinalForm.model_validate(raw)
+
+    def test_final_form_accepts_voice_preference_with_e164_phone(self):
+        """Voice preference + valid E.164 phone passes the completion gate."""
+        FinalForm, _, _, _ = _import_state()
+        raw = {
+            "location": {"city": "Berlin"},
+            "scene": {"scene": "techno"},
+            "darkness": {"drug_tolerance": 3},
+            "identity": {"name": "Sam", "age": 28, "occupation": "artist"},
+            "backstory": {
+                "chosen_option_id": "aabbccddeeff",
+                "cache_key": "berlin|techno|3",
+            },
+            "phone": {"phone_preference": "voice", "phone": "+14155550234"},
+        }
+        form = FinalForm.model_validate(raw)
+        assert form is not None
+
+    def test_final_form_accepts_text_preference_without_phone(self):
+        """Text preference does NOT require a phone — gate accepts None."""
+        FinalForm, _, _, _ = _import_state()
+        raw = {
+            "location": {"city": "Berlin"},
+            "scene": {"scene": "techno"},
+            "darkness": {"drug_tolerance": 3},
+            "identity": {"name": "Sam", "age": 28, "occupation": "artist"},
+            "backstory": {
+                "chosen_option_id": "aabbccddeeff",
+                "cache_key": "berlin|techno|3",
+            },
+            "phone": {"phone_preference": "text", "phone": None},
+        }
+        form = FinalForm.model_validate(raw)
+        assert form is not None
+
     def test_age_under_18_is_rejected_by_final_form(self):
         """FinalForm must enforce age >= 18 (AC-11d.9 cross-field validation)."""
         FinalForm, SlotDelta, _, WizardSlots = _import_state()

--- a/tests/api/routes/test_walkx_h2.py
+++ b/tests/api/routes/test_walkx_h2.py
@@ -1,0 +1,354 @@
+"""Walk X H2 regression tests — GH #407.
+
+Bug: identity slots (name, age, occupation) are NOT persisted to
+user_profiles structured columns after the LLM emits an IdentityExtraction.
+The cumulative WizardSlots in-memory state is correct, but the write-through
+to user_profiles.name / user_profiles.age / user_profiles.occupation was
+dropped during the PR #405 consolidation refactor.
+
+Fix direction: after slots_after = slots_after.apply(_fallback_delta) (line ~1114
+in portal_onboarding.py), call ProfileRepository.upsert_identity_slots() if
+the identity slot is newly filled.
+
+TDD: T3 tests written BEFORE implementation (RED phase).
+
+PII policy (per .claude/rules/testing.md): assertions reference field names
+and boolean flags only; actual name/age/occupation values are synthetic test
+data in fixtures only, not in log-line format strings or assertion messages.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call, patch
+from uuid import uuid4
+
+import pytest
+
+
+USER_ID = uuid4()
+
+
+def _make_user_stub(onboarding_profile: dict | None = None) -> SimpleNamespace:
+    """Build a minimal user stub with mutable onboarding_profile dict."""
+    return SimpleNamespace(
+        id=USER_ID,
+        onboarding_profile=onboarding_profile if onboarding_profile is not None else None,
+    )
+
+
+def _make_session_returning(user_stub: SimpleNamespace) -> AsyncMock:
+    """Build an AsyncMock session returning user_stub from any SELECT."""
+    mock_session = AsyncMock()
+    select_result = MagicMock()
+    select_result.scalar_one = MagicMock(return_value=user_stub)
+    mock_session.execute = AsyncMock(return_value=select_result)
+    return mock_session
+
+
+def _make_turn_output_with_identity() -> object:
+    """Build a TurnOutput whose delta is an identity SlotDelta."""
+    from nikita.agents.onboarding.conversation_agent import TurnOutput
+    from nikita.agents.onboarding.state import SlotDelta
+
+    delta = SlotDelta(
+        kind="identity",
+        data={"name": "Max", "age": 28, "occupation": "designer", "confidence": 0.9},
+    )
+    return TurnOutput(
+        delta=delta,
+        reply="Nice to meet you, Max! What kind of social scene are you into?",
+    )
+
+
+def _make_agent_result(turn_output: object) -> object:
+    return SimpleNamespace(output=turn_output, usage=lambda: None)
+
+
+# ---------------------------------------------------------------------------
+# T3: POST /converse — identity slot writes to user_profiles structured columns
+# ---------------------------------------------------------------------------
+
+
+class TestConverseIdentitySlotPersistence:
+    """H2 regression: identity delta must trigger ProfileRepository.upsert_identity_slots().
+
+    After the fix, when TurnOutput.delta.kind == 'identity', the handler
+    must call upsert_identity_slots(user_id, name, age, occupation) exactly
+    once with the values from the slot data.
+    """
+
+    @pytest.mark.asyncio
+    async def test_identity_delta_calls_upsert_identity_slots(self):
+        """T3-A: When agent emits identity SlotDelta, ProfileRepository
+        upsert_identity_slots() is called exactly once with correct args.
+
+        This test FAILS on master because upsert_identity_slots() does not
+        exist on ProfileRepository and the handler never calls it.
+        """
+        from nikita.api.dependencies.auth import AuthenticatedUser
+        from nikita.api.routes.portal_onboarding import converse
+        from nikita.agents.onboarding.converse_contracts import ConverseRequest
+
+        user_stub = _make_user_stub()
+        mock_session = _make_session_returning(user_stub)
+        turn_output = _make_turn_output_with_identity()
+        agent_result = _make_agent_result(turn_output)
+
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(return_value=agent_result)
+        auth_user = AuthenticatedUser(id=USER_ID, email="test@example.com")
+
+        req = ConverseRequest(
+            conversation_history=[],
+            user_input="I'm Max, 28, and I work as a designer",
+        )
+
+        mock_profile_repo = AsyncMock()
+        mock_profile_repo.upsert_identity_slots = AsyncMock(return_value=None)
+
+        with patch(
+            "nikita.api.routes.portal_onboarding.get_conversation_agent",
+            return_value=mock_agent,
+        ), patch(
+            "nikita.api.routes.portal_onboarding.IdempotencyStore"
+        ) as mock_idem_cls, patch(
+            "nikita.api.routes.portal_onboarding.LLMSpendLedger"
+        ) as mock_ledger_cls, patch(
+            "nikita.api.routes.portal_onboarding.ProfileRepository",
+        ) as mock_profile_repo_cls:
+            mock_idem = MagicMock()
+            mock_idem.get = AsyncMock(return_value=None)
+            mock_idem.put = AsyncMock(return_value=None)
+            mock_idem_cls.return_value = mock_idem
+
+            mock_ledger = MagicMock()
+            mock_ledger.get_today = AsyncMock(return_value=0)
+            mock_ledger.add_spend = AsyncMock(return_value=None)
+            mock_ledger_cls.return_value = mock_ledger
+
+            mock_profile_repo_cls.return_value = mock_profile_repo
+
+            response = await converse(
+                req=req,
+                current_user=auth_user,
+                session=mock_session,
+                _rate_limit=None,
+                idempotency_key_header=None,
+            )
+
+        from nikita.agents.onboarding.converse_contracts import ConverseResponse
+        assert isinstance(response, ConverseResponse), (
+            f"expected ConverseResponse, got {type(response).__name__}"
+        )
+        # ProfileRepository must have been instantiated with the session.
+        mock_profile_repo_cls.assert_called_once_with(mock_session)
+        # upsert_identity_slots must have been awaited exactly once.
+        mock_profile_repo.upsert_identity_slots.assert_awaited_once()
+        # The call must include user_id and the identity fields.
+        call_kwargs = mock_profile_repo.upsert_identity_slots.call_args
+        assert call_kwargs is not None, "upsert_identity_slots was not called"
+        args, kwargs = call_kwargs
+        # First positional arg (or kwarg user_id) must be USER_ID
+        all_args = {**kwargs}
+        if args:
+            all_args["user_id"] = args[0] if len(args) > 0 else kwargs.get("user_id")
+        assert all_args.get("user_id") == USER_ID or (args and args[0] == USER_ID), (
+            "upsert_identity_slots called with wrong user_id"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_identity_delta_does_not_call_upsert_identity_slots(self):
+        """T3-B: When agent emits a non-identity delta, upsert_identity_slots
+        is NOT called (no spurious writes on every turn).
+        """
+        from nikita.api.dependencies.auth import AuthenticatedUser
+        from nikita.api.routes.portal_onboarding import converse
+        from nikita.agents.onboarding.converse_contracts import ConverseRequest
+        from nikita.agents.onboarding.conversation_agent import TurnOutput
+        from nikita.agents.onboarding.state import SlotDelta
+
+        # Location delta (not identity)
+        location_delta = SlotDelta(
+            kind="location",
+            data={"city": "Berlin", "confidence": 0.9},
+        )
+        turn_output = TurnOutput(
+            delta=location_delta,
+            reply="Berlin! A city with real character. What kind of scene are you into?",
+        )
+        agent_result = _make_agent_result(turn_output)
+
+        user_stub = _make_user_stub()
+        mock_session = _make_session_returning(user_stub)
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(return_value=agent_result)
+        auth_user = AuthenticatedUser(id=USER_ID, email="test@example.com")
+
+        req = ConverseRequest(
+            conversation_history=[],
+            user_input="I'm based in Berlin",
+        )
+
+        mock_profile_repo = AsyncMock()
+        mock_profile_repo.upsert_identity_slots = AsyncMock(return_value=None)
+
+        with patch(
+            "nikita.api.routes.portal_onboarding.get_conversation_agent",
+            return_value=mock_agent,
+        ), patch(
+            "nikita.api.routes.portal_onboarding.IdempotencyStore"
+        ) as mock_idem_cls, patch(
+            "nikita.api.routes.portal_onboarding.LLMSpendLedger"
+        ) as mock_ledger_cls, patch(
+            "nikita.api.routes.portal_onboarding.ProfileRepository",
+        ) as mock_profile_repo_cls:
+            mock_idem = MagicMock()
+            mock_idem.get = AsyncMock(return_value=None)
+            mock_idem.put = AsyncMock(return_value=None)
+            mock_idem_cls.return_value = mock_idem
+
+            mock_ledger = MagicMock()
+            mock_ledger.get_today = AsyncMock(return_value=0)
+            mock_ledger.add_spend = AsyncMock(return_value=None)
+            mock_ledger_cls.return_value = mock_ledger
+
+            mock_profile_repo_cls.return_value = mock_profile_repo
+
+            response = await converse(
+                req=req,
+                current_user=auth_user,
+                session=mock_session,
+                _rate_limit=None,
+                idempotency_key_header=None,
+            )
+
+        from nikita.agents.onboarding.converse_contracts import ConverseResponse
+        assert isinstance(response, ConverseResponse)
+        # upsert_identity_slots must NOT have been called for a location turn
+        mock_profile_repo.upsert_identity_slots.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# T3-C: ProfileRepository.upsert_identity_slots() unit test
+# ---------------------------------------------------------------------------
+
+
+class TestProfileRepositoryUpsertIdentitySlots:
+    """upsert_identity_slots() must write name, age, occupation to user_profiles.
+
+    Tests the repository method in isolation — no endpoint wiring.
+    The method must exist on ProfileRepository and correctly invoke the
+    SQLAlchemy upsert pattern for the user_profiles table.
+    """
+
+    def test_upsert_identity_slots_method_exists(self):
+        """T3-C-1: ProfileRepository has upsert_identity_slots method.
+
+        Fails on master because the method does not exist.
+        """
+        from nikita.db.repositories.profile_repository import ProfileRepository
+
+        assert hasattr(ProfileRepository, "upsert_identity_slots"), (
+            "ProfileRepository must have upsert_identity_slots method (H2 fix)"
+        )
+        method = getattr(ProfileRepository, "upsert_identity_slots")
+        import inspect
+        assert inspect.iscoroutinefunction(method), (
+            "upsert_identity_slots must be async"
+        )
+
+    @pytest.mark.asyncio
+    async def test_upsert_identity_slots_writes_name_age_occupation(self):
+        """T3-C-2: upsert_identity_slots(user_id, name, age, occupation)
+        issues a DB write that sets those columns on user_profiles.
+
+        Uses a mock session; asserts session.execute() is called and
+        session.flush() or session.commit() fires.
+        """
+        from nikita.db.repositories.profile_repository import ProfileRepository
+
+        mock_session = AsyncMock()
+        # Simulate get_by_user_id returning an existing profile.
+        existing_profile = MagicMock()
+        existing_profile.name = None
+        existing_profile.age = None
+        existing_profile.occupation = None
+
+        repo = ProfileRepository(mock_session)
+
+        with patch.object(repo, "get_by_user_id", return_value=existing_profile):
+            await repo.upsert_identity_slots(
+                user_id=USER_ID,
+                name="Max",
+                age=28,
+                occupation="designer",
+            )
+
+        # After the upsert, the profile's identity fields must be set.
+        assert existing_profile.name == "Max"
+        assert existing_profile.age == 28
+        assert existing_profile.occupation == "designer"
+        # session.flush() must be called to persist the changes.
+        mock_session.flush.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_upsert_identity_slots_creates_profile_if_missing(self):
+        """T3-C-3: When user_profiles row does not exist, upsert_identity_slots
+        creates the profile with identity fields set.
+        """
+        from nikita.db.repositories.profile_repository import ProfileRepository
+
+        mock_session = AsyncMock()
+        repo = ProfileRepository(mock_session)
+
+        with patch.object(repo, "get_by_user_id", return_value=None), patch.object(
+            repo, "create_profile", new=AsyncMock(return_value=MagicMock())
+        ) as mock_create:
+            await repo.upsert_identity_slots(
+                user_id=USER_ID,
+                name="Lena",
+                age=25,
+                occupation="artist",
+            )
+
+        # create_profile must have been called with the identity fields.
+        mock_create.assert_awaited_once()
+        create_call = mock_create.call_args
+        assert create_call is not None
+        # Should pass user_id positionally or as kwarg
+        all_kw = create_call.kwargs if create_call.kwargs else {}
+        all_pos = list(create_call.args) if create_call.args else []
+        # user_id must appear
+        assert USER_ID in all_pos or all_kw.get("user_id") == USER_ID, (
+            "create_profile must be called with the correct user_id"
+        )
+
+    @pytest.mark.asyncio
+    async def test_upsert_identity_slots_partial_fields_ok(self):
+        """T3-C-4: Partial identity (name only, no age/occupation) is valid.
+        Only the provided fields should be written; None fields left unchanged.
+        """
+        from nikita.db.repositories.profile_repository import ProfileRepository
+
+        mock_session = AsyncMock()
+        existing_profile = MagicMock()
+        existing_profile.name = None
+        existing_profile.age = 30  # pre-existing age must not be overwritten
+        existing_profile.occupation = "engineer"
+
+        repo = ProfileRepository(mock_session)
+
+        with patch.object(repo, "get_by_user_id", return_value=existing_profile):
+            await repo.upsert_identity_slots(
+                user_id=USER_ID,
+                name="Sam",
+                age=None,
+                occupation=None,
+            )
+
+        assert existing_profile.name == "Sam"
+        # age and occupation should remain unchanged (not overwritten with None)
+        assert existing_profile.age == 30
+        assert existing_profile.occupation == "engineer"
+        mock_session.flush.assert_awaited()

--- a/tests/api/routes/test_walkx_h2.py
+++ b/tests/api/routes/test_walkx_h2.py
@@ -38,11 +38,26 @@ def _make_user_stub(onboarding_profile: dict | None = None) -> SimpleNamespace:
 
 
 def _make_session_returning(user_stub: SimpleNamespace) -> AsyncMock:
-    """Build an AsyncMock session returning user_stub from any SELECT."""
+    """Build an AsyncMock session returning user_stub from any SELECT.
+
+    Wires session.execute() to return a result that supports:
+    - scalar_one() — used by append_conversation_turn (SELECT FOR UPDATE)
+    - unique().scalar_one_or_none() — used by UserRepository.get()
+
+    Both paths need to return user_stub so the full handler flow works.
+    """
     mock_session = AsyncMock()
+
+    unique_result = MagicMock()
+    unique_result.scalar_one_or_none = MagicMock(return_value=user_stub)
+
     select_result = MagicMock()
     select_result.scalar_one = MagicMock(return_value=user_stub)
+    select_result.scalar_one_or_none = MagicMock(return_value=user_stub)
+    select_result.unique = MagicMock(return_value=unique_result)
+
     mock_session.execute = AsyncMock(return_value=select_result)
+    mock_session.get = AsyncMock(return_value=user_stub)
     return mock_session
 
 
@@ -115,7 +130,9 @@ class TestConverseIdentitySlotPersistence:
         ) as mock_idem_cls, patch(
             "nikita.api.routes.portal_onboarding.LLMSpendLedger"
         ) as mock_ledger_cls, patch(
-            "nikita.api.routes.portal_onboarding.ProfileRepository",
+            # Patch source module per testing.md — local `from X import Y` resolves
+            # through sys.modules at call time; patching the source is correct.
+            "nikita.db.repositories.profile_repository.ProfileRepository",
         ) as mock_profile_repo_cls:
             mock_idem = MagicMock()
             mock_idem.get = AsyncMock(return_value=None)
@@ -201,7 +218,8 @@ class TestConverseIdentitySlotPersistence:
         ) as mock_idem_cls, patch(
             "nikita.api.routes.portal_onboarding.LLMSpendLedger"
         ) as mock_ledger_cls, patch(
-            "nikita.api.routes.portal_onboarding.ProfileRepository",
+            # Patch source module per testing.md.
+            "nikita.db.repositories.profile_repository.ProfileRepository",
         ) as mock_profile_repo_cls:
             mock_idem = MagicMock()
             mock_idem.get = AsyncMock(return_value=None)

--- a/tests/api/routes/test_walkx_h2.py
+++ b/tests/api/routes/test_walkx_h2.py
@@ -160,18 +160,13 @@ class TestConverseIdentitySlotPersistence:
         )
         # ProfileRepository must have been instantiated with the session.
         mock_profile_repo_cls.assert_called_once_with(mock_session)
-        # upsert_identity_slots must have been awaited exactly once.
-        mock_profile_repo.upsert_identity_slots.assert_awaited_once()
-        # The call must include user_id and the identity fields.
-        call_kwargs = mock_profile_repo.upsert_identity_slots.call_args
-        assert call_kwargs is not None, "upsert_identity_slots was not called"
-        args, kwargs = call_kwargs
-        # First positional arg (or kwarg user_id) must be USER_ID
-        all_args = {**kwargs}
-        if args:
-            all_args["user_id"] = args[0] if len(args) > 0 else kwargs.get("user_id")
-        assert all_args.get("user_id") == USER_ID or (args and args[0] == USER_ID), (
-            "upsert_identity_slots called with wrong user_id"
+        # upsert_identity_slots must have been awaited exactly once with the
+        # full identity payload from _make_turn_output_with_identity().
+        mock_profile_repo.upsert_identity_slots.assert_awaited_once_with(
+            user_id=USER_ID,
+            name="Max",
+            age=28,
+            occupation="designer",
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **H1 (GH #406)**: `contact_preference=\"voice\"` on turn 5 caused an unrecoverable wedge. Root cause: `PhoneExtraction._voice_requires_phone` model_validator required `phone` when `phone_preference=\"voice\"`, even on preference-only turns (before the user provides their number). This exhausted `retries=4` → `UnexpectedModelBehavior` → FALLBACK_REPLY → wizard stuck. Fix: remove the constraint from the per-turn extraction schema; move it to `FinalForm._voice_requires_phone` (completion gate only).
- **H2 (GH #407)**: identity slots (name, age, occupation) were never written to `user_profiles` structured columns. The cumulative `WizardSlots` in-memory state was correct, but the write-through to the DB was dropped during the PR #405 consolidation refactor. Fix: add `ProfileRepository.upsert_identity_slots()` + call it in the `/converse` handler after slot reconstruction.

## Files changed

- `nikita/agents/onboarding/extraction_schemas.py` — remove `_voice_requires_phone` from `PhoneExtraction`
- `nikita/agents/onboarding/state.py` — add `FinalForm._voice_requires_phone` validator
- `nikita/db/repositories/profile_repository.py` — add `upsert_identity_slots()`
- `nikita/api/routes/portal_onboarding.py` — call `upsert_identity_slots()` after slot reconstruction
- `tests/agents/onboarding/test_walkx_h1.py` — new: 9 RED→GREEN tests for H1
- `tests/api/routes/test_walkx_h2.py` — new: 6 RED→GREEN tests for H2
- `tests/agents/onboarding/test_extraction_schemas.py` — updated test_phone_missing_on_voice_rejected to reflect new behavior

## Local tests

- `uv run pytest -q` → **6664 passed, 0 failed** (152s)
- Portal: no portal files changed; gate not applicable

## Pre-PR grep gates

- `conversation_complete = (True|False)` literal → 0 matches
- `_compute_progress(extracted_fields)` → 0 matches
- `@agent.tool` in conversation_agent.py → 0 matches

Closes #406
Closes #407