### PR TITLE
fix(db): apply portal_bridge_tokens migration to prod (GH #413)

### DIFF
--- a/supabase/migrations/20260419120000_create_portal_bridge_tokens.sql
+++ b/supabase/migrations/20260419120000_create_portal_bridge_tokens.sql
@@ -43,14 +43,22 @@ CREATE POLICY "admin_and_service_role_only"
 -- while preserving a short audit trail for recently consumed tokens.
 --
 -- Idempotency: a second application of this migration must not fail
--- on duplicate jobname. Safe-delete any prior registration first.
-DELETE FROM cron.job WHERE jobname = 'portal_bridge_tokens_prune';
+-- on duplicate jobname. The Supabase MCP migration applier runs as a
+-- role without DELETE privilege on cron.job, so use the cron.unschedule()
+-- API wrapped in an exception-safe DO block instead of a raw DELETE.
+DO $do_block$
+BEGIN
+    PERFORM cron.unschedule('portal_bridge_tokens_prune');
+EXCEPTION WHEN OTHERS THEN
+    NULL;
+END
+$do_block$;
 
 SELECT cron.schedule(
     'portal_bridge_tokens_prune',
     '0 * * * *',
-    $$
+    $cron$
       DELETE FROM portal_bridge_tokens
        WHERE expires_at < now() - INTERVAL '6 hours';
-    $$
+    $cron$
 );

--- a/supabase/migrations/20260419120000_create_portal_bridge_tokens.sql
+++ b/supabase/migrations/20260419120000_create_portal_bridge_tokens.sql
@@ -41,11 +41,23 @@ CREATE POLICY "admin_and_service_role_only"
 
 -- Hourly prune of expired rows. Keeps the table from growing unbounded
 -- while preserving a short audit trail for recently consumed tokens.
+-- Retention semantics: the prune treats consumed and unconsumed tokens
+-- identically once expires_at has passed; both are removed at expires_at
+-- + 6h. There is no longer-term forensic store for consumed tokens; if
+-- one is ever needed it should land in a separate audit table, not by
+-- relaxing this prune.
 --
 -- Idempotency: a second application of this migration must not fail
 -- on duplicate jobname. The Supabase MCP migration applier runs as a
 -- role without DELETE privilege on cron.job, so use the cron.unschedule()
--- API wrapped in an exception-safe DO block instead of a raw DELETE.
+-- API wrapped in a DO block.
+--
+-- Exception scope: pg_cron does not raise a stable SQLSTATE for "job
+-- name not registered" (the expected first-apply path), so we catch
+-- WHEN OTHERS. The leak is bounded in practice: any latent failure
+-- (missing extension, revoked privilege, schema drift) re-throws on
+-- the immediately following cron.schedule(...) call, which has no
+-- exception handler.
 DO $do_block$
 BEGIN
     PERFORM cron.unschedule('portal_bridge_tokens_prune');


### PR DESCRIPTION
## Summary
- Apply the `portal_bridge_tokens` table to prod Supabase. The migration file shipped on master via PR for FR-11c on 2026-04-19, but the DDL was never applied. Spec 214 FR-11c E5/E6 resume bridges have been silently broken in production since then.
- Discovered by Spec 215 GATE 2 data-layer validator (Plan v17.1 §23 iter-1).
- Adjust cron-job idempotency to use `cron.unschedule()` inside an exception-safe DO block instead of `DELETE FROM cron.job` (the Supabase MCP migration applier role lacks DELETE privilege on `cron.job`; functionally equivalent).

## How applied
- `mcp__supabase__apply_migration` with the (adjusted) migration SQL.
- Then committed the migration file as proof-of-record.

## Verification (live, prod Supabase)
```sql
SELECT
  (SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name='portal_bridge_tokens') AS table_exists,
  (SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename='portal_bridge_tokens') AS policy_count,
  (SELECT count(*) FROM cron.job WHERE jobname='portal_bridge_tokens_prune') AS cron_jobs,
  (SELECT count(*) FROM pg_indexes WHERE schemaname='public' AND tablename='portal_bridge_tokens') AS index_count,
  (SELECT relrowsecurity FROM pg_class WHERE relname='portal_bridge_tokens') AS rls_enabled;
```

Result: `[{"table_exists":1,"policy_count":1,"cron_jobs":1,"index_count":2,"rls_enabled":true}]`

## Local tests
- `uv run pytest -q` -> **6667 passed, 2 skipped, 184 deselected, 3 xpassed** in 167s
- portal not touched -> npm tests not required

## Closes
Closes #413.

## Plan reference
Plan v17.1 §23 GATE 2 iter-1 (data-layer C1) + handover §6 step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)