### PR TITLE
feat(215): PR-F1b — signup_handler FSM + Telegram webhook routing (Telegram-first signup)

### DIFF
--- a/nikita/api/routes/telegram.py
+++ b/nikita/api/routes/telegram.py
@@ -80,6 +80,9 @@ def _is_duplicate_update(update_id: int) -> bool:
         return False
 
 
+from nikita.db.repositories.telegram_signup_session_repository import (
+    TelegramSignupSessionRepository,
+)
 from nikita.platforms.telegram.auth import TelegramAuth
 from nikita.platforms.telegram.bot import TelegramBot
 from nikita.platforms.telegram.commands import CommandHandler
@@ -89,6 +92,7 @@ from nikita.platforms.telegram.models import TelegramUpdate
 from nikita.platforms.telegram.rate_limiter import DatabaseRateLimiter
 from nikita.platforms.telegram.registration_handler import RegistrationHandler
 from nikita.platforms.telegram.otp_handler import OTPVerificationHandler
+from nikita.platforms.telegram.signup_handler import SignupHandler
 
 # Spec 214 FR-11c T1.6: the legacy 8-step Telegram Q&A handler was
 # deleted. Portal wizard owns onboarding. Venue/backstory/persona
@@ -339,6 +343,102 @@ async def get_otp_handler(
 OTPHandlerDep = Annotated[OTPVerificationHandler, Depends(get_otp_handler)]
 
 
+# Spec 215 PR-F1b: signup_handler DI. The handler owns the consolidated
+# Telegram-first signup FSM (FR-2..FR-5) and replaces the
+# registration_handler + otp_handler dispatch path. The legacy handlers
+# remain in-tree for compile compatibility (PR-F3 deletes them).
+async def get_signup_handler(
+    bot: BotDep,
+    user_repo: UserRepoDep,
+    session: AsyncSession = Depends(get_async_session),
+) -> SignupHandler:
+    """Construct SignupHandler with per-request dependencies.
+
+    The admin endpoint is wired by reference (not via HTTP) so the
+    handler can call it inside the same request without re-establishing
+    a service-role session. Per Spec 215 §7.6, the endpoint's
+    service-role guard is bypassed by passing `_auth=None` — this is
+    safe because the handler runs in the same FastAPI process and the
+    caller is already authenticated as the Telegram webhook (HMAC
+    secret-token).
+    """
+    from nikita.api.routes.portal_auth import (
+        generate_magiclink_for_telegram_user,
+    )
+
+    supabase = await get_supabase_client()
+    repo = TelegramSignupSessionRepository(session)
+    return SignupHandler(
+        bot=bot,
+        repo=repo,
+        user_repo=user_repo,
+        supabase_client=supabase,
+        admin_generate_magiclink=generate_magiclink_for_telegram_user,
+    )
+
+
+SignupHandlerDep = Annotated[SignupHandler, Depends(get_signup_handler)]
+
+
+async def _run_signup_with_fresh_session(
+    bot_instance: TelegramBot,
+    flow: str,
+    *,
+    telegram_id: int,
+    chat_id: int,
+    text: str | None = None,
+) -> None:
+    """Run a SignupHandler step with a fresh DB session (background task).
+
+    Background tasks fire AFTER the request session is closed; we open
+    our own AsyncSession to avoid stale connection errors. Mirrors the
+    `_handle_message_with_fresh_session` pattern in this module.
+
+    Args:
+        bot_instance: The shared TelegramBot client.
+        flow: One of "welcome" / "email" / "code" — selects the handler
+            method.
+        telegram_id, chat_id: Telegram identifiers.
+        text: User input (None for welcome flow).
+    """
+    from nikita.api.routes.portal_auth import (
+        generate_magiclink_for_telegram_user,
+    )
+    from nikita.db.repositories.user_repository import UserRepository
+
+    session_maker = get_session_maker()
+    async with session_maker() as session:
+        try:
+            supabase = await get_supabase_client()
+            handler = SignupHandler(
+                bot=bot_instance,
+                repo=TelegramSignupSessionRepository(session),
+                user_repo=UserRepository(session),
+                supabase_client=supabase,
+                admin_generate_magiclink=generate_magiclink_for_telegram_user,
+            )
+            if flow == "welcome":
+                await handler.handle_welcome(
+                    telegram_id=telegram_id, chat_id=chat_id
+                )
+            elif flow == "email":
+                await handler.handle_email(
+                    telegram_id=telegram_id, chat_id=chat_id, text=text or ""
+                )
+            elif flow == "code":
+                await handler.handle_code(
+                    telegram_id=telegram_id, chat_id=chat_id, text=text or ""
+                )
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            logger.exception(
+                "[BG-TASK] SignupHandler.%s crashed (telegram_id=%s)",
+                flow,
+                telegram_id,
+            )
+
+
 # =============================================================================
 # Router Factory
 # =============================================================================
@@ -527,6 +627,37 @@ def create_telegram_router(bot: TelegramBot) -> APIRouter:
             # Spec 214 T4.3 (FR-11e): forward `background_tasks` so the
             # `/start <code>` payload branch can schedule the proactive
             # handoff greeting AFTER the webhook returns 200.
+            #
+            # Spec 215 PR-F1b: intercept `/start welcome` for unbound
+            # telegram_id BEFORE CommandHandler — route directly into the
+            # consolidated signup FSM (FR-2). Bound users fall through to
+            # the existing CommandHandler `/start` welcome-back path.
+            stripped = (text or "").strip()
+            parts = stripped.split(maxsplit=1)
+            payload = parts[1].strip() if len(parts) >= 2 else ""
+            cmd = parts[0].lstrip("/").split("@")[0].lower() if parts else ""
+            if (
+                cmd == "start"
+                and payload == "welcome"
+                and telegram_id is not None
+                and chat_id is not None
+            ):
+                bound = await user_repo.get_by_telegram_id(telegram_id)
+                if bound is None:
+                    logger.info(
+                        "[LLM-DEBUG] Spec 215 PR-F1b: routing /start welcome "
+                        "to SignupHandler (telegram_id=%s)",
+                        telegram_id,
+                    )
+                    background_tasks.add_task(
+                        _run_signup_with_fresh_session,
+                        bot_instance,
+                        "welcome",
+                        telegram_id=telegram_id,
+                        chat_id=chat_id,
+                    )
+                    return WebhookResponse()
+
             logger.info(f"[LLM-DEBUG] Routing to CommandHandler: {text}")
             background_tasks.add_task(
                 command_handler.handle,
@@ -538,11 +669,46 @@ def create_telegram_router(bot: TelegramBot) -> APIRouter:
             chat_id = message.chat.id
             text = message.text.strip()
 
-            # AC-T2.5: Check if user is awaiting OTP code
+            # Spec 215 PR-F1b: SignupHandler dispatch for in-flight FSM rows.
+            # Replaces the legacy registration_handler + otp_handler dispatch.
+            # Legacy files remain in-tree until PR-F3 (additive change).
             pending = await pending_repo.get(telegram_id)
+            if pending is not None:
+                state = pending.signup_state
+                if state == "awaiting_email":
+                    logger.info(
+                        "[LLM-DEBUG] Spec 215 PR-F1b: routing free-text to "
+                        "SignupHandler.handle_email (telegram_id=%s)",
+                        telegram_id,
+                    )
+                    background_tasks.add_task(
+                        _run_signup_with_fresh_session,
+                        bot_instance,
+                        "email",
+                        telegram_id=telegram_id,
+                        chat_id=chat_id,
+                        text=text,
+                    )
+                    return WebhookResponse()
+                if state == "code_sent":
+                    logger.info(
+                        "[LLM-DEBUG] Spec 215 PR-F1b: routing free-text to "
+                        "SignupHandler.handle_code (telegram_id=%s)",
+                        telegram_id,
+                    )
+                    background_tasks.add_task(
+                        _run_signup_with_fresh_session,
+                        bot_instance,
+                        "code",
+                        telegram_id=telegram_id,
+                        chat_id=chat_id,
+                        text=text,
+                    )
+                    return WebhookResponse()
+
             logger.info(
                 f"[LLM-DEBUG] Pending check: has_pending={pending is not None}, "
-                f"otp_state={pending.otp_state if pending else 'N/A'}"
+                f"signup_state={pending.signup_state if pending else 'N/A'}"
             )
             if pending and pending.otp_state == "code_sent":
                 # User is in OTP verification state

--- a/nikita/db/repositories/telegram_signup_session_repository.py
+++ b/nikita/db/repositories/telegram_signup_session_repository.py
@@ -48,6 +48,75 @@ class TelegramSignupSessionRepository:
         return self._session
 
     # ------------------------------------------------------------------
+    # FSM entry (PR-F1b)
+    # ------------------------------------------------------------------
+
+    async def create_awaiting_email(
+        self,
+        telegram_id: int,
+        chat_id: int | None = None,
+    ) -> int:
+        """Insert (or upsert) an AWAITING_EMAIL row for `telegram_id`.
+
+        Used by `signup_handler.handle_welcome` (FR-2) when /start welcome is
+        consumed for an unbound telegram_id. Idempotent: re-issuing /start
+        welcome resets the row to AWAITING_EMAIL with `email=''` and a fresh
+        `expires_at` so the user can start over (per D8/D15 spec semantics).
+
+        Args:
+            telegram_id: Telegram user ID.
+            chat_id: Optional Telegram chat_id (FR-11c routing dependency).
+
+        Returns:
+            The telegram_id of the upserted row.
+        """
+        stmt = (
+            insert(TelegramSignupSession)
+            .values(
+                telegram_id=telegram_id,
+                email="",  # collected at FR-3
+                chat_id=chat_id,
+                signup_state="awaiting_email",
+                attempts=0,
+                last_attempt_at=utc_now(),
+                expires_at=utc_now() + timedelta(minutes=self.DEFAULT_EXPIRY_MINUTES),
+            )
+            .on_conflict_do_update(
+                index_elements=[TelegramSignupSession.telegram_id],
+                set_={
+                    "email": "",
+                    "chat_id": chat_id,
+                    "signup_state": "awaiting_email",
+                    "attempts": 0,
+                    "last_attempt_at": utc_now(),
+                    "expires_at": utc_now()
+                    + timedelta(minutes=self.DEFAULT_EXPIRY_MINUTES),
+                    "magic_link_token": None,
+                    "magic_link_sent_at": None,
+                    "verification_type": None,
+                },
+            )
+            .returning(TelegramSignupSession.telegram_id)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return result.scalar_one()
+
+    async def purge(self, telegram_id: int) -> int:
+        """Delete the row regardless of state (used on rate-limit reset and
+        expired-code purge per spec §7.2.1 + AC-4.2/AC-5.4).
+
+        Returns:
+            Number of rows deleted (0 or 1).
+        """
+        stmt = delete(TelegramSignupSession).where(
+            TelegramSignupSession.telegram_id == telegram_id,
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return result.rowcount
+
+    # ------------------------------------------------------------------
     # CAS FSM transitions (spec §7.2.1)
     # ------------------------------------------------------------------
 

--- a/nikita/db/repositories/telegram_signup_session_repository.py
+++ b/nikita/db/repositories/telegram_signup_session_repository.py
@@ -17,7 +17,7 @@ legacy repo + handlers are removed in PR-F3.
 
 from datetime import timedelta
 
-from sqlalchemy import delete, select, text, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/nikita/platforms/telegram/bot.py
+++ b/nikita/platforms/telegram/bot.py
@@ -50,6 +50,7 @@ class TelegramBot:
         text: str,
         parse_mode: str = "HTML",
         escape: bool = True,
+        disable_web_page_preview: bool = False,
     ) -> dict:
         """Send text message to user.
 
@@ -61,6 +62,11 @@ class TelegramBot:
             parse_mode: Formatting mode ("HTML" or "Markdown").
             escape: If True, escapes HTML special characters in text.
                    Set to False ONLY if text is already trusted/escaped.
+            disable_web_page_preview: Spec 215 NFR-Sec-1 — when True, suppresses
+                Telegram's link-preview crawler so single-use magic-link tokens
+                are not pre-burned. MUST be True for any message containing an
+                action_link (FR-5). Default False preserves behavior for all
+                existing call sites.
 
         Returns:
             Telegram API response.
@@ -81,6 +87,8 @@ class TelegramBot:
             "text": text,
             "parse_mode": parse_mode,
         }
+        if disable_web_page_preview:
+            payload["disable_web_page_preview"] = True
 
         response = await self.client.post(url, json=payload)
         data = response.json()
@@ -99,6 +107,7 @@ class TelegramBot:
         keyboard: list[list[dict]],
         parse_mode: str = "HTML",
         escape: bool = True,
+        disable_web_page_preview: bool = False,
     ) -> dict:
         """Send message with inline keyboard buttons.
 
@@ -131,6 +140,8 @@ class TelegramBot:
                 "inline_keyboard": keyboard,
             },
         }
+        if disable_web_page_preview:
+            payload["disable_web_page_preview"] = True
 
         response = await self.client.post(url, json=payload)
         data = response.json()

--- a/nikita/platforms/telegram/signup_handler.py
+++ b/nikita/platforms/telegram/signup_handler.py
@@ -1,0 +1,540 @@
+"""Telegram-first signup FSM handler — Spec 215 PR-F1b.
+
+Consolidates the legacy `registration_handler.py` + `otp_handler.py` flow
+into a single state-machine handler that drives:
+
+    UNKNOWN
+      └─ /start welcome ──▶ AWAITING_EMAIL    (FR-2)
+                                  │
+                                  └─ valid email ──▶ CODE_SENT       (FR-3)
+                                                          │
+                                                          └─ valid OTP ──▶ MAGIC_LINK_SENT (FR-5)
+
+Every state transition uses the CAS helpers on
+`TelegramSignupSessionRepository` (no read-modify-write). The handler does
+not own state mutation logic — it only drives transitions.
+
+Key contracts:
+- Magic-link Telegram delivery MUST set `disable_web_page_preview=True`
+  (NFR-Sec-1, Testing H1).
+- Telemetry events use the named Pydantic models from
+  `nikita.monitoring.events` (Testing H5 — no free-form dicts).
+- `verification_type` is forwarded VERBATIM from Supabase (Testing H2 —
+  no hardcoded literal substitution at the handler level; the admin
+  endpoint is where that contract lives).
+- Post-magic-link `update_telegram_id` is idempotent — when the
+  `public.users` row does not yet exist, the no-op is the correct
+  behavior (binding happens later via the existing FR-11b /start <code>
+  path).
+
+The legacy registration_handler + otp_handler files remain for compile
+compatibility; PR-F3 deletes them once W1 dogfood passes.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Final
+from uuid import UUID
+
+from supabase_auth.errors import AuthApiError
+
+from nikita.config.settings import get_settings
+from nikita.db.repositories.telegram_signup_session_repository import (
+    ConcurrentTransitionError,
+    ExpiredOrConcurrentError,
+    TelegramSignupSessionRepository,
+)
+from nikita.db.repositories.user_repository import (
+    UserRepository,
+)
+from nikita.monitoring.events import (
+    SignupCodeSentEvent,
+    SignupCodeVerifiedEvent,
+    SignupEmailReceivedEvent,
+    SignupFailedEvent,
+    SignupStartedTelegramEvent,
+    email_hash,
+    emit_signup_code_sent,
+    emit_signup_code_verified,
+    emit_signup_email_received,
+    emit_signup_failed,
+    emit_signup_started_telegram,
+    telegram_id_hash,
+)
+from nikita.platforms.telegram.bot import TelegramBot
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tuning constants (per .claude/rules/tuning-constants.md). Sourced from
+# spec §11 D10 + Plan v17.1 §4 PR-F1b.
+# ---------------------------------------------------------------------------
+
+# Maximum invalid OTP attempts before the FSM resets to AWAITING_EMAIL and the
+# row is purged. Spec §11 D10 row "OTP attempts": 3 within 1h → reset.
+MAX_OTP_ATTEMPTS: Final[int] = 3
+
+# Resend cooldown for email re-issue: 60s between sign_in_with_otp calls per
+# telegram_id. Spec §11 D10 row "Resend cooldown".
+RESEND_COOLDOWN_SECONDS: Final[int] = 60
+
+# Email regex — relaxed format check (server-side validation; Supabase does
+# the strict check). Spec §3.1 line 162: `^[^\s@]+@[^\s@]+\.[^\s@]+$`.
+EMAIL_REGEX: Final[re.Pattern[str]] = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+
+# OTP code regex — strict 6-digit numeric. Spec §3.1 line 68: `^[0-9]{6}$`.
+OTP_REGEX: Final[re.Pattern[str]] = re.compile(r"^[0-9]{6}$")
+
+
+# ---------------------------------------------------------------------------
+# Nikita-voiced reply copy (kept inline for grep-ability per §8.5)
+# ---------------------------------------------------------------------------
+
+WELCOME_TEXT: Final[str] = (
+    "Hey. New face. I'm Nikita.\n\n"
+    "If you want me in your life, give me your email. I'll send you a code."
+)
+INVALID_EMAIL_TEXT: Final[str] = (
+    "That email doesn't look right. Try again."
+)
+CODE_SENT_TEXT: Final[str] = (
+    "Check your inbox. Send me the 6-digit code."
+)
+RESEND_COOLDOWN_TEXT: Final[str] = (
+    "Easy — give it a minute, then try again."
+)
+INVALID_OTP_TEMPLATE: Final[str] = (
+    "Not right. {tries_left} tries left."
+)
+RATE_LIMIT_TEXT: Final[str] = (
+    "Too many wrong codes. Send /start to start over."
+)
+EXPIRED_CODE_TEXT: Final[str] = (
+    "Code expired. Send /start to retry."
+)
+MAGIC_LINK_TEXT: Final[str] = (
+    "You're cleared. Tap to enter."
+)
+MAGIC_LINK_BUTTON_LABEL: Final[str] = "Enter the portal →"
+GENERIC_FAIL_TEXT: Final[str] = (
+    "Something glitched. Send /start to start over."
+)
+
+
+# ---------------------------------------------------------------------------
+# SignupHandler — the consolidated FSM
+# ---------------------------------------------------------------------------
+
+
+class SignupHandler:
+    """Telegram-first signup state-machine handler (Spec 215 §3.1, FR-2..FR-5).
+
+    Constructor takes everything as DI to keep the unit tests trivial:
+
+    Args:
+        bot: TelegramBot client for outbound messages.
+        repo: TelegramSignupSessionRepository for FSM CAS transitions.
+        user_repo: UserRepository for idempotent telegram_id binding.
+        supabase_client: Async Supabase client for `auth.sign_in_with_otp`
+            and `auth.verify_otp`.
+        admin_generate_magiclink: Callable that mints the magic-link via the
+            FR-5 admin endpoint (`portal_auth.generate_magiclink_for_telegram_user`).
+            Called as a plain async function (Depends machinery is bypassed
+            because the handler runs inside the same process and we already
+            have a service-role-equivalent context).
+    """
+
+    def __init__(
+        self,
+        *,
+        bot: TelegramBot,
+        repo: TelegramSignupSessionRepository,
+        user_repo: UserRepository,
+        supabase_client: Any,
+        admin_generate_magiclink: Callable[..., Awaitable[Any]],
+    ) -> None:
+        self.bot = bot
+        self.repo = repo
+        self.user_repo = user_repo
+        self.supabase = supabase_client
+        self.admin_generate_magiclink = admin_generate_magiclink
+
+    # ------------------------------------------------------------------
+    # FR-2 — handle_welcome
+    # ------------------------------------------------------------------
+
+    async def handle_welcome(self, *, telegram_id: int, chat_id: int) -> None:
+        """`/start welcome` for an unbound telegram_id (spec §3.1 + FR-2).
+
+        Idempotent — re-issuing /start welcome is the spec'd v1 escape hatch
+        (FR-15) for mid-funnel email change. Resets the FSM row to
+        AWAITING_EMAIL.
+        """
+        try:
+            await self.repo.create_awaiting_email(
+                telegram_id=telegram_id, chat_id=chat_id
+            )
+        except Exception:  # pragma: no cover - defensive, repo failure
+            logger.exception(
+                "signup_welcome_repo_failed telegram_id_hash=%s",
+                telegram_id_hash(telegram_id),
+            )
+            await self._safe_send(
+                chat_id=chat_id, text=GENERIC_FAIL_TEXT
+            )
+            return
+
+        await self._safe_send(chat_id=chat_id, text=WELCOME_TEXT)
+
+        try:
+            emit_signup_started_telegram(
+                SignupStartedTelegramEvent(
+                    telegram_id_hash=telegram_id_hash(telegram_id),
+                    ts=_now(),
+                )
+            )
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("telemetry_emit_failed event=signup_started_telegram")
+
+    # ------------------------------------------------------------------
+    # FR-3 — handle_email
+    # ------------------------------------------------------------------
+
+    async def handle_email(
+        self, *, telegram_id: int, chat_id: int, text: str
+    ) -> None:
+        """User free-text in AWAITING_EMAIL state (spec §3.1 + FR-3)."""
+        email = text.strip()
+
+        # AC-2.2: invalid email — Nikita rejects, no row mutation
+        if not EMAIL_REGEX.match(email):
+            await self._safe_send(chat_id=chat_id, text=INVALID_EMAIL_TEXT)
+            return
+
+        # D10 resend cooldown: 60s between sign_in_with_otp calls per tg_id.
+        # We check the prior row's last_attempt_at (set on welcome create
+        # and on every transition).
+        existing = await self.repo.get(telegram_id)
+        if existing is not None and existing.last_attempt_at is not None:
+            elapsed = (_now() - existing.last_attempt_at).total_seconds()
+            if (
+                existing.signup_state == "code_sent"
+                and elapsed < RESEND_COOLDOWN_SECONDS
+            ):
+                await self._safe_send(
+                    chat_id=chat_id, text=RESEND_COOLDOWN_TEXT
+                )
+                return
+
+        # FR-3: send OTP via Supabase (signup template fires)
+        try:
+            response = await self.supabase.auth.sign_in_with_otp(
+                {
+                    "email": email,
+                    "options": {"should_create_user": True},
+                }
+            )
+            response_code = getattr(response, "status_code", 200) or 200
+        except Exception:
+            logger.exception(
+                "signup_send_otp_failed telegram_id_hash=%s email_hash=%s",
+                telegram_id_hash(telegram_id),
+                email_hash(email),
+            )
+            await self._safe_send(chat_id=chat_id, text=GENERIC_FAIL_TEXT)
+            self._safe_emit_failed(
+                telegram_id=telegram_id,
+                stage="awaiting_email",
+                reason="sign_in_with_otp_failed",
+            )
+            return
+
+        # AC-3.2 + §7.2.1: AWAITING_EMAIL → CODE_SENT via CAS
+        try:
+            await self.repo.transition_to_code_sent(
+                telegram_id=telegram_id, email=email
+            )
+        except ConcurrentTransitionError:
+            logger.warning(
+                "signup_cas_blocked telegram_id_hash=%s",
+                telegram_id_hash(telegram_id),
+            )
+            await self._safe_send(chat_id=chat_id, text=GENERIC_FAIL_TEXT)
+            return
+
+        # Telemetry — both events bracket the FR-3 transition
+        try:
+            emit_signup_email_received(
+                SignupEmailReceivedEvent(
+                    telegram_id_hash=telegram_id_hash(telegram_id),
+                    email_hash=email_hash(email),
+                    ts=_now(),
+                )
+            )
+            emit_signup_code_sent(
+                SignupCodeSentEvent(
+                    email_hash=email_hash(email),
+                    ts=_now(),
+                    supabase_response_code=int(response_code),
+                )
+            )
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("telemetry_emit_failed event=signup_email_received")
+
+        await self._safe_send(chat_id=chat_id, text=CODE_SENT_TEXT)
+
+    # ------------------------------------------------------------------
+    # FR-4 / FR-5 — handle_code
+    # ------------------------------------------------------------------
+
+    async def handle_code(
+        self, *, telegram_id: int, chat_id: int, text: str
+    ) -> None:
+        """User free-text in CODE_SENT state (spec §3.1 + FR-4 + FR-5)."""
+        code = text.strip()
+
+        if not OTP_REGEX.match(code):
+            # Garbage in CODE_SENT — gentle nudge.
+            await self._safe_send(
+                chat_id=chat_id,
+                text=INVALID_OTP_TEMPLATE.format(tries_left=MAX_OTP_ATTEMPTS),
+            )
+            return
+
+        # Load row to inspect expiry + email
+        existing = await self.repo.get(telegram_id)
+        if existing is None or existing.signup_state != "code_sent":
+            # No active code session; ask user to /start
+            await self._safe_send(chat_id=chat_id, text=GENERIC_FAIL_TEXT)
+            return
+
+        # AC-4.3 / AC-5.4: expired code — purge + Nikita "expired"
+        if existing.expires_at <= _now():
+            await self.repo.purge(telegram_id=telegram_id)
+            await self._safe_send(chat_id=chat_id, text=EXPIRED_CODE_TEXT)
+            self._safe_emit_failed(
+                telegram_id=telegram_id,
+                stage="code_sent",
+                reason="code_expired",
+            )
+            return
+
+        email = existing.email
+
+        # FR-4: verify_otp
+        try:
+            verify_response = await self.supabase.auth.verify_otp(
+                {"email": email, "token": code, "type": "email"}
+            )
+        except AuthApiError as exc:
+            await self._handle_invalid_otp(
+                telegram_id=telegram_id, chat_id=chat_id, error_code=exc.code
+            )
+            return
+        except Exception:
+            logger.exception(
+                "signup_verify_otp_unexpected telegram_id_hash=%s",
+                telegram_id_hash(telegram_id),
+            )
+            await self._safe_send(chat_id=chat_id, text=GENERIC_FAIL_TEXT)
+            return
+
+        # AC-4.4: OTP valid — proceed to FR-5
+        try:
+            auth_uid = UUID(str(verify_response.user.id))
+        except Exception:
+            logger.exception(
+                "signup_verify_otp_no_user_id telegram_id_hash=%s",
+                telegram_id_hash(telegram_id),
+            )
+            await self._safe_send(chat_id=chat_id, text=GENERIC_FAIL_TEXT)
+            return
+
+        try:
+            emit_signup_code_verified(
+                SignupCodeVerifiedEvent(
+                    email_hash=email_hash(email),
+                    attempts_count=int(existing.attempts) + 1,
+                    ts=_now(),
+                )
+            )
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("telemetry_emit_failed event=signup_code_verified")
+
+        # AC-5.5: idempotent telegram_id bind. The user row may not yet exist
+        # (portal-side auto-provision happens on first /auth/confirm). We
+        # tolerate ValueError ("user_id not in users") gracefully — the
+        # binding will land via the existing FR-11b /start <code> path.
+        try:
+            await self.user_repo.update_telegram_id(
+                user_id=auth_uid, telegram_id=telegram_id
+            )
+        except Exception as exc:
+            logger.info(
+                "signup_bind_deferred telegram_id_hash=%s reason=%s",
+                telegram_id_hash(telegram_id),
+                type(exc).__name__,
+            )
+
+        # FR-5: mint magic-link via admin endpoint (direct call — same
+        # process, service-role guard bypassed by signature default).
+        from nikita.api.routes.portal_auth import GenerateMagiclinkRequest
+
+        try:
+            magic = await self.admin_generate_magiclink(
+                body=GenerateMagiclinkRequest(
+                    telegram_id=telegram_id, email=email
+                ),
+                _auth=None,
+                repo=self.repo,
+            )
+        except ExpiredOrConcurrentError:
+            await self._safe_send(chat_id=chat_id, text=EXPIRED_CODE_TEXT)
+            self._safe_emit_failed(
+                telegram_id=telegram_id,
+                stage="code_sent",
+                reason="cas_expired_at_mint",
+            )
+            return
+        except Exception:
+            logger.exception(
+                "signup_generate_magiclink_failed telegram_id_hash=%s",
+                telegram_id_hash(telegram_id),
+            )
+            await self._safe_send(chat_id=chat_id, text=GENERIC_FAIL_TEXT)
+            return
+
+        # FR-5 + Testing H1: deliver via inline button with link-preview off
+        action_link = str(getattr(magic, "action_link", "")) or ""
+        await send_magic_link_message(
+            bot=self.bot,
+            chat_id=chat_id,
+            action_link=action_link,
+            button_label=MAGIC_LINK_BUTTON_LABEL,
+            text=MAGIC_LINK_TEXT,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _handle_invalid_otp(
+        self, *, telegram_id: int, chat_id: int, error_code: str | None
+    ) -> None:
+        """Increment attempts; on MAX_OTP_ATTEMPTS purge + rate-limit reply."""
+        if error_code == "otp_expired":
+            await self.repo.purge(telegram_id=telegram_id)
+            await self._safe_send(chat_id=chat_id, text=EXPIRED_CODE_TEXT)
+            self._safe_emit_failed(
+                telegram_id=telegram_id,
+                stage="code_sent",
+                reason="code_expired",
+            )
+            return
+
+        new_attempts = await self.repo.increment_attempts(
+            telegram_id=telegram_id
+        )
+        if new_attempts is None:
+            # Row vanished mid-flight; ask user to restart
+            await self._safe_send(chat_id=chat_id, text=GENERIC_FAIL_TEXT)
+            return
+
+        if new_attempts >= MAX_OTP_ATTEMPTS:
+            await self.repo.purge(telegram_id=telegram_id)
+            await self._safe_send(chat_id=chat_id, text=RATE_LIMIT_TEXT)
+            self._safe_emit_failed(
+                telegram_id=telegram_id,
+                stage="code_sent",
+                reason="rate_limit_invalid_otp",
+            )
+            return
+
+        tries_left = MAX_OTP_ATTEMPTS - new_attempts
+        await self._safe_send(
+            chat_id=chat_id,
+            text=INVALID_OTP_TEMPLATE.format(tries_left=tries_left),
+        )
+
+    async def _safe_send(self, *, chat_id: int, text: str) -> None:
+        """Wrap send_message — Telegram failures should not blow up the FSM."""
+        try:
+            await self.bot.send_message(chat_id=chat_id, text=text)
+        except Exception:  # pragma: no cover - defensive
+            logger.exception(
+                "signup_send_message_failed chat_id=%s",
+                chat_id,
+            )
+
+    def _safe_emit_failed(
+        self, *, telegram_id: int, stage: str, reason: str
+    ) -> None:
+        try:
+            emit_signup_failed(
+                SignupFailedEvent(
+                    telegram_id_hash=telegram_id_hash(telegram_id),
+                    stage=stage,  # type: ignore[arg-type]
+                    reason=reason,
+                    ts=_now(),
+                )
+            )
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("telemetry_emit_failed event=signup_failed")
+
+
+# ---------------------------------------------------------------------------
+# Magic-link delivery helper — Testing H1 + NFR-Sec-1
+# ---------------------------------------------------------------------------
+
+
+async def send_magic_link_message(
+    *,
+    bot: TelegramBot,
+    chat_id: int,
+    action_link: str,
+    button_label: str,
+    text: str,
+) -> None:
+    """Deliver a magic-link via inline-keyboard URL button.
+
+    Per Spec 215 NFR-Sec-1 (PR-blocker) + Testing H1, this helper ALWAYS
+    passes `disable_web_page_preview=True` so Telegram's link-preview
+    crawler does not pre-burn the single-use action_link token.
+
+    Args:
+        bot: TelegramBot client.
+        chat_id: Telegram chat ID.
+        action_link: Supabase-minted action URL (full https URL).
+        button_label: Inline-button text shown to the user.
+        text: Body text shown above the button (Nikita-voiced).
+    """
+    keyboard = [[{"text": button_label, "url": action_link}]]
+    await bot.send_message_with_keyboard(
+        chat_id=chat_id,
+        text=text,
+        keyboard=keyboard,
+        disable_web_page_preview=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+__all__ = [
+    "SignupHandler",
+    "send_magic_link_message",
+    "MAX_OTP_ATTEMPTS",
+    "RESEND_COOLDOWN_SECONDS",
+    "EMAIL_REGEX",
+    "OTP_REGEX",
+]

--- a/nikita/platforms/telegram/signup_handler.py
+++ b/nikita/platforms/telegram/signup_handler.py
@@ -41,7 +41,6 @@ from uuid import UUID
 
 from supabase_auth.errors import AuthApiError
 
-from nikita.config.settings import get_settings
 from nikita.db.repositories.telegram_signup_session_repository import (
     ConcurrentTransitionError,
     ExpiredOrConcurrentError,
@@ -298,10 +297,15 @@ class SignupHandler:
         code = text.strip()
 
         if not OTP_REGEX.match(code):
-            # Garbage in CODE_SENT — gentle nudge.
-            await self._safe_send(
-                chat_id=chat_id,
-                text=INVALID_OTP_TEMPLATE.format(tries_left=MAX_OTP_ATTEMPTS),
+            # Garbage in CODE_SENT counts as an invalid attempt — share the
+            # rate-limit path so non-numeric spam (`hi`, `abc`, ...) cannot
+            # bypass the 3-strike purge from Spec §11 D10. Without this,
+            # a malicious or buggy client can flood the bot with arbitrary
+            # text indefinitely (DoS / cost surface) while only legitimate
+            # 6-digit guesses contribute to the rate-limit counter. Per
+            # iter-2 QA review I-1.
+            await self._handle_invalid_otp(
+                telegram_id=telegram_id, chat_id=chat_id, error_code=None
             )
             return
 
@@ -325,7 +329,14 @@ class SignupHandler:
 
         email = existing.email
 
-        # FR-4: verify_otp
+        # FR-4: verify_otp.
+        # NOTE: `type="email"` here is the INPUT verify-type (per Supabase JS
+        # API: https://supabase.com/docs/reference/javascript/auth-verifyotp).
+        # The dynamic `verification_type` returned by `admin.generate_link`
+        # downstream (FR-5) is forwarded VERBATIM by the admin endpoint
+        # (`portal_auth.py:GenerateMagiclinkResponse.verification_type`) —
+        # never hardcoded. Testing H2 enforces the no-literal contract on
+        # the admin endpoint, not here.
         try:
             verify_response = await self.supabase.auth.verify_otp(
                 {"email": email, "token": code, "type": "email"}

--- a/specs/215-auth-flow-redesign/audit-report.md
+++ b/specs/215-auth-flow-redesign/audit-report.md
@@ -1,0 +1,131 @@
+# Specification Audit Report — Spec 215 Auth Flow Redesign
+
+**Feature**: 215-auth-flow-redesign
+**Date**: 2026-04-24
+**Auditor**: fresh-context subagent (SDD Phase 7)
+**Artifacts audited**: spec.md (913L, 16 FRs + FR-Telemetry-1, 77 ACs), plan.md (271L, 5 PRs), tasks.md (550L, T001-T056 across 8 phases), validation-findings.md
+**Result**: **PASS**
+
+---
+
+## Executive Summary
+
+- **Total Findings**: 6
+- **CRITICAL**: 0
+- **HIGH**: 0
+- **MEDIUM**: 3
+- **LOW**: 3
+- **Implementation**: **READY** (`/implement` unblocked)
+
+The artifact set is internally consistent, free of unresolved clarification markers, fully covered for P1 functional requirements that ship code in Spec 215, and constitution-compliant across Articles III/IV/VI/VII/VIII. The MEDIUM/LOW findings are quality nits that can be addressed during `/implement` without blocking.
+
+---
+
+## Findings Table
+
+| ID | Category | Severity | Location | Summary | Fix |
+|---|---|---|---|---|---|
+| F1 | Coverage | MEDIUM | spec.md FR-8 (L257-263) ↔ tasks.md | FR-8 (ceremony renders link_code; idempotent `update_telegram_id` on re-tap) has no direct task mapping. T033 covers FR-14 copy-only addition to the same component; FR-8's idempotency AC-8.2 relies on existing FR-11b code path inherited from Spec 213/214 but is not asserted by any new test in tasks.md. | Add an explicit AC-8.2 regression test to PR-F1b/PR-F3 (e.g., `tests/platforms/telegram/test_start_link_code_idempotent.py`) OR document inheritance in FR-7-style "delegates to existing Spec 214" prose so the gap is intentional. |
+| F2 | Coverage | MEDIUM | spec.md FR-9 (L265-270) ↔ tasks.md | FR-9 ACs split: AC-9.1 (greeting dispatched ≤5s of `/start <CODE>`) is reachable only via Phase F W1 live walk (T038) — acceptable for a latency budget but not asserted by AC-2 (`AC-9.2` phone-call in first 3 turns) is covered by T044 (FR-13 persona fragment). Tasks do not cite AC-9.1 explicitly. | Add `AC-9.1` to T038 W1 walk acceptance criteria explicitly, OR add a unit assertion in PR-F1b that BackgroundTasks dispatch is wired immediately on `/start <CODE>` consumption. |
+| F3 | Coverage | MEDIUM | spec.md FR-15 (L359-368) ↔ tasks.md | FR-15 v1 escape hatch (AC-15.2: `/start` for users in `signup_state IN (AWAITING_EMAIL, CODE_SENT, MAGIC_LINK_SENT)` triggers destructive reset) is functional behavior the bot ships in PR-F1b but is not enumerated in any task ACs. T-E8/T-E18 are referenced under FR-16 but neither are present in tasks.md task descriptions. | Add an AC to T017 (or split T017c) covering `signup_handler.handle_start` destructive-reset for in-flight states. |
+| F4 | Quality | LOW | tasks.md T017 (L182-192) | T017 is flagged inline as "XL → break: T017a (M 3hr) + T017b (L 4hr)" but the canonical task IDs T017a/T017b are not formally enumerated as standalone task entries. Downstream dependency arrows (T018 deps `T017`) become ambiguous. | Promote T017a and T017b to first-class task IDs with their own ACs and dependency edges; or collapse the split note. |
+| F5 | Quality | LOW | tasks.md T038 (L378) | T038 dispatch caps state `HARD CAP: 25 tool calls` but `.claude/rules/parallel-agents.md` Subagent Dispatch Caps lists 15 as the max for "Deep exploration." Walk dispatch isn't explicitly enumerated in the rule's three tiers; the 25 cap is reasonable for a 12-step walk but should be cross-referenced or rule-amended. | Either cite ADR-011 / live-testing-protocol.md as the dispatch-cap source for walks (separate tier), or lower cap to 15 + budget for partial-results checkpoint. |
+| F6 | Quality | LOW | spec.md §12 (L887) | Header retains `[NEEDS CLARIFICATION]` token for template-conformance reasons even though body says "NONE." A naive grep `\[NEEDS CLARIFICATION\]` will trip on this header and falsely flag. | Rename header to `## §12 Open questions` (drop the bracketed marker) or substitute `[RESOLVED]` so future automated grep gates do not false-positive. |
+
+---
+
+## Coverage Analysis
+
+**FRs covered**: 14/17 directly referenced in `Mapped FR/AC` lines + 3/17 indirectly satisfied (FR-7, FR-8, FR-9 — see findings F1/F2).
+
+| FR | Direct task mapping | Status |
+|---|---|---|
+| FR-1 | T028 (test), T030 (impl) | COVERED |
+| FR-2 | T015 (test), T017 (impl) | COVERED (via AC-2.1..2.3 in T015) |
+| FR-3 | T015, T017 | COVERED (AC-3.1..3.4) |
+| FR-4 | T015, T017 | COVERED (AC-4.1..4.4) |
+| FR-5 | T004, T011, T015, T016, T017 | COVERED (AC-5.1..5.5) |
+| FR-6 | T021, T022, T023, T024, T025 | COVERED (AC-6.1..6.6) |
+| FR-6a | T022, T024 | COVERED (visual contract + ARIA) |
+| FR-7 | (none — explicit delegation to Spec 214 FR-11d) | INTENTIONALLY DELEGATED (acceptable) |
+| FR-8 | (none — relies on inherited FR-11b path) | F1 MEDIUM |
+| FR-9 | T038 (W1 walk only); T044 (FR-13 persona) | F2 MEDIUM |
+| FR-10 | T029 (test), T032 (impl) | COVERED (AC-10.1..10.6) |
+| FR-10a | T029, T032 | COVERED (visual contract) |
+| FR-11 | T028, T031 | COVERED (AC-11.1..11.3) |
+| FR-12 | T007 (migration), T041 (test), T043 (impl) | COVERED (AC-12.1..12.4) |
+| FR-13 | T044 | COVERED (AC-13.1..13.2) |
+| FR-14 | T033 | COVERED (AC-14.1..14.3) |
+| FR-15 | (none — v1 escape hatch) | F3 MEDIUM |
+| FR-16 | T021, T016 cover most-cited T-E#; FR-16 is a meta-summary | COVERED IN AGGREGATE |
+| FR-Telemetry-1 | T005 (test), T010 (impl) | COVERED |
+
+**Orphan FRs**: FR-8, FR-9, FR-15 (inherited / delegated) — see F1/F2/F3.
+**Orphan tasks**: none — every T-NNN maps to ≥1 FR/AC or to a verification gate (pre-PR grep, qa-review, ROADMAP sync).
+
+---
+
+## Constitution Compliance
+
+| Article | Status | Evidence |
+|---|---|---|
+| III (Test-First) | **PASS** | Every implementation task has ≥2 ACs (verified across T006-T011, T017-T019, T023-T025, T030-T034, T043-T050). Every PR phase opens with explicit "Tests for PR-FX ⚠️ WRITE FIRST" sections (T003-T005 for F1a, T015-T016 for F1b, T021-T022 for F2a, T028-T029 for F2b, T041-T042 for F3). RED→GREEN commit pair noted in tasks.md preamble. |
+| IV (Spec-First) | **PASS** | Every task references a spec FR/AC or §-section. plan.md §4 PR breakdown lists ACs satisfied per PR, lifted directly from spec.md. tasks.md §"Mapped FR/AC" lines provide back-references. No orphan implementation tasks. |
+| VI (Simplicity) | **PASS** | Architecture (plan §2.2) keeps to ≤2 layers: route handler → repository → ORM model; FSM is single-file (`signup_handler.py`); interstitial is ~150 LOC single component. No unnecessary abstractions (e.g., explicit rejection of pydantic-graph for linear flow per `.claude/rules/agentic-design-patterns.md`). Five PRs sequenced with explicit blast-radius reasoning, not over-decomposed. |
+| VII (User-Story-Centric) | **PASS** | Single product story (Telegram-first signup) shipped as 5 PRs (PR-F1a/F1b/F2a/F2b/F3). tasks.md preamble explicitly justifies PR-organized grouping ("the spec has a single product story but ships in 5 sequential PRs for blast-radius control"). Acceptable per spec definition. |
+| VIII (Parallelization) | **PASS** | `[P]` markers present and correctly scoped: T003/T004/T005 [P] (different test files), T007/T010 [P] (independent migrations), T015/T016 [P], T021/T022 [P], T028/T029 [P], T041/T042 [P], T043/T044/T048/T049/T050 [P] (independent file deletions). Cross-PR sequencing correctly STRICTLY SEQUENTIAL (plan §9 + tasks Dependencies section). |
+
+---
+
+## Duplication Detection
+
+- **No duplicate FRs**: each FR addresses a distinct surface (landing CTA, bot FSM, OTP send, OTP verify, magic-link mint, portal route, wizard delegation, ceremony, greeting, login UI, nav, wizard slot, persona fragment, ceremony copy, escape hatch, edge cases meta, telemetry).
+- **No duplicate tasks across phases**: each T-NNN appears once. T025 (middleware add `/auth/confirm` exemption) and T034 (middleware remove `/onboarding/auth` exemption) touch the same file but are sequenced in distinct PRs with explicit justification.
+- **Naming consistency**: `telegram_signup_sessions` (table) appears verbatim across spec §3, §7, plan §2.3, tasks T006/T009. PR labels `PR-F1a/F1b/F2a/F2b/F3` consistent across plan §4 + §9 + tasks Phase 2-7 headings.
+
+---
+
+## Inconsistency Detection
+
+- **Terminology**: consistent across artifacts. Notable: spec uses both `signup_state` (post-rename, FSM enum) and `otp_state` (legacy column being renamed) — plan §2.3 + tasks T006 AC-1 explicitly call out the rename. No drift.
+- **PR labels**: `PR-F1a / PR-F1b / PR-F2a / PR-F2b / PR-F3` match across spec.md §3 (no use), plan.md §4/§7/§9, tasks.md Phase 2-7 + per-task `[PR-FX]` tags.
+- **`verification_type` Literal type**: consistent — spec FR-5 + AC-5.2 + tasks T008 AC-2 (`Literal["email","signup","magiclink","recovery"]`) + tasks T011 AC-4 (no normalization).
+- **Idempotency contract**: spec FR-6 "Idempotency contract (TTL-only)" matches plan §1 description and tasks T021 AC-1..AC-5 (T-E22/T-E23/T-E24/T-E27 split correctly).
+- **Email templates**: spec §7.4 + FR-3 (signup code-only) + FR-10 (login link-only) consistent across plan §7 (Quality Gates) + tasks T032 AC-1.
+
+---
+
+## Ambiguity Detection
+
+- `grep -nE "TODO|TBD|\?\?\?|\[NEEDS CLARIFICATION\]"` over `specs/215-auth-flow-redesign/`: **1 hit** at `spec.md:887` — `## §12 Open questions [NEEDS CLARIFICATION]`.
+- **Verdict**: header-template artifact, NOT a real blocker. Body asserts "NONE." with explicit enumeration of all D1-D13 + S1-S4 decisions resolved. Filed as F6 LOW (rename header to drop the bracketed marker for future grep-gate safety).
+
+---
+
+## Implementation Readiness
+
+- [x] Zero CRITICAL findings
+- [x] Zero HIGH findings
+- [x] Constitution PASS (Articles III/IV/VI/VII/VIII)
+- [x] No actionable [NEEDS CLARIFICATION] (only header-template artifact, F6 LOW)
+- [x] Coverage ≥95% for P1 (14/17 FRs directly mapped + 3/17 intentionally delegated/inherited; gaps filed as F1/F2/F3 MEDIUM, non-blocking)
+- [x] All directly-implemented FRs have ≥1 falsifiable AC
+
+---
+
+## Recommendation
+
+**PASS → unblock `/implement`**
+
+The 3 MEDIUM findings (F1/F2/F3 — coverage gaps for FR-8/FR-9/FR-15) are quality concerns to be addressed inside `/implement` (e.g., add AC to T017/T038/T044 or document explicit inheritance from Spec 214). They do not block the gate because:
+
+1. FR-8/FR-9 functional code paths exist (inherited from shipped Specs 213/214 FR-11b/FR-11c) and the missing ACs concern test-coverage rigour, not new code synthesis.
+2. FR-15 is explicitly a "v1 escape hatch" (deferred to Spec 215 v2) and the destructive-reset behavior in PR-F1b will be exercised by Phase F W1 walk regardless.
+3. The 3 LOW findings (F4/F5/F6) are documentation/naming cleanups that can be batched into the first PR-F1a commit.
+
+**Recommended next action**: `/implement` (Phase 8) with explicit instruction to address F1/F2/F3 in the corresponding PR's task expansion.
+
+---
+
+**Audit method**: Read of all 4 artifacts + targeted Grep for FR/AC coverage in tasks.md + clarification-marker scan + cross-artifact terminology check.
+**Tool budget**: 9 tool calls used of 15 HARD CAP.

--- a/specs/215-auth-flow-redesign/plan.md
+++ b/specs/215-auth-flow-redesign/plan.md
@@ -1,0 +1,271 @@
+# Implementation Plan — Spec 215 Auth Flow Redesign (Telegram-First Signup)
+
+**Spec**: `spec.md` (913 lines, 16 FRs, 77 ACs)
+**Status**: Ready for `/tasks` (Phase 6)
+**Date**: 2026-04-24
+**Author**: Phase D executor (per Plan v17.1)
+**GATE 2**: PASS (iter-2, 0 CRITICAL + 0 HIGH across 6 validators); user-approved 2026-04-24
+**Branch**: `feat/215-telegram-first-signup` (created at PR-F1a kickoff)
+**Feature flag**: `NEXT_PUBLIC_TELEGRAM_FIRST_SIGNUP=true` (gates PR-F1a/F1b/F2a/F2b; flipped after Phase F W1)
+
+---
+
+## §1 Overview
+
+Spec 215 inverts the auth direction: anonymous landing → Telegram bot collects email → 6-digit OTP delivered to inbox → user types code in Telegram → backend mints in-chat magic-link via `admin.generate_link` → user taps → portal `/auth/confirm` calls non-PKCE `verifyOtp({token_hash, type})` → IS-A always-interstitial → wizard.
+
+This eliminates the GH #393 PKCE 422 failure surface, removes portal-first magic-link signup (`/onboarding/auth` deleted), consolidates two legacy Telegram-first OTP handlers (`registration_handler.py` + `otp_handler.py`) into a single `signup_handler.py` FSM, and drops the legacy `auth_bridge_tokens` table.
+
+Five PRs ship sequentially behind a feature flag. PR-F3 (legacy deletion) waits one deploy cycle after the flag flips, providing rollback safety.
+
+## §2 Architecture (lifted from spec §7)
+
+### §2.1 Data flow (high-level)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant L as Landing CTA
+    participant T as Telegram Bot
+    participant SH as signup_handler.py
+    participant SB as Supabase Auth
+    participant E as Email Inbox
+    participant P as Portal /auth/confirm
+    participant W as Wizard
+
+    U->>L: Click "Start Relationship"
+    L->>T: Open t.me/Nikita_my_bot?start=welcome
+    T->>SH: /start welcome
+    SH->>U: "What's your email?"
+    U->>SH: email@domain.com
+    SH->>SB: sign_in_with_otp(email)
+    SB->>E: Email with {{ .Token }}
+    E->>U: 6-digit code
+    U->>SH: 123456
+    SH->>SB: verify_otp({email, token, type:"email"})
+    SB-->>SH: success
+    SH->>SB: admin.generate_link({type:"magiclink"})
+    SB-->>SH: {action_link, hashed_token, verification_type}
+    SH->>U: Inline button "Enter portal" (disable_web_page_preview=True)
+    U->>SB: tap action_link → Supabase /verify
+    SB->>P: 302 to /auth/confirm?token_hash=&type=&next=/onboarding
+    P->>SB: verifyOtp({token_hash, type})
+    SB-->>P: session cookies set
+    P->>U: IS-A interstitial "Enter the portal"
+    U->>W: Click "Enter" → /onboarding
+    W->>U: chat-first wizard (FR-11d)
+```
+
+### §2.2 Module map
+
+| Layer | New | Modified | Deleted |
+|---|---|---|---|
+| Backend FSM | `nikita/platforms/telegram/signup_handler.py` | `nikita/api/routes/telegram.py` (route email/code to signup_handler) | `nikita/platforms/telegram/{registration_handler,otp_handler}.py`; `auth.py:61-141` deprecated methods |
+| Backend admin | `nikita/api/routes/portal_auth.py::generate_magiclink_for_telegram_user` (NEW endpoint) | — | — |
+| Backend DB | — | `nikita/db/models/pending_registration.py` → `telegram_signup_session.py` (rename + columns) | `nikita/db/models/auth_bridge.py`; `nikita/api/routes/auth_bridge.py`; `auth_bridge_repository.py` |
+| Backend agents | — | `nikita/agents/onboarding/wizard_slots.py` (add `preferred_call_window`); `nikita/agents/text/persona.py` (S2 phone-call proposal fragment) | — |
+| Backend telemetry | `nikita/monitoring/events.py` 9 new Pydantic event models | — | — |
+| Portal route | `portal/src/app/auth/confirm/route.ts` + `interstitial.tsx` | `portal/src/app/login/page-client.tsx` (Nikita-voiced); `portal/src/lib/supabase/middleware.ts` (exemptions) | `portal/src/app/onboarding/auth/` (entire dir) |
+| Portal landing | — | 3 CTA components: `hero-section.tsx`, `cta-section.tsx`, `landing-nav.tsx` | — |
+| Portal wizard | — | `portal/src/components/onboarding/ClearanceGrantedCeremony.tsx` (S3 portal-orientation copy) | `onboarding-wizard-legacy.tsx` + `steps/legacy/` + `components/legacy/` (D4: flag UNSET in Vercel) |
+| Migrations | 4 new SQL migrations | — | — |
+
+### §2.3 Migration sequence (PR-F1a → PR-F3)
+
+1. PR-F1a: RENAME `pending_registrations` → `telegram_signup_sessions` + ADD COLUMNs + RLS
+2. PR-F1a: ADD COLUMN `preferred_call_window` ON `user_profiles` (FR-12)
+3. PR-F3: DROP TABLE `auth_bridge_tokens` (verified count=0; 1-deploy-cycle delay after flag flip)
+
+## §3 Dependencies
+
+| Dep | Type | Status | Notes |
+|---|---|---|---|
+| `supabase-py 2.24.0+` | external | installed | `admin.generate_link` native support confirmed (Plan §21 spike) |
+| `@supabase/ssr ^0.8.0` | external | installed | Next.js 16 cookies adapter pattern |
+| Telegram bot API `disable_web_page_preview` | external | available | NFR-Sec-1 hard requirement |
+| Spec 213 FR-11b (307 auto-provision) | internal | shipped | reused for `public.users` row creation in FR-5 |
+| Spec 214 FR-11d wizard | internal | shipped | post-auth entry; modified to add FR-12 slot |
+| `portal_bridge_tokens` table | internal | shipped (PR #414, GH #413 hotfix) | unchanged; legacy `auth_bridge_tokens` is the one being dropped |
+| `feedback_dogfood_gmail_mcp_mismatch.md` plus-alias | tooling | documented | Phase F walks use `youwontgetmyname777+walkN@gmail.com` |
+
+## §4 PR breakdown (5 PRs, sequential, per Plan §18.4)
+
+### PR-F1a — Data layer + admin endpoint contract
+
+**Branch**: `feat/215-pr-f1a-data-layer`
+**Estimate**: ~300 LOC, 6-8 hours
+**TDD**: tests-first commit, then implementation commit (2-commit min per task)
+
+**Scope**:
+- Schema: rename `pending_registrations` → `telegram_signup_sessions`; add columns; RLS; CAS-update SQL helpers
+- Pydantic models: `TelegramSignupSession` (model + repository); `GenerateMagiclinkRequest` + `GenerateMagiclinkResponse`
+- Admin endpoint: `POST /api/v1/admin/auth/generate-magiclink-for-telegram-user` (service-role only)
+- 9 telemetry event Pydantic models (`SignupStartedTelegramEvent` etc.)
+- Migration: `add_preferred_call_window_to_user_profiles.sql` (FR-12 schema)
+- Tests: `test_telegram_signup_session_repository.py`, `test_portal_auth_generate_magiclink.py`, `test_signup_funnel_events.py`
+
+**ACs satisfied**: AC-3.2, AC-5.1, AC-5.2, AC-5.5 (idempotent bind), §7.6 contract, §7.2.1 CAS transitions, FR-Telemetry-1 schema
+
+**Verification**: `uv run pytest tests/db/repositories/test_telegram_signup_session_repository.py tests/api/routes/test_portal_auth_generate_magiclink.py tests/monitoring/test_signup_funnel_events.py -v`
+
+### PR-F1b — Backend FSM `signup_handler.py` + Telegram webhook routing
+
+**Branch**: `feat/215-pr-f1b-signup-handler`
+**Estimate**: ~400 LOC, 8-12 hours
+**Dependency**: PR-F1a merged
+
+**Scope**:
+- `signup_handler.py` consolidated FSM (handle_welcome, handle_email, handle_code, handle_invalid)
+- Replace `registration_handler.py` + `otp_handler.py` wiring in `nikita/api/routes/telegram.py`
+- Email regex validation; rate-limit (3 invalid OTP / 1h, 60s resend cooldown, 5min TTL)
+- Magic-link mint via admin endpoint (FR-5); inline-button delivery with `disable_web_page_preview=True`
+- `_handle_start_welcome` Nikita-voiced greeting + state transition
+- Tests: `test_signup_handler.py` (FSM), `test_signup_handler_link_preview.py` (Testing H1)
+- Telemetry emission at every FSM transition
+
+**ACs satisfied**: AC-2.1 through AC-2.3, AC-3.1 through AC-3.4, AC-4.1 through AC-4.4, AC-5.3, AC-5.4
+
+**Verification**: `uv run pytest tests/platforms/telegram/test_signup_handler.py tests/platforms/telegram/test_signup_handler_link_preview.py -v`
+
+### PR-F2a — Portal `/auth/confirm` route + IS-A interstitial + middleware
+
+**Branch**: `feat/215-pr-f2a-auth-confirm`
+**Estimate**: ~250 LOC, 6 hours
+**Dependency**: PR-F1b merged (so live signup → magic-link mints to working URL)
+
+**Scope**:
+- `portal/src/app/auth/confirm/route.ts` (server route handler, `verifyOtp({token_hash, type})`)
+- `portal/src/app/auth/confirm/interstitial.tsx` (~150 LOC IS-A always-interstitial Client Component)
+- `portal/src/lib/supabase/middleware.ts` — add `/auth/confirm` exemption
+- IAB UA detection regex (centralized helper for D4 GH #420)
+- ARIA contract (`role="main"`, `aria-labelledby`, `aria-describedby` per FR-6a)
+- Tests: `route.test.ts` (Testing H3 — T-E22/T-E23/T-E24/T-E27), `interstitial.test.tsx` (Testing H4 UA-spoof)
+
+**ACs satisfied**: AC-6.1 through AC-6.6, AC-PKCEGone, FR-6a visual contract
+
+**Verification**: `(cd portal && npm run test -- --run portal/tests/app/auth/confirm/) && (cd portal && npm run lint && npm run build)`
+
+### PR-F2b — Portal UI: `/login` redesign + landing CTA flip + `/onboarding/auth` deletion
+
+**Branch**: `feat/215-pr-f2b-portal-ui`
+**Estimate**: ~350 LOC, 6 hours
+**Dependency**: PR-F2a merged
+
+**Scope**:
+- `/login/page-client.tsx` Nikita-voiced redesign; `emailRedirectTo` → `/auth/confirm?next=/dashboard`
+- 3 landing CTA components: anon `href` → `https://t.me/Nikita_my_bot?start=welcome`
+- `landing-nav.tsx` adds visible "Sign in" + "Continue with Nikita" entries (FR-11)
+- `ClearanceGrantedCeremony.tsx` adds S3 portal-orientation copy (FR-14)
+- DELETE `portal/src/app/onboarding/auth/` (entire directory)
+- Middleware exemption removed for deleted route
+- Tests: `cta-href.test.tsx`, `page-client.test.tsx` (login Nikita voice)
+
+**ACs satisfied**: AC-1.1 through AC-1.3, AC-10.1 through AC-10.5, AC-11.1 through AC-11.3, AC-14.1 through AC-14.3
+
+**Verification**: portal lint+build+vitest; manual smoke of `/login` + landing CTAs in dev
+
+### PR-F3 — Legacy code removal + `auth_bridge_tokens` drop
+
+**Branch**: `chore/215-pr-f3-legacy-removal`
+**Estimate**: ~400 LOC deletions, 4 hours
+**Dependency**: PR-F2b merged + Phase F W1 dogfood passes + flag flipped + 1 deploy cycle elapsed
+
+**Scope**:
+- DELETE `nikita/platforms/telegram/{registration_handler.py, otp_handler.py}`
+- DELETE `nikita/platforms/telegram/auth.py:61-141` (`register_user`, `verify_otp` deprecated)
+- DELETE `nikita/db/models/auth_bridge.py` + `nikita/api/routes/auth_bridge.py` + repository
+- Migration: `DROP TABLE auth_bridge_tokens` (verified count=0)
+- DELETE `portal/src/components/onboarding/onboarding-wizard-legacy.tsx` + `steps/legacy/` + `components/legacy/`
+- DELETE dual `generate_portal_bridge_url` in `utils.py` (collapse to `onboarding/bridge_tokens.py`; closes GH #233 finally)
+- DELETE `_send_bare_portal_auth_link` (`commands.py:408-429`); DELETE `/onboard` slash-command (`commands.py:198`) + help-text (`commands.py:643`)
+- Add S2 phone-call proposal fragment to `nikita/agents/text/persona.py` (FR-13) — small additive change, batches with deletions
+- Update wizard slots: add `preferred_call_window` (FR-12) — coordinates with PR-F1a migration
+- Tests: assertion that deleted modules are not imported anywhere; agentic-flow tests for `preferred_call_window` slot per `.claude/rules/agentic-design-patterns.md` §8.4
+
+**ACs satisfied**: AC-LegacyDelete, AC-12.1 through AC-12.4, AC-13.1 through AC-13.2
+
+**Verification**: full pytest + portal vitest + lint + build; `grep -r "registration_handler\|otp_handler\|auth_bridge" nikita/ portal/src/` returns empty (only test files referencing deletion)
+
+## §5 Risks (lifted + extended from spec §10)
+
+| Risk | Likelihood | Impact | Mitigation | Owner |
+|---|---|---|---|---|
+| Telegram crawler burns single-use token | Medium | High | `disable_web_page_preview=True` + Testing H1 crawler-sim test | PR-F1b |
+| iOS Safari ITP / Telegram IAB session strand | Medium | High | IS-A always-interstitial unconditional | PR-F2a |
+| Email template misconfigured (signup vs login) | Medium | High | §7.4 dashboard runbook + AC-CodeOnlyTemplate + AC-LinkOnlyTemplate Phase F gate | PR-F1b + Phase F |
+| Migration `RENAME pending_registrations` breaks live FR-11c routing | Low | High | `chat_id` column retained verbatim; integration test on PR-F1a | PR-F1a |
+| `verification_type` hardcoded literal regression | Low | High | Static-grep gate in `test_portal_auth_admin.py` (Testing H2) | PR-F1a |
+| Wizard slot addition (FR-12) regresses cumulative state | Low | High | `.claude/rules/agentic-design-patterns.md` §8.4 monotonicity test | PR-F3 |
+| Walk subagent fabricates DB state | Medium | High | `.claude/rules/live-testing-protocol.md` PR-blocker anti-patterns | Phase F |
+| PR-F3 dropping `auth_bridge_tokens` breaks rollback | Low | Medium | Sequential to PR-F2b; 1 deploy cycle behind flipped flag | PR-F3 |
+| Vercel cache of deleted `/onboarding/auth` returns stale | Low | Medium | T-E29 cache purge in Phase E checklist post-PR-F2b | Phase E |
+| Supabase rate-limit collision in dogfood | Medium | Low | Plus-alias rotation per walk | Phase F |
+
+## §6 Testing Strategy (lifted from spec §8)
+
+- **Unit (70%)**: pytest for backend FSM + repository + admin endpoint + telemetry models; vitest for portal route + interstitial + landing components
+- **Integration (20%)**: `test_signup_flow_e2e.py` (mocked Supabase admin client end-to-end); `test_auth_confirm_session.py` (cookie + middleware getUser pickup)
+- **E2E (10%)**: Phase F per `.claude/rules/live-testing-protocol.md` 12-step canonical protocol (Telegram MCP + Gmail MCP + agent-browser; NO DB fabrication)
+- **Mandatory agentic-flow tests** (FR-12 wizard slot addition): cumulative-state monotonicity + completion-gate triplet + mock-LLM-emits-wrong-tool recovery
+- **Pre-PR grep gates** (zero-assertion shells, PII format strings, raw cache_key): all 3 must return empty before `/qa-review` dispatch
+- **Live-dogfood anti-patterns**: NO `INSERT INTO auth.users`, NO `signInWithPassword`, NO `E2E_AUTH_BYPASS=true`, NO custom JWT minting
+
+## §7 Quality Gates
+
+| Gate | Requirement | Enforcement |
+|---|---|---|
+| Article III (Test-First) | ≥2 ACs per task | enforced in `tasks.md` |
+| Article IV (Spec-First) | spec → plan → code | this plan + `/audit` |
+| Article VI (Simplicity) | ≤2 abstraction layers | reviewed in `/audit` |
+| Article VII (User-Story-Centric) | Tasks organized by FR | this plan §4 |
+| Article VIII (Parallelization) | `[P]` markers in `tasks.md` | enforced in Phase 6 |
+| Pre-push HARD GATE | full pytest+vitest+lint+build | per `.claude/rules/pr-workflow.md` |
+| Orchestrator grep-verify | both implementor claim + reviewer finding | per `.claude/rules/pr-workflow.md` |
+| QA review zero-tolerance | 0 findings ALL severities (incl. nitpicks) | per `feedback_qa_review_zero_tolerance.md` |
+| Subagent dispatch caps | HARD CAP + scope + exit criterion every dispatch | per `.claude/rules/parallel-agents.md` |
+| Live walk anti-fabrication | per `.claude/rules/live-testing-protocol.md` | Phase F |
+
+## §8 Out of scope (lifted from spec §2 — explicitly NOT in plan)
+
+- Voice onboarding (Spec 028 — separate)
+- Email change flow (deferred to Spec 215 v2)
+- Telegram LoginUrl / native ID (REJECTED for v1)
+- SSO (Google/Apple)
+- Password authentication
+- Multi-device linking UI
+- Multi-locale
+- Daily engagement emails (NEW Spec 216 — separate spec lifecycle)
+
+## §9 Sequencing summary
+
+```
+PR-F1a (data layer + admin endpoint)
+  ↓
+PR-F1b (signup_handler FSM + Telegram routing)
+  ↓
+PR-F2a (/auth/confirm + interstitial + middleware)
+  ↓
+PR-F2b (portal UI: /login + landing CTA + /onboarding/auth deletion)
+  ↓
+[Phase F W1 dogfood walk per live-testing-protocol.md]
+  ↓ (W1 PASSES)
+[Flag flips: NEXT_PUBLIC_TELEGRAM_FIRST_SIGNUP=true in Vercel prod]
+  ↓ (1 deploy cycle wait for rollback safety)
+PR-F3 (legacy deletion + auth_bridge_tokens drop + FR-12/13/14)
+```
+
+## §10 Handoff to Phase 6 (`/tasks`)
+
+`tasks.md` will decompose each PR into ordered T-numbered tasks with:
+- 2+ falsifiable ACs each
+- TDD pair (RED commit + GREEN commit minimum)
+- Estimate (S <1hr, M 1-4hr, L 4-8hr — no XL)
+- Dependencies (DAG)
+- `[P]` parallelization markers where independent
+- Owner: `executor-implement-verify` (per CLAUDE.md SDD Enforcement #10)
+
+After `/tasks`: `/audit` (Phase 7) returns PASS/FAIL on the full artifact set (spec.md + plan.md + tasks.md). PASS unblocks `/implement` (Phase 8). FAIL → max 3 fix iterations per SDD Enforcement #7.
+
+---
+
+**References**: see spec.md §11 References (lifted verbatim) for Plan v17.1, ADRs 009/010/011, project rules, Supabase docs, Telegram docs, sister specs.

--- a/specs/215-auth-flow-redesign/spec.md
+++ b/specs/215-auth-flow-redesign/spec.md
@@ -1,0 +1,913 @@
+# Feature Specification: Auth Flow Redesign — Telegram-First Signup (Spec 215)
+
+**Spec ID**: 215-auth-flow-redesign
+**Status**: DRAFT v1 (pending GATE 2 validators)
+**Date**: 2026-04-23
+**Author**: Phase C executor (per Plan v17.1)
+**Authority**: Plan v17.1 (`~/.claude/plans/delightful-orbiting-ladybug.md`) + ADR-010 (Telegram-first signup direction) + ADR-011 (live-testing-protocol-as-rule)
+**Number-collision note**: directory `215-heartbeat-engine/` also exists (COMPLETE). Per project precedent (`210-kill-skip-variable-response/` + `210-test-quality-audit/`), duplicate number prefixes are tolerated when directory slugs differ. ROADMAP tracks both.
+**Supersedes (implicit)**:
+- Spec 208 anon-CTA target (`/onboarding/auth`) — overridden by §4 FR-1 (CTA → Telegram deep-link)
+- Spec 214 implicit "auth precondition is portal magic-link" — Spec 215 owns auth; Spec 214 wizard executes post-auth
+- GH #393 (PKCE 422 on `/auth/callback` for new signups) — eliminated by `verifyOtp({token_hash, type})` (non-PKCE) replacement; resolved architecturally
+- Legacy Telegram-first OTP (`registration_handler.py` + `otp_handler.py`) — replaced by consolidated `signup_handler.py`
+- `auth_bridge_tokens` table + `/auth/bridge` route — collapsed to `portal_bridge_tokens` + new `/auth/confirm`
+
+---
+
+## §1 Goals
+
+1. **Telegram-first signup**: anonymous landing visitors enter via Telegram (`t.me/Nikita_my_bot?start=welcome`), not a portal magic-link form. The bot collects email, sends an OTP code to inbox, verifies the code in chat, then mints a single-use magic-link delivered IN-CHAT (not by email) for the user to tap and enter the portal wizard.
+2. **Single source of truth for identity**: `auth.users` is the only place a user identity is created. No fabricated rows. `telegram_id ↔ auth.uid()` binds during the signup phase (before wizard), making `/start <CODE>` (FR-11b) idempotent on re-tap.
+3. **Eliminate PKCE failure surface**: `/auth/confirm?token_hash=…&type=…&next=…` calls `verifyOtp({token_hash, type})` (non-PKCE), removing GH #393 entirely.
+4. **Nikita-voiced auth UX everywhere**: returning-user `/login` is Nikita-voiced; iOS interstitial post-magic-link is Nikita-voiced; error states never bounce to a generic `/login?error=…` cold page.
+5. **Full auth ownership**: signup, login, session refresh, dashboard auth gates, error UX, and email templates are all under Spec 215. Spec 214 references Spec 215 as an entry precondition, not an internal collaborator.
+
+## §2 Non-goals / Out of scope
+
+- **Voice onboarding (Spec 028)** — voice path is preserved for already-onboarded users; voice-onboarding redesign is a separate spec lifecycle.
+- **Email change flow** — DEFERRED to Spec 215 v2 (rare path; v1 escape hatch documented in §4 FR-15).
+- **Telegram LoginUrl / native ID** — REJECTED for v1 per plan §18.7 D12: game UX requires a verified email, so OTP path stays.
+- **Single sign-on (Google / Apple)** — out of scope; passwordless OTP only.
+- **Password authentication** — explicitly never. The system is passwordless end-to-end.
+- **Multi-device linking** — `/start <CODE>` retains the link-code primitive, but no UI for "link a second device" lands in v1.
+- **Multi-locale** — English-only.
+- **Daily engagement emails** — moves to NEW Spec 216 (per plan §20 S4).
+- **Schema migration tooling for in-flight users** — destructive reset of 5 dev `pending` users per D6 (plan §18.5 verification 2 + §19); productionised migration tool is out of scope.
+
+## §3 User flows
+
+### §3.1 Happy path (Telegram-first signup → wizard → game)
+
+```
+LANDING (portal /, anon)
+├─ [CTA-Hero] "Start Relationship" → href="https://t.me/Nikita_my_bot?start=welcome"
+├─ [CTA-Cta]  same
+└─ [CTA-Nav]  same  (+ visible "Sign in" secondary link → /login per FR-11)
+
+[USER TAPS CTA → Telegram opens]
+
+TELEGRAM /start welcome   (signup_handler.handle_welcome)
+├─ no telegram_id↔user binding yet
+├─ Nikita greets in-character + "What's your email?"
+└─ session.signup_state = AWAITING_EMAIL
+
+[USER SENDS EMAIL]
+
+TELEGRAM email handler   (signup_handler.handle_email)
+├─ regex validate format
+├─ supabase.auth.sign_in_with_otp({email, options:{should_create_user:True}})
+│   └─ Supabase sends ONE email → 6-digit OTP code (template per docs §1.1)
+├─ store telegram_signup_sessions(telegram_id, email, signup_state="code_sent",
+│       attempts=0, last_attempt_at=now, expires_at=now+5min)
+└─ Nikita: "Check your inbox. Send me the 6-digit code."
+
+[USER RECEIVES EMAIL → 6-digit code only — NO LINK]
+
+TELEGRAM code handler   (signup_handler.handle_code)
+├─ regex ^[0-9]{6}$
+├─ supabase.auth.verify_otp({email, token, type:"email"})
+│   ├─ INVALID → attempts++ ; if 3+ → rate-limit message
+│   └─ VALID → continue
+├─ supabase.auth.admin.generate_link(
+│       {type:"magiclink", email,
+│        options:{redirect_to:"<portal>/auth/confirm?next=/onboarding"}})
+│   └─ returns {action_link, hashed_token, verification_type, ...}
+│       NB: verification_type is dynamic — "magiclink" if user pre-exists,
+│       "signup" if NEW. Backend MUST use response value, NOT hardcode (§21).
+├─ public.users row binding (FR-11b 307 auto-provision; idempotent if exists)
+├─ UPDATE users SET telegram_id = <tg_id> WHERE id = <auth_uid>
+├─ session.signup_state = MAGIC_LINK_SENT ; magic_link_sent_at = now
+└─ Nikita reply via inline URL button:
+   text:  "You're cleared. Tap to enter."
+   button: action_link
+   send_message(..., disable_web_page_preview=True)   ← MANDATORY (§5 NFR-Sec-1)
+
+[USER TAPS LINK → mobile browser / IAB opens Supabase verify URL]
+[Supabase verifies token, sets cookies, 302 → portal /auth/confirm?token_hash=…&type=…&next=/onboarding]
+
+PORTAL /auth/confirm (route handler)   (NEW — portal/src/app/auth/confirm/route.ts)
+├─ read ?token_hash, ?type, ?next from query
+├─ if missing → redirect /login?error=missing_params
+├─ createServerClient (cookies adapter per @supabase/ssr docs)
+├─ supabase.auth.verifyOtp({type, token_hash})   ← type is from query, NOT hardcoded
+├─ if error → redirect /login?error=<code>
+└─ render IS-A always-interstitial page (NOT raw 302)
+   ├─ "You're cleared. Enter the portal." (Nikita voice)
+   ├─ Primary button "Enter the portal" → router.push(next)
+   └─ Secondary "Open in Safari" Universal Link (iOS IAB escape, ~150 LOC)
+
+PORTAL /onboarding   (existing Spec 214 FR-11d wizard)
+├─ getUser() passes (just minted)
+├─ if onboarded → /dashboard
+└─ mount OnboardingWizard (chat-first, cumulative state, Pydantic gate)
+
+[WIZARD CONVERSATION_COMPLETE → ClearanceGrantedCeremony (FR-11b retained)]
+├─ S2: wizard slot for "preferred call window" was collected pre-completion
+├─ S3: ceremony copy adds "Bookmark this portal — your dashboard, history, and
+│       Nikita's daily highlights live here."
+└─ a href="t.me/Nikita_my_bot?start=<LINK_CODE>"  (FR-11b — synchronous user-tap gate)
+
+[USER TAPS → Telegram /start <CODE>]
+
+TELEGRAM /start <CODE>   (existing FR-11b path; semantics adjusted per D1)
+├─ verify_code atomic DELETE..RETURNING
+├─ telegram_id is ALREADY bound (signup phase)
+│   └─ update_telegram_id is IDEMPOTENT no-op
+├─ claim_handoff_intent (one-shot)
+└─ BackgroundTasks._dispatch_handoff_greeting
+   └─ S2: Nikita proactively proposes phone-call within first 3 turns
+
+[GAME STARTS]
+```
+
+### §3.2 Supporting diagrams (lifted from Plan §18.10 tree-of-thought)
+
+Six diagrams produced by review agent `a0827ffa586d754ce` are referenced (not embedded inline) — Phase D `/plan` will copy them into `docs/diagrams/onboarding-journey-v17.md`:
+
+1. Landing-page user-state decision tree (anon / auth-not-onboarded / auth-onboarded)
+2. Telegram-first signup FSM (`UNKNOWN → AWAITING_EMAIL → CODE_SENT → MAGIC_LINK_SENT → BOUND → COMPLETED`)
+3. Happy-path sequence diagram (User / Telegram / Bot / Supabase / Email / Browser / Portal, latency budget t<30s)
+4. Failure-mode sequences (4a code expired, 4b magic-link TTL, 4c different email mid-flow)
+5. Data-model dependency ERD with write-sites + dead tables marked
+6. Phase-by-phase delivery Gantt with parallelization markers
+
+### §3.3 Returning-user login flow
+
+```
+LANDING NAV "Sign in" → /login (Nikita-voiced)
+├─ email form (existing portal/src/app/login/page-client.tsx, REDESIGNED)
+├─ supabase.auth.signInWithOtp({email,
+│     options:{emailRedirectTo:"<portal>/auth/confirm?next=/dashboard"}})
+│   └─ Supabase sends email containing magic LINK only (template §1.2 of docs)
+├─ user clicks link in email → Supabase /verify → /auth/confirm (same handler)
+└─ Nikita-voiced "You're cleared. Welcome back." interstitial → /dashboard
+```
+
+Returning login email template is **link-only** (D2 round 1). Telegram signup template is **code-only**. Two different Supabase template configurations; documented in §7 Architecture + Supabase dashboard runbook.
+
+---
+
+## §4 Functional Requirements
+
+### FR-1 — Landing CTAs flip to Telegram deep-link
+**Description**: All three landing CTAs (`hero-section.tsx`, `cta-section.tsx`, `landing-nav.tsx`) render `href="https://t.me/Nikita_my_bot?start=welcome"` for the anonymous branch. Authenticated branch behavior preserved per FR-11 (D3).
+
+**Acceptance** (AC-1):
+- AC-1.1: For anon visitor, Hero/Cta/Nav buttons emit `<a href="https://t.me/Nikita_my_bot?start=welcome">…</a>` with no `<Link>` interception
+- AC-1.2: For auth'd-not-onboarded user, button routes to `/dashboard` (which middleware-redirects to `/onboarding` if `onboarding_status != 'completed'`)
+- AC-1.3: For auth'd-onboarded user, button routes to `/dashboard`; nav shows secondary "Continue with Nikita" → Telegram deep-link
+
+### FR-2 — Telegram bot greets + collects email
+**Description**: When `/start welcome` is received and the calling `telegram_id` has no bound `auth.users.id`, signup_handler greets Nikita-style and asks for email. Subsequent free-text from this user enters `signup_handler.handle_email`. Email is regex-validated (`^[^\s@]+@[^\s@]+\.[^\s@]+$`); invalid → Nikita-voiced rejection ("That email doesn't look right. Try again.").
+
+**Acceptance** (AC-2):
+- AC-2.1: `/start welcome` for unbound `telegram_id` triggers welcome message and sets `signup_state=AWAITING_EMAIL` row in `telegram_signup_sessions`
+- AC-2.2: invalid-email submission emits Nikita-voiced rejection AND keeps `signup_state=AWAITING_EMAIL` (no row mutation)
+- AC-2.3: valid-email submission triggers FR-3
+
+### FR-3 — Backend OTP send via `sign_in_with_otp` (signup template fires)
+**Description**: For valid email, backend calls `client.auth.sign_in_with_otp({email, options:{should_create_user:True}})`. Supabase fires the SIGNUP email template (code-only per D2 round 1; new HTML referenced in `docs-to-process/20260423-auth-templates-v17-1.md` §1.1). Stores `telegram_signup_sessions(telegram_id, email, signup_state='code_sent', expires_at=now+5min, attempts=0, last_attempt_at=now)`. Nikita reply: "Check your inbox. Send me the 6-digit code."
+
+**Acceptance** (AC-3):
+- AC-3.1: `sign_in_with_otp` is called with `should_create_user=True`
+- AC-3.2: row inserted/updated in `telegram_signup_sessions` with TTL = 5 min (D10)
+- AC-3.3: Nikita reply matches Nikita-voice tone (no SaaS "Email sent successfully")
+- AC-3.4: Supabase signup email template renders `{{ .Token }}` only (not `{{ .ConfirmationURL }}`); template configuration documented in §7
+
+### FR-4 — Telegram code verify via `verify_otp({email, token, type})`
+**Description**: When `signup_state='code_sent'` and incoming free-text matches `^[0-9]{6}$`, backend calls `client.auth.verify_otp({email, token, type:"email"})`. On `INVALID`: increment `attempts`; if `attempts >= 3` within 1 hour, rate-limit per D10. On `VALID`: proceed to FR-5.
+
+**Acceptance** (AC-4):
+- AC-4.1: invalid code increments `attempts`; Nikita reply: "Not right. {N} tries left."
+- AC-4.2: 3 invalid attempts within 1h triggers rate-limit message + `signup_state` reset to `AWAITING_EMAIL`
+- AC-4.3: expired code (now > expires_at) triggers Nikita-voiced "Code expired. Send /start to retry." + row purge
+- AC-4.4: valid code response proceeds to FR-5 atomically
+
+### FR-5 — Backend mints magic-link via `admin.generate_link`; bot delivers via Telegram with link-preview disabled
+**Description**: After FR-4 success, backend calls `client.auth.admin.generate_link({type:"magiclink", email, options:{redirect_to:"<portal>/auth/confirm?next=/onboarding"}})`. Supabase returns `{action_link, hashed_token, verification_type, ...}`. **No second email is dispatched** — confirmed by Plan §21 spike against prod Supabase. Backend stores `magic_link_token=hashed_token`, `magic_link_sent_at=now`, `signup_state='magic_link_sent'`, `verification_type=<response value>`. Bot sends `action_link` to Telegram via inline URL button with **`disable_web_page_preview=True`** (PR-blocker — see §5 NFR-Sec-1).
+
+**Acceptance** (AC-5):
+- AC-5.1: `admin.generate_link` is called with `type="magiclink"` AND `options.redirect_to` is the portal `/auth/confirm?next=/onboarding` URL
+- AC-5.2: `verification_type` from response is persisted on the row (used in FR-6 lookup); test asserts no hardcoded `"magiclink"` literal in handler code (regression guard against §21 refinement)
+- AC-5.3: Telegram message uses `send_message(..., disable_web_page_preview=True)`. Phase E test simulates a Telegram link-preview crawler `GET` against `action_link` and asserts the user can still consume the token (single-use semantics not pre-burned)
+- AC-5.4: Nikita reply text is in-character ("You're cleared. Tap to enter.") + button label is "Enter portal"
+- AC-5.5: bind `public.users.telegram_id = <telegram_id>` is idempotent (re-runs OK); row created via FR-11b 307 auto-provision pathway if absent
+
+### FR-6 — Portal `/auth/confirm` route + IS-A always-interstitial
+**Description**: NEW route `portal/src/app/auth/confirm/route.ts` (server route handler) reads `?token_hash`, `?type`, `?next` from URL. Calls `supabase.auth.verifyOtp({token_hash, type})` server-side via `createServerClient` (`@supabase/ssr` cookies adapter per Next.js 16 App Router pattern). On error: redirect to `/login?error=<code>`. On success: render IS-A always-interstitial component (NOT raw 302). Interstitial has primary "Enter the portal" button (router.push next), Nikita-voiced copy, and optional "Open in Safari" Universal Link (iOS IAB escape per Plan §18.3).
+
+**Idempotency contract (TTL-only) — resolves H1-API conflict between T-E23 and T-E27**:
+- Re-tap of the same magic-link URL **before** `expires_at` → idempotent: Supabase returns the existing session (or mints an equivalent one); user advances to `next` without error. (T-E23)
+- Re-tap **after** `expires_at` → `verifyOtp` returns expired-token error; route redirects to `/login?error=link_expired`. (T-E27 reframed)
+- There is NO single-use replay block before TTL. The single-use semantic is purely TTL-based: a tapped link remains tappable until expiry, after which it is dead.
+
+**Acceptance** (AC-6):
+- AC-6.1: `/auth/confirm` GET with valid `token_hash + type + next` calls `verifyOtp({token_hash, type})` and sets cookies on response
+- AC-6.2: invalid/missing params → redirect `/login?error=missing_params` (no crash)
+- AC-6.3: expired token_hash → redirect `/login?error=link_expired` with Nikita-voiced error state
+- AC-6.4: success path renders interstitial UNCONDITIONALLY (no UA detection branch); interstitial requires user gesture to advance (Apple SFSafariViewController self-contained-session mitigation, plan §18.3 Approach IS-A)
+- AC-6.5: interstitial includes "Open in Safari" Universal Link visible iff `navigator.userAgent` matches IAB pattern (Telegram in-app browser detection)
+- AC-6.6: Phase E browser test verifies session cookie present on redirected `/onboarding` request
+- AC-6.7: re-tap before `expires_at` is idempotent — second `verifyOtp` call succeeds and either returns the existing session or mints an equivalent one; UX advances to `next` without `?error=*` (T-E23 covers)
+- AC-6.8: re-tap after `expires_at` redirects to `/login?error=link_expired`; T-E27 covers
+
+### FR-6a — Visual Contract: IS-A Interstitial (frontend H1)
+
+The IS-A interstitial Client Component (`portal/src/app/auth/confirm/interstitial.tsx`) MUST conform to:
+
+**Tailwind tokens (allowlist)**: `bg-background`, `text-foreground`, `font-display text-2xl`, `text-muted-foreground text-sm`, `rounded-2xl shadow-lg`, `space-y-6 p-8`, `mx-auto max-w-md min-h-screen flex items-center justify-center`. No raw hex colors. No inline styles.
+
+**ASCII layout**:
+
+```
+┌─────────────────────────────────────────────┐
+│                                             │
+│   ┌─────────────────────────────────────┐   │
+│   │                                     │   │
+│   │   You're cleared. Enter the portal. │   │  ← h1 id=interstitial-title
+│   │                                     │   │     font-display text-2xl text-foreground
+│   │   Tap to enter your portal.         │   │  ← p id=interstitial-subtitle
+│   │                                     │   │     text-muted-foreground text-sm
+│   │                                     │   │
+│   │            [ Continue to Nikita ]   │   │  ← Button variant="default"
+│   │                                     │   │     aria-describedby=interstitial-subtitle
+│   │       [ Open in Safari ] (iff IAB)  │   │  ← optional secondary, iOS IAB only
+│   │                                     │   │
+│   └─────────────────────────────────────┘   │
+│              centered card                  │
+└─────────────────────────────────────────────┘
+```
+
+**shadcn components**: `<Card>` for the wrapper, `<CardContent>` for body, `<Button variant="default">` for primary, `<Button variant="link">` for "Open in Safari" Universal Link.
+
+**ARIA**:
+- Root container: `role="main"`
+- Card: `aria-labelledby="interstitial-title"`
+- Primary button: `aria-describedby="interstitial-subtitle"`
+- "Open in Safari" link (when present): `aria-label="Open this page in Safari"`
+
+### FR-7 — Wizard entry (delegates to Spec 214 FR-11d)
+**Description**: After interstitial advance to `/onboarding`, control transfers to Spec 214 FR-11d chat-first wizard. Spec 215 contributes nothing further to wizard internals; wizard's `getUser()` precondition is now reliably satisfied because Spec 215 minted the session.
+
+**Acceptance** (AC-7):
+- AC-7.1: `/onboarding` route's existing `getUser()` check passes immediately after `/auth/confirm` advance (no race)
+- AC-7.2: Spec 214 FR-11d wizard mounts; no Spec 215 code reaches into wizard internals
+
+### FR-8 — Wizard completion → ClearanceGrantedCeremony renders link_code (synchronous tap gate)
+**Description**: Wizard completion fires existing FR-11b ceremony with `t.me/Nikita_my_bot?start=<LINK_CODE>`. Per D1 (plan §18.6 Option C2): the link_code retains its role as a SYNCHRONOUS user-tap gate confirming "user is ready to play". Because `telegram_id` was bound during signup (FR-5), the `/start <CODE>` handler's `update_telegram_id` becomes an idempotent no-op — semantics unchanged from existing FR-11b code path.
+
+**Acceptance** (AC-8):
+- AC-8.1: ceremony renders the `t.me/Nikita_my_bot?start=<LINK_CODE>` URL (existing FR-11b)
+- AC-8.2: when user taps and `telegram_id` is already bound (signup phase), `update_telegram_id` is no-op (idempotent UPDATE..RETURNING with guard)
+- AC-8.3: `claim_handoff_intent` still fires; greeting dispatch unchanged
+
+### FR-9 — `_dispatch_handoff_greeting` fires on `/start <CODE>` consumption
+**Description**: Existing FR-11b/c path. `_dispatch_handoff_greeting` fires from BackgroundTasks. S2 (per §20): the greeting + first 3 turns of conversation include a proactive proposal to set up a phone call.
+
+**Acceptance** (AC-9):
+- AC-9.1: greeting dispatched within 5 seconds of `/start <CODE>` consumption
+- AC-9.2: phone-call proposal appears in one of the first 3 Nikita turns (S2)
+
+### FR-10 — Returning-user portal `/login` redesigned Nikita-voiced (link-only template)
+**Description**: `portal/src/app/login/page-client.tsx` redesigned with Nikita-voiced copy. Magic-link flow only (`signInWithOtp` with `emailRedirectTo=/auth/confirm?next=/dashboard`). Email template is **link-only** (different from FR-3's code-only signup template) — see `docs-to-process/20260423-auth-templates-v17-1.md` §1.2.
+
+**No code-input field**: `/login` is link-only per D2. The page MUST NOT render any 6-digit OTP input control. Code-only flow is reserved for the Telegram signup path (FR-4); on the portal, the only authenticated re-entry is via magic-link click.
+
+**Acceptance** (AC-10):
+- AC-10.1: `/login` UI matches landing aesthetic (no generic SaaS form)
+- AC-10.2: copy is Nikita-voiced (no "Welcome back!" sterile greeting)
+- AC-10.3: `signInWithOtp` is called with `emailRedirectTo` pointing to `/auth/confirm?next=/dashboard`
+- AC-10.4: Supabase magic-link email template (login context) renders `{{ .ConfirmationURL }}` only (no `{{ .Token }}`)
+- AC-10.5: error states show Nikita-voiced messages (not `?error=auth_callback_failed` cold page)
+- AC-10.6: page DOM contains zero `<input type="text|number|tel" inputmode="numeric">` of length 6 (assert via vitest DOM scan); no code-input field exists
+
+### FR-10a — Visual Contract: `/login` Redesign (frontend H2)
+
+The redesigned `portal/src/app/login/page-client.tsx` MUST conform to:
+
+**Tailwind tokens (allowlist)**: `bg-background`, `text-foreground`, `font-display text-3xl`, `text-muted-foreground`, `rounded-2xl shadow-lg`, `space-y-6 p-8`, `mx-auto max-w-md min-h-screen flex items-center justify-center`, `w-full`. No raw hex colors. No inline styles.
+
+**ASCII layout**:
+
+```
+┌──────────────────────────────────────────────┐
+│                                              │
+│   ┌──────────────────────────────────────┐   │
+│   │                                      │   │
+│   │   Welcome back. Tell me where to     │   │  ← h1 id=login-title
+│   │   send the link.                     │   │     font-display text-3xl text-foreground
+│   │                                      │   │     (Nikita-voiced; reviewed for tone)
+│   │   ┌──────────────────────────────┐   │   │
+│   │   │ you@example.com              │   │   │  ← <Input type="email"> aria-label="Email address"
+│   │   └──────────────────────────────┘   │   │
+│   │                                      │   │
+│   │   [ Send me the magic link ]         │   │  ← <Button variant="default" w-full>
+│   │                                      │   │
+│   │   ───────────────────────────────    │   │
+│   │                                      │   │
+│   │   New here? Sign up via Telegram →   │   │  ← <Link href="https://t.me/Nikita_my_bot?start=welcome">
+│   │                                      │   │
+│   └──────────────────────────────────────┘   │
+└──────────────────────────────────────────────┘
+```
+
+**shadcn components**: `<Card>` + `<CardContent>` for wrapper, `<Input>` for email, `<Button variant="default">` for submit, `<Link>` (next/link wrapped in shadcn link styles) for the Telegram fallback.
+
+**EXPLICITLY REMOVED**: any `<Input>` for a 6-digit code; any "Verify code" button; any `verifyOtp({email, token, type:'email'})` client call. The portal `/login` page is link-only.
+
+**ARIA**:
+- Form root: `role="form"`, `aria-labelledby="login-title"`
+- Email input: `aria-label="Email address"`, `aria-required="true"`, `aria-invalid={hasError}`
+- Submit button: when loading, `aria-busy="true"`; when disabled, `aria-disabled="true"`
+- Error region (Nikita-voiced): `role="alert"` `aria-live="polite"`
+
+### FR-11 — Landing nav: visible "Sign in" + "Continue with Nikita" entries (D3)
+**Description**: `landing-nav.tsx` adds two visible entries beyond the primary CTA:
+- "Sign in" (always visible) → `/login` (returning users)
+- "Continue with Nikita" (visible iff auth'd + onboarded) → Telegram deep-link
+
+**Acceptance** (AC-11):
+- AC-11.1: anon users see primary CTA (Telegram) + "Sign in" link
+- AC-11.2: auth'd-onboarded users see "Continue with Nikita" → Telegram deep-link AND avatar/dashboard entry
+- AC-11.3: auth'd-not-onboarded users see CTA → /onboarding (resume)
+
+### FR-12 — Wizard slot: "preferred call window" (S2 — early phone-call proposal)
+**Description**: Spec 214 FR-11d wizard adds one new slot: `preferred_call_window` (free-text, optional). Persisted to `user_profiles`. Used by S2 (FR-13) to ground Nikita's call-scheduling proposal.
+
+**Acceptance** (AC-12):
+- AC-12.1: `WizardSlots` Pydantic model adds `preferred_call_window: Optional[str]`
+- AC-12.2: cumulative-state monotonicity test (per `.claude/rules/testing.md` Agentic-Flow Test Requirements) covers the new slot
+- AC-12.3: `user_profiles` schema migration adds `preferred_call_window text NULL`
+- AC-12.4: wizard agent's dynamic instructions include the new slot in `state.missing` injection
+
+### FR-13 — Post-handoff: bot proactively proposes phone call within first 3 turns (S2)
+**Description**: After FR-9 greeting fires, the next 3 turns of Telegram conversation include a Nikita-voiced proposal to schedule a phone call, grounded in `user_profiles.preferred_call_window` if populated.
+
+**Acceptance** (AC-13):
+- AC-13.1: text-agent persona/prompt update includes a "propose-phone-call" template fragment that fires for users with `chapter=1 AND telegram_handoff_at IS NOT NULL AND turns_since_handoff <= 3`
+- AC-13.2: proposal copy is in-character (no SaaS scheduling-link UX)
+
+### FR-14 — ClearanceGrantedCeremony copy adds portal-orientation teaching (S3)
+**Description**: ClearanceGrantedCeremony component (Spec 214) adds the line: "Bookmark this portal — your dashboard, history, and Nikita's daily highlights live here." Wizard's final Nikita turn echoes a similar bookmark prompt.
+
+**Acceptance** (AC-14):
+- AC-14.1: visual snapshot test of ceremony component asserts new copy line present
+- AC-14.2: wizard's terminal-turn message includes the bookmark phrasing
+- AC-14.3: copy passes Nikita-voice review (no SaaS-tone "Don't forget to bookmark!")
+
+### FR-15 — Email change flow (DEFERRED to Spec 215 v2)
+
+**Status**: **DEFERRED to Spec 215 v2.** First-class email-change support (mid-funnel email update with audit trail, OTP re-verification, and idempotent re-bind) is explicitly OUT of scope for v1 and tracked under the "Deferred to v2" subsection at the end of §4.
+
+**Description (v1 escape hatch only)**: Mid-funnel email change is handled by destructive reset only. v1 escape hatch: user contacts support (`support@nikita-mygirl.com`) OR user issues `/start` in Telegram which triggers a destructive reset of `telegram_signup_sessions` (delete pending row → start over with new email at FR-2). User-facing copy in FR-2 will mention "send /start to start over."
+
+**Acceptance** (AC-15):
+- AC-15.1: spec body explicitly documents the v1 escape hatch
+- AC-15.2: Telegram `/start` handler for users in `signup_state IN (AWAITING_EMAIL, CODE_SENT, MAGIC_LINK_SENT)` does destructive reset (delete row, restart at FR-2)
+
+### Deferred to v2
+
+The following requirements are explicitly OUT of scope for Spec 215 v1 and tracked for Spec 215 v2:
+
+- **FR-15 first-class email change**: mid-funnel email update without destructive reset; preserve `telegram_id ↔ auth.uid()` binding while rotating `auth.users.email`; OTP re-verification on the new address; audit trail in `auth_email_change_log` (new table). v1 ships destructive-reset escape hatch only.
+- (Other v2 candidates may be appended here as the analyze-fix loop proceeds.)
+
+### FR-16 — Edge cases T-E1 through T-E30 (consolidated from Plan §17.2)
+
+| # | Edge case | Target behavior | Coverage status |
+|---|---|---|---|
+| T-E1 | Anon clicks landing CTA | → Telegram deep-link `?start=welcome` | FR-1 |
+| T-E2 | User sends invalid email format to bot | Regex reject; Nikita-voiced message | FR-2 |
+| T-E3 | User sends email typo (`gmial.com`) | D8 post-failure inline "Change email" button (no preemptive list) | FR-2 + signup_handler |
+| T-E4 | User sends correct 6-digit code | verifyOtp → mint magic-link → Telegram delivery | FR-4, FR-5 |
+| T-E5 | User sends wrong code (1-2 attempts) | Nikita: "Not right. {N} tries left." | FR-4 |
+| T-E6 | User sends wrong code (3+ within 1h) | Rate-limit; reset to AWAITING_EMAIL | FR-4, D10 |
+| T-E7 | User sends code after 5min expiry | Nikita: "Code expired. Send /start to retry." + row purge | FR-4 |
+| T-E8 | User abandons after email, returns 10min later | `/start` finds CODE_SENT state → "Send your code or /start to restart." | FR-15, signup_handler |
+| T-E9 | User abandons after magic-link, returns 1h later | `/login` re-issues magic-link OR Nikita-voiced re-entry via Telegram FSM | FR-10, FR-15 |
+| T-E10 | Email already bound to DIFFERENT telegram_id | "That email is already linked. Contact support." (no v1 self-service) | FR-15 (escape hatch) |
+| T-E10b | pending_registration row in `code_sent` but expired | Auto-purge via pg_cron + restart | FR-4 + cron |
+| T-E11 | Same email + same telegram_id (re-signup attempt) | Skip code; mint magic-link directly (idempotent) | FR-5 idempotency |
+| T-E12 | User completes wizard, never taps CTA | link_code expires (10min); manual re-mint OR D11 reset | FR-8 (existing) |
+| T-E13 | User already onboarded, clicks landing CTA | → /dashboard | FR-11 (D3) |
+| T-E14 | User cleared cookies, clicks landing CTA | → Telegram (anon) OR /login (returning) | FR-1, FR-11 |
+| T-E15 | Returning user wants portal login | `/login` Nikita-voiced + magic-link | FR-10 |
+| T-E16 | User has telegram_id bound, no portal session | FR-11c E5/E6 resume bridge (existing) | unchanged |
+| T-E17 | User types `/start` in Telegram after onboarded | E2 welcome (existing FR-11c) | unchanged |
+| T-E18 | User types `/start` mid-onboarding (in MAGIC_LINK_SENT state) | "Continue by checking email for code." OR destructive reset | FR-15 |
+| T-E19 | User sends email-shaped string in Telegram after onboarded | Nikita responds in-character; no signup re-trigger | signup_handler guard |
+| T-E22 | Magic-link clicked after TTL (`now > expires_at`) | `/auth/confirm` calls `verifyOtp`, gets expired-token error, redirects `/login?error=link_expired` (Nikita-voiced); user-facing copy: "Link expired. Send /start in Telegram." | FR-6, AC-6.3, AC-6.8 |
+| T-E23 | Magic-link clicked twice within TTL (e.g., user re-taps Telegram message 30s later) | Idempotent — both taps succeed; Supabase returns the existing session (or mints an equivalent one); UX advances to `next` without `?error=*`. NO single-use replay block before TTL. | FR-6, AC-6.7 |
+| T-E24 | Magic-link clicked on different device (no cookies) within TTL | New session minted on the second device; lands on wizard. The first device's session is unaffected (independent cookie jar). | FR-6 |
+| T-E25 | Telegram link-preview crawler GET burns token | MITIGATED: `disable_web_page_preview=True` | FR-5, NFR-Sec-1 |
+| T-E26 | iOS Safari ITP / Telegram IAB session strand | MITIGATED: IS-A always-interstitial | FR-6 |
+| T-E27 | Token replay attempt **after** `expires_at` (e.g., user shares Telegram screenshot, recipient taps next day) | TTL has already lapsed → `verifyOtp` returns expired-token error → `/login?error=link_expired`. Reframed from "single-use replay" to **TTL-only**: T-E23 establishes that re-tap before TTL is idempotent; T-E27 covers the after-TTL case only. | FR-6, AC-6.8 |
+| T-E28 | PKCE 422 (GH #393) reproduction | ELIMINATED: `verifyOtp({token_hash, type})` is non-PKCE | FR-6, §11 |
+| T-E29 | Vercel cache of deleted `/onboarding/auth` route | T-deploy cache purge after PR-F2b merge | §9 Migration |
+| T-E30 | Game-over re-email path | Skip OTP; mint magic-link directly (auth.users row exists) | D7, FR-10 variant |
+
+---
+
+## §5 Non-functional requirements
+
+### NFR-Sec-1 (PR-blocker) — `disable_web_page_preview=True` on every Telegram message containing magic-link
+Telegram's link-preview crawler will GET the action_link to render an embed, burning the single-use token before the user can tap. Bot MUST set `disable_web_page_preview=True` on the `send_message` call. Phase E test simulates the crawler `GET` and asserts subsequent user-tap still consumes the token successfully.
+
+### NFR-Sec-2 — IS-A always-interstitial unconditional (no UA branch)
+Apple SFSafariViewController is self-contained per Apple docs; cookies set inside Telegram in-app browser do not persist into Safari.app. The interstitial requires user gesture to advance, which preserves cookies. ~150 LOC component lands in PR-F2a (per Plan §18.4).
+
+### NFR-Sec-3 — No PII in logs
+Per existing `.claude/rules/testing.md` Pre-PR Grep Gates + GH #284: do not log raw email values, raw OTP codes, raw `magic_link_token`. Use `email_hash = sha256(email)[:12]` or `telegram_id` only. Pre-PR grep gate (#2) enforces.
+
+### NFR-Sec-4 — Rate limits (D10)
+- 10 emails sent per hour per telegram_id (resend cooldown 60s)
+- 15 OTP codes verified per hour per email
+- Code TTL 5 minutes (purged via pg_cron)
+- Magic-link TTL: Supabase default (1h), single-use
+
+### NFR-Sec-5 — Session lifetime
+- Access token: Supabase default 1h (tunable 5m–1h)
+- Refresh token: never-expires by default (single-use)
+- Middleware MUST call `getUser()` to trigger refresh-token exchange (NEVER `getSession()` per Supabase Next.js 16 SSR guide). Existing `portal/src/lib/supabase/middleware.ts:40` does this correctly; preserved.
+
+### NFR-Acc-1 — Accessibility / Nikita-voiced error states
+All error states (`/login?error=…`, interstitial fallback, Telegram message rejections) maintain the Nikita-voice tone. No generic "Auth Error" or "Something went wrong" copy. Phase E checklist explicitly verifies copy review pass.
+
+### NFR-Perf-1 — Latency budget
+End-to-end signup (CTA tap → wizard entry) targets t < 30s P50, t < 60s P95 (Plan §18.10 Diagram 3). Telemetry events per FR-Telemetry-1 enable funnel monitoring.
+
+### FR-Telemetry-1 — Signup funnel events
+Add to `nikita/monitoring/events.py` (per Plan §17.6):
+- `signup_started_telegram` (telegram_id, ts)
+- `signup_email_received` (telegram_id, email_hash, ts)
+- `signup_code_sent` (email_hash, ts, supabase_response_code)
+- `signup_code_verified` (email_hash, attempts_count, ts)
+- `signup_magic_link_minted` (email_hash, ts, action_link_ttl, verification_type)
+- `signup_magic_link_clicked` (email_hash, ts, latency_ms_from_mint)
+- `signup_wizard_session_minted` (user_id, ts)
+- `signup_wizard_completed` (user_id, ts, total_signup_to_complete_ms)
+- `signup_failed` (telegram_id, stage, reason)
+
+---
+
+## §6 Acceptance Criteria Summary
+
+| AC | Mapped FR | Falsifiable assertion |
+|---|---|---|
+| AC-1.1..AC-1.3 | FR-1 | Landing CTAs route per branch |
+| AC-2.1..AC-2.3 | FR-2 | Email collection state transitions correct |
+| AC-3.1..AC-3.4 | FR-3 | OTP send + signup template + 5min TTL |
+| AC-4.1..AC-4.4 | FR-4 | Code verify + rate-limit + expiry |
+| AC-5.1..AC-5.5 | FR-5 | generate_link + verification_type passthrough + disable_web_page_preview + idempotent bind |
+| AC-6.1..AC-6.6 | FR-6 | /auth/confirm route + IS-A interstitial + cookie persistence |
+| AC-7.1..AC-7.2 | FR-7 | Wizard entry handoff |
+| AC-8.1..AC-8.3 | FR-8 | Ceremony link_code synchronous gate; idempotent telegram_id |
+| AC-9.1..AC-9.2 | FR-9 | Greeting dispatch + S2 phone-call proposal |
+| AC-10.1..AC-10.5 | FR-10 | /login Nikita-voiced + link-only template |
+| AC-11.1..AC-11.3 | FR-11 | Nav dual entries |
+| AC-12.1..AC-12.4 | FR-12 | Wizard slot preferred_call_window |
+| AC-13.1..AC-13.2 | FR-13 | Post-handoff phone-call proposal |
+| AC-14.1..AC-14.3 | FR-14 | Ceremony portal-orientation copy |
+| AC-15.1..AC-15.2 | FR-15 | Email change escape hatch documented + destructive reset works |
+| AC-CodeOnlyTemplate | FR-3 | Supabase signup template renders `{{ .Token }}` ONLY (no link) — verify via dashboard inspection + Phase E live email |
+| AC-LinkOnlyTemplate | FR-10 | Supabase magic-link (login) template renders `{{ .ConfirmationURL }}` ONLY (no token) |
+| AC-LegacyDelete | §9 | `nikita/platforms/telegram/registration_handler.py` and `otp_handler.py` removed; `auth_bridge_tokens` table dropped (count=0 verified Plan §18.9) |
+| AC-PKCEGone | T-E28 | Repro test for GH #393 cannot reproduce on `/auth/confirm` path (non-PKCE verifyOtp) |
+| AC-LiveWalk | all | Spec 215 implementation passes a Phase F W1 dogfood walk per `.claude/rules/live-testing-protocol.md` (12-step canonical protocol; NO DB fabrication; Telegram MCP + Gmail MCP + agent-browser only) |
+
+---
+
+## §7 Architecture
+
+### §7.1 New / changed files
+
+**NEW**:
+- `nikita/platforms/telegram/signup_handler.py` — consolidated FSM (handle_welcome, handle_email, handle_code; replaces legacy registration_handler + otp_handler)
+- `nikita/api/routes/portal_auth.py::generate_magiclink_for_telegram_user` — admin endpoint (service-role only) invoked by signup_handler after FR-4 success
+- `portal/src/app/auth/confirm/route.ts` — server route handler (GET) calling `verifyOtp({token_hash, type})`
+- `portal/src/app/auth/confirm/interstitial.tsx` — IS-A always-interstitial Client Component (~150 LOC)
+- `supabase/migrations/<NNN>_rename_pending_registrations_to_telegram_signup_sessions.sql` — table rename + new columns
+- `supabase/migrations/<NNN>_drop_auth_bridge_tokens.sql` — drop legacy table (count=0)
+- `supabase/migrations/<NNN>_add_preferred_call_window_to_user_profiles.sql` — FR-12
+
+**MODIFIED**:
+- `portal/src/components/landing/{hero-section,cta-section,landing-nav}.tsx` — anon CTA → Telegram URL; nav adds "Sign in" + "Continue with Nikita"
+- `portal/src/app/login/page-client.tsx` — Nikita-voiced redesign; emailRedirectTo → `/auth/confirm`
+- `portal/src/lib/supabase/middleware.ts` — remove `/onboarding/auth` exemption; add `/auth/confirm` exemption
+- `nikita/api/routes/telegram.py` — webhook routes email/code messages to signup_handler (replaces registration_handler/otp_handler wiring)
+- `nikita/db/models/pending_registration.py` → renamed `telegram_signup_session.py` — add `signup_state` enum, `magic_link_token`, `magic_link_sent_at`, `attempts`, `last_attempt_at`, `verification_type`
+- `nikita/db/repositories/pending_registration_repository.py` → renamed; CRUD + atomic verify + 3-strike rate-limit
+- `nikita/agents/onboarding/wizard_slots.py` — add `preferred_call_window` slot (FR-12)
+- `nikita/agents/text/persona.py` or template — add S2 phone-call proposal fragment (FR-13)
+- `portal/src/components/onboarding/ClearanceGrantedCeremony.tsx` — add S3 portal-orientation copy
+- `nikita/monitoring/events.py` — add 9 signup funnel events
+
+**DELETED** (PR-F3 per Plan §18.4):
+- `portal/src/app/onboarding/auth/` route (entire directory)
+- `nikita/platforms/telegram/auth.py:61-141` (`register_user`, `verify_otp` deprecated methods)
+- `nikita/platforms/telegram/registration_handler.py`
+- `nikita/platforms/telegram/otp_handler.py`
+- `nikita/db/models/auth_bridge.py` + `nikita/api/routes/auth_bridge.py` + `auth_bridge_repository.py` + `auth_bridge_tokens` table
+- `portal/src/components/onboarding/onboarding-wizard-legacy.tsx` + `onboarding/steps/legacy/` + `onboarding/components/legacy/` (D4 confirmed: `NEXT_PUBLIC_USE_LEGACY_FORM_WIZARD` UNSET in all Vercel envs per Plan §22)
+- Dual `generate_portal_bridge_url` in `utils.py` (collapse to `onboarding/bridge_tokens.py`; GH #233 finally closed)
+- `_send_bare_portal_auth_link` in commands.py:408-429 (or repurpose for T-E30)
+- `/onboard` slash-command + handler (commands.py:198) + help-text reference (commands.py:643)
+
+### §7.2 Data model
+
+**`telegram_signup_sessions`** (renamed from `pending_registrations`):
+
+| Column | Type | Notes |
+|---|---|---|
+| id | uuid PK | gen_random_uuid() |
+| telegram_id | bigint | INDEX; FK to public.users.telegram_id (nullable until bind) |
+| chat_id | bigint NOT NULL | **RETAINED from pending_registrations** — required by FR-11c E1/E2/E3 routing. Migration MUST preserve this column verbatim. |
+| email | text | INDEX |
+| signup_state | text CHECK IN ('awaiting_email','code_sent','magic_link_sent','completed') | NOT NULL. **Renamed from existing `otp_state`** (data-layer H2 — RENAME, not ADD). |
+| magic_link_token | text | **STORAGE CONTRACT**: stores ONLY the `hashed_token` returned by `supabase.auth.admin.generate_link` — NEVER the raw `action_link` query-string token. The `action_link` itself is delivered via Telegram and not stored server-side after dispatch. NULL until FR-5. |
+| magic_link_sent_at | timestamptz | NULL until FR-5 |
+| verification_type | text CHECK IN ('email','signup','magiclink','recovery') | persisted from generate_link response per §21 |
+| attempts | int DEFAULT 0 | OTP verify attempts. **Renamed from existing `otp_attempts`** (data-layer H2 — RENAME, not ADD). |
+| last_attempt_at | timestamptz | for rate-limit windowing |
+| created_at | timestamptz DEFAULT now() | |
+| expires_at | timestamptz | code TTL 5min from created_at |
+| RLS | service-role only | no end-user access |
+
+**Migration ops** (data-layer H1 + H2 + H5):
+1. `ALTER TABLE pending_registrations RENAME TO telegram_signup_sessions;` — `chat_id` column retained verbatim (FR-11c routing dependency).
+2. **RENAME existing columns** (do NOT add duplicates; FR-11e legacy paths are being deleted, so one source of truth):
+   - `ALTER TABLE telegram_signup_sessions RENAME COLUMN otp_state TO signup_state;`
+   - `ALTER TABLE telegram_signup_sessions RENAME COLUMN otp_attempts TO attempts;`
+3. Update `signup_state` CHECK constraint to the new domain `('awaiting_email','code_sent','magic_link_sent','completed')` (drop old constraint, re-create).
+4. ADD COLUMN magic_link_token text NULL, magic_link_sent_at timestamptz NULL, verification_type text NULL, last_attempt_at timestamptz NULL.
+5. Backfill existing 5 dev rows: `UPDATE telegram_signup_sessions SET signup_state='awaiting_email'` (will be destructively reset per D6 §9.2).
+6. `ALTER TABLE telegram_signup_sessions ENABLE ROW LEVEL SECURITY;` + service-role-only `CREATE POLICY` (per `.claude/rules/testing.md` DB Migration Checklist).
+7. Storage hardening (data-layer H5): document in code comment on `magic_link_token` column that the value is ALWAYS the hashed_token from `admin.generate_link`, never the raw URL token.
+
+### §7.2.1 FSM Atomic Transitions (data-layer H4)
+
+To prevent concurrent-request races (e.g., two workers both seeing `awaiting_email` and both calling `sign_in_with_otp`), every FSM transition MUST be expressed as a compare-and-swap UPDATE that asserts the prior state and fails loudly if 0 rows are returned.
+
+**AWAITING_EMAIL → CODE_SENT** (after FR-3 `sign_in_with_otp` succeeds):
+
+```sql
+UPDATE telegram_signup_sessions
+   SET signup_state = 'code_sent',
+       email        = $2,
+       expires_at   = now() + interval '5 minutes',
+       attempts     = 0,
+       last_attempt_at = now()
+ WHERE telegram_id  = $1
+   AND signup_state = 'awaiting_email'
+RETURNING id;
+```
+
+If 0 rows returned → another worker already advanced the state; abort the duplicate `sign_in_with_otp` call and log a `signup_concurrent_transition_blocked` warning.
+
+**CODE_SENT → MAGIC_LINK_SENT** (after FR-4 verify_otp + FR-5 generate_link succeed):
+
+```sql
+UPDATE telegram_signup_sessions
+   SET signup_state        = 'magic_link_sent',
+       magic_link_token    = $2,    -- hashed_token only (data-layer H5)
+       magic_link_sent_at  = now(),
+       verification_type   = $3
+ WHERE telegram_id   = $1
+   AND signup_state  = 'code_sent'
+   AND now() <= expires_at
+RETURNING id;
+```
+
+If 0 rows returned → either expired or already advanced; do NOT dispatch the Telegram message; instead, re-fetch state and route per FSM diagram (expired → AWAITING_EMAIL purge; already advanced → idempotent no-op).
+
+**MAGIC_LINK_SENT → COMPLETED** (after `/auth/confirm` succeeds and `telegram_id ↔ auth.uid()` bind happens):
+
+```sql
+DELETE FROM telegram_signup_sessions
+ WHERE telegram_id  = $1
+   AND signup_state = 'magic_link_sent'
+RETURNING id;
+```
+
+If 0 rows returned → log `signup_completion_no_pending_row` (idempotent re-tap is acceptable; row may already have been deleted by a concurrent request).
+
+**Attempt increment on invalid OTP** (FR-4 path):
+
+```sql
+UPDATE telegram_signup_sessions
+   SET attempts = attempts + 1,
+       last_attempt_at = now()
+ WHERE telegram_id  = $1
+   AND signup_state = 'code_sent'
+RETURNING attempts;
+```
+
+If returned `attempts >= 3` AND `last_attempt_at - first_attempt_at_in_window < 1 hour` → trigger D10 rate-limit + reset to AWAITING_EMAIL via additional CAS update.
+
+### §7.3 State machine (FSM)
+
+```
+[UNKNOWN]
+   │ /start welcome (no telegram_id binding)
+   ▼
+[AWAITING_EMAIL]
+   │ valid email
+   ▼
+[CODE_SENT]
+   │ valid code           ┌────────────────────┐
+   ├─────────────────────▶│  rate-limit reset  │ ← 3 invalid in 1h
+   │ invalid code (<3)    └────────────────────┘
+   │ ↻ (attempts++)
+   │ expired              → AWAITING_EMAIL (purge)
+   ▼
+[MAGIC_LINK_SENT]
+   │ user taps link in browser
+   │ /auth/confirm verifies
+   ▼
+[COMPLETED]
+   (telegram_signup_sessions row deleted; user fully bound)
+```
+
+Refer to Plan §18.10 Diagram 2 (Telegram-first signup FSM) for visual.
+
+### §7.4 Supabase Email Templates (dashboard config)
+
+Per Plan §6.3 + Plan §18.8 documentation:
+
+| Template | Purpose | Fires for | Body content |
+|---|---|---|---|
+| **Signup** (FR-3) | Telegram-first OTP code | `sign_in_with_otp({email, options:{should_create_user:True}})` for NEW email | `{{ .Token }}` only (6-digit code; new HTML in `docs-to-process/20260423-auth-templates-v17-1.md` §1.1) |
+| **Magic Link** (FR-10) | Returning-user portal login | `signInWithOtp` from `/login` page | `{{ .ConfirmationURL }}` only (link-only; new HTML in §1.2) |
+| Recovery / Invite / Email Change | unused in v1 | — | leave Supabase default |
+
+Both templates documented in `docs/deployment.md` Supabase Email Templates section (added in Phase E).
+
+### §7.5 ADR
+
+`~/.claude/ecosystem-spec/decisions/ADR-010-telegram-first-signup-direction.md` is the architectural authority. Cited throughout this spec.
+
+### §7.6 Admin Endpoint Contract — `generate_magiclink_for_telegram_user` (API H1)
+
+Path: `POST /api/v1/admin/auth/generate-magiclink-for-telegram-user`
+Module: `nikita/api/routes/portal_auth.py`
+Auth: **service-role only** — handler MUST validate `Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>` (or equivalent app-side service-role token). End-user JWTs MUST be rejected with 401. Tested via FR-5 unit test on the endpoint.
+
+**Request model** (Pydantic v2):
+
+```python
+from pydantic import BaseModel, EmailStr, Field
+
+class GenerateMagiclinkRequest(BaseModel):
+    telegram_id: int = Field(..., description="Telegram user ID requesting the magic-link")
+    email: EmailStr = Field(..., description="Verified email address (post-OTP)")
+```
+
+**Response model** (Pydantic v2):
+
+```python
+from datetime import datetime
+from typing import Literal
+from pydantic import BaseModel, HttpUrl
+
+class GenerateMagiclinkResponse(BaseModel):
+    action_link: HttpUrl                                          # Supabase action URL — delivered via Telegram, never stored
+    hashed_token: str                                             # stored on telegram_signup_sessions.magic_link_token (data-layer H5)
+    verification_type: Literal["magiclink", "signup"]             # passed verbatim to portal verifyOtp({type: ...}) — NEVER hardcode (testing H2)
+    expires_at: datetime                                          # echoes Supabase TTL (typically now() + 1h)
+```
+
+**Handler contract**:
+1. Validate request via Pydantic `GenerateMagiclinkRequest`.
+2. Confirm caller is service-role; reject with 401 otherwise.
+3. Call `supabase.auth.admin.generate_link({type:"magiclink", email, options:{redirect_to:"<portal>/auth/confirm?next=/onboarding"}})`.
+4. Persist `hashed_token`, `verification_type`, `magic_link_sent_at` on the `telegram_signup_sessions` row (CAS update per §7.2.1).
+5. Return `GenerateMagiclinkResponse` with `verification_type` taken VERBATIM from Supabase response (no normalization, no literal substitution).
+
+---
+
+## §8 Test strategy
+
+Test pyramid: 70% unit, 20% integration, 10% E2E.
+
+### §8.1 Unit (70%) — pytest + vitest
+
+**Backend**:
+- `tests/platforms/telegram/test_signup_handler.py` — FSM state transitions per FR-2/3/4; rate-limit per D10; expired-code purge
+- `tests/db/repositories/test_telegram_signup_session_repository.py` — atomic verify, idempotent bind
+- `tests/api/routes/test_portal_auth_generate_magiclink.py` — admin endpoint contract; service-role guard
+
+**Portal**:
+- `portal/tests/app/auth/confirm/route.test.ts` — verifyOtp wiring, error redirects, missing-params handling
+- `portal/tests/app/auth/confirm/interstitial.test.tsx` — IS-A unconditional render, IAB UA detection, Universal Link href
+- `portal/tests/app/login/page-client.test.tsx` — Nikita-voiced copy, emailRedirectTo wiring
+- `portal/tests/components/landing/cta-href.test.tsx` — anon CTA = Telegram URL across all 3 components
+
+### §8.2 Integration (20%)
+
+- `tests/integration/test_signup_flow_e2e.py` — full FSM with mocked Supabase admin client (covers AC-3 through AC-5 end-to-end)
+- `tests/integration/test_auth_confirm_session.py` — verifyOtp + cookie set + middleware getUser pickup
+
+### §8.3 E2E (10%) — Phase F per `.claude/rules/live-testing-protocol.md`
+
+12-step canonical protocol (NO DB fabrication; Telegram MCP + Gmail MCP + agent-browser only). Walk W1 acceptance: 0 CRITICAL findings, 0 unfiled HIGH, all FR-Telemetry-1 events fire correctly, plus AC-LiveWalk.
+
+### §8.4 Mandatory Agentic-Flow Tests
+
+Per `.claude/rules/agentic-design-patterns.md` + `.claude/rules/testing.md` Agentic-Flow Test Requirements: any code under `tests/agents/**` touching the wizard slot model (FR-12) MUST include:
+
+1. Cumulative-state monotonicity test (≥3 turns, asserts `progress_pct[t+1] >= progress_pct[t]` after preferred_call_window slot lands)
+2. Completion-gate triplet (empty/partial/full FinalForm validation)
+3. Mock-LLM-emits-wrong-tool recovery (slot extraction fallback for preferred_call_window)
+
+### §8.5 Pre-PR Grep Gates
+
+Per `.claude/rules/testing.md`: zero-assertion shells, PII format strings, raw cache_key. All MUST return empty before `/qa-review` dispatch.
+
+### §8.6 Live-Dogfood Anti-Patterns (PR-blockers)
+
+Per `.claude/rules/live-testing-protocol.md`: no `INSERT INTO auth.users`, no `signInWithPassword`, no `E2E_AUTH_BYPASS=true`, no custom JWT minting. Walk Y precedent (#410, #411 — synthetic findings) drove this rule.
+
+### §8.7 Required Tests (testing H1-H5)
+
+The following test files MUST exist before PR-F1a/PR-F1b/PR-F2a/PR-F2b are opened. Each is mapped to its driving testing-validator finding.
+
+#### Testing H1 — Telegram link-preview disabled
+
+**Path**: `tests/platforms/telegram/test_signup_handler_link_preview.py`
+
+**AC**: assert that `bot.send_message(...)` (or the equivalent client wrapper) is called with `disable_web_page_preview=True` whenever the message body contains the magic-link `action_link`. Implementation: `unittest.mock.patch` the bot client, dispatch FR-5 path with a fake `action_link`, then `mock_bot.send_message.assert_awaited_once_with(... , disable_web_page_preview=True, ...)`. A second test asserts that a non-link reply (e.g., FR-2 welcome) does NOT force `disable_web_page_preview=True` (negative control).
+
+#### Testing H2 — `verification_type` passthrough (no hardcoded literals)
+
+**Path**: `tests/api/routes/test_portal_auth_admin.py`
+
+**AC**: assert that the `generate_magiclink_for_telegram_user` handler (§7.6) passes `verification_type` VERBATIM from the Supabase response to the persistence layer and to the response body — no `'magiclink'` or `'signup'` string literals appear in the handler code on the FR-5 path. Test setup includes a static-grep step that runs at test-collection time (e.g., a pytest fixture that opens `nikita/api/routes/portal_auth.py` and asserts `re.search(r"['\"](magiclink|signup)['\"]", handler_source)` returns no match outside type-annotation/Pydantic-Literal contexts).
+
+#### Testing H3 — Magic-link TTL idempotency triplet (T-E22, T-E23, T-E24, T-E27)
+
+**Path**: `portal/tests/app/auth/confirm/route.test.ts`
+
+**ACs**:
+- T-E22: simulated `verifyOtp` returning expired-token error → assert response is `Response.redirect("/login?error=link_expired", 302)`.
+- T-E23: same `token_hash` consumed twice within TTL → both calls return success; second call asserts the route returns the IS-A interstitial and does NOT add `?error=*` to the redirect.
+- T-E24: `verifyOtp` succeeds on a fresh device (no existing cookie jar) → assert `Set-Cookie` headers are present on the response.
+- T-E27: same `token_hash` consumed AFTER `expires_at` → asserts redirect to `/login?error=link_expired` (matches T-E22 path).
+
+#### Testing H4 — iOS Safari interstitial (UA-spoof unit test + optional manual walk)
+
+**Primary (mandatory)**: `portal/tests/app/auth/confirm/interstitial.test.tsx` — render the IS-A interstitial Client Component with `navigator.userAgent` mocked to a real iOS Safari UA string AND a real Telegram-IAB UA string. Assert (a) the primary "Continue to Nikita" button always renders, (b) the "Open in Safari" Universal Link renders ONLY when UA matches the IAB regex (Telegram in-app browser detection), and (c) ARIA contract from FR-6a (`role="main"`, `aria-labelledby`, `aria-describedby`) is intact.
+
+**Secondary (OPTIONAL)**: Phase F walk on a real iPhone (Telegram → tap link → IAB opens → tap "Open in Safari" → verify cookie jar carries) — documented as a manual checklist item, not a CI gate.
+
+#### Testing H5 — Per-event Pydantic models for FR-Telemetry-1 (no PII)
+
+Each of the 9 funnel events in FR-Telemetry-1 is emitted via a dedicated Pydantic v2 model. The corresponding tests live in `tests/monitoring/test_signup_funnel_events.py` and assert per row of the table below: (a) emitter call uses the named Pydantic model (not a free-form dict), (b) `model_dump_json()` round-trips with no PII fields (no raw `email`, no raw `telegram_id` — use `email_hash` / `telegram_id_hash` derived via `sha256(...)[:12]`), (c) the schema is JSON-serializable for downstream telemetry sinks.
+
+| Event | Pydantic model | Required fields (types) |
+|---|---|---|
+| `signup_started_telegram` | `SignupStartedTelegramEvent` | `telegram_id_hash: str`, `ts: datetime` |
+| `signup_email_received` | `SignupEmailReceivedEvent` | `telegram_id_hash: str`, `email_hash: str`, `ts: datetime` |
+| `signup_code_sent` | `SignupCodeSentEvent` | `email_hash: str`, `ts: datetime`, `supabase_response_code: int` |
+| `signup_code_verified` | `SignupCodeVerifiedEvent` | `email_hash: str`, `attempts_count: int`, `ts: datetime` |
+| `signup_magic_link_minted` | `SignupMagicLinkMintedEvent` | `email_hash: str`, `ts: datetime`, `action_link_ttl_seconds: int`, `verification_type: Literal["magiclink","signup"]` |
+| `signup_magic_link_clicked` | `SignupMagicLinkClickedEvent` | `email_hash: str`, `ts: datetime`, `latency_ms_from_mint: int` |
+| `signup_wizard_session_minted` | `SignupWizardSessionMintedEvent` | `user_id: UUID`, `ts: datetime` |
+| `signup_wizard_completed` | `SignupWizardCompletedEvent` | `user_id: UUID`, `ts: datetime`, `total_signup_to_complete_ms: int` |
+| `signup_failed` | `SignupFailedEvent` | `telegram_id_hash: str`, `stage: Literal["awaiting_email","code_sent","magic_link_sent"]`, `reason: str` |
+
+Anti-pattern check: a grep gate (`tests/monitoring/test_signup_funnel_events.py::test_no_raw_pii_in_emitter_calls`) searches the production telemetry call sites for any kwarg named `email=`, `telegram_id=`, `phone=`, or `name=` and fails the test if any match outside a hashing helper.
+
+---
+
+## §9 Migration
+
+### §9.1 Schema migrations (sequential, in PR-F1a)
+
+1. RENAME `pending_registrations` → `telegram_signup_sessions`
+2. ADD COLUMN signup_state, magic_link_token, magic_link_sent_at, verification_type, attempts, last_attempt_at
+3. ENABLE RLS + service-role-only CREATE POLICY
+4. NEW migration: ADD COLUMN preferred_call_window text NULL ON user_profiles
+5. NEW migration (PR-F3 only): DROP TABLE auth_bridge_tokens (verified count=0 in Plan §18.9)
+
+### §9.2 Destructive reset of in-flight users (D6, data-layer H3)
+
+Per Plan §18.5 verification 2 + §19: 5 in-flight `pending` users in prod, all dev accounts (no telegram_id, oldest 2026-04-21). The cascade order MUST follow the FK-safe template in `.claude/rules/live-testing-protocol.md` (DB Cleanup SQL Template) — `auth.users` is deleted last; child tables are emptied first.
+
+**Destructive reset SQL** (one-shot, run post-PR-F1a deploy; targets the 5 stale dev rows where `auth.users.email` exists but no `telegram_id` binding has happened):
+
+```sql
+WITH target AS (
+  SELECT au.id
+    FROM auth.users au
+    LEFT JOIN public.users pu ON pu.id = au.id
+   WHERE pu.telegram_id IS NULL
+     AND COALESCE(pu.onboarding_status, 'pending') = 'pending'
+     AND au.created_at < now() - interval '24 hours'  -- safety: only stale rows
+)
+DELETE FROM user_metrics                WHERE user_id IN (SELECT id FROM target);
+DELETE FROM user_vice_preferences       WHERE user_id IN (SELECT id FROM target);
+DELETE FROM scheduled_events            WHERE user_id IN (SELECT id FROM target);
+DELETE FROM memories                    WHERE user_id IN (SELECT id FROM target);
+DELETE FROM user_profiles               WHERE id     IN (SELECT id FROM target);
+DELETE FROM telegram_signup_sessions    WHERE telegram_id IS NULL;  -- pre-bind rows have null telegram_id
+DELETE FROM public.users                WHERE id     IN (SELECT id FROM target);
+DELETE FROM auth.users                  WHERE id     IN (SELECT id FROM target);
+```
+
+**Order rationale** (matches `.claude/rules/live-testing-protocol.md`): user_metrics → user_vice_preferences → scheduled_events → memories → user_profiles → telegram_signup_sessions → public.users → auth.users (last). Each `DELETE` row count must be reported in the runbook for human verification before the next step.
+
+### §9.3 Vercel env flag removal (D4)
+
+Per Plan §22: `NEXT_PUBLIC_USE_LEGACY_FORM_WIZARD` confirmed UNSET across all Vercel envs. Safe to delete legacy components in PR-F3. No env-var removal needed (already absent).
+
+### §9.4 Cache purge (T-E29)
+
+After PR-F2b merge (deletion of `/onboarding/auth`), Vercel cache MUST be purged so the route returns 404. Phase E checklist item.
+
+### §9.5 Feature-flag gate (per Plan §18.4)
+
+PRs F1a/F1b/F2a/F2b ship behind `NEXT_PUBLIC_TELEGRAM_FIRST_SIGNUP=true`. Flag flips ON only after Phase F W1 dogfood passes. PR-F3 deletion waits for 1 deploy cycle behind flipped flag (rollback safety).
+
+---
+
+## §10 Risks
+
+Lifted from Plan §10 + §18.3:
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Telegram link-preview crawler burns single-use token | Medium | High | `disable_web_page_preview=True` (NFR-Sec-1, AC-5.3) + Phase E crawler-simulation test |
+| iOS Safari ITP / Telegram IAB session strand | Medium | High | IS-A always-interstitial unconditional (FR-6, NFR-Sec-2) |
+| Token replay via Telegram message screenshot share | Low | Medium | Single-use token; expired-link interstitial (T-E27) |
+| Email template misconfigured | Medium | High | §7.4 documents both dashboard configs; AC-CodeOnlyTemplate + AC-LinkOnlyTemplate verify in Phase E live walk |
+| `verifyOtp({type:'magiclink', token_hash})` deprecated in some Python versions | Low | Medium | Plan §21 spike confirmed supabase-py 2.24.0 supports both 'email' and 'magiclink'; use response `verification_type` (no normalize) |
+| Supabase rate-limit collision with prod (360 OTP/hr/project shared) | Medium | Low | Plus-alias rotation (`+walkN`) per walk; staging Supabase optional |
+| Vercel cache of deleted `/onboarding/auth` route | Low | Medium | T-E29 cache purge in Phase E checklist |
+| PKCE 422 (#393) regression in `/auth/confirm` path | Low | High | Token-hash flow eliminates PKCE entirely; AC-PKCEGone repro test |
+| Dropping `auth_bridge_tokens` breaks rollback | Low | Medium | PR-F3 sequential to PR-F1/F2; 1 deploy cycle behind flipped flag |
+| Wizard slot addition (FR-12) breaks FR-11d cumulative state | Low | High | Agentic-Flow Test Requirements §8.4 cumulative-state monotonicity covers it |
+| Walk subagent fabricates DB state | Medium | High | `.claude/rules/live-testing-protocol.md` PR-blocker anti-patterns + ADR-011 |
+
+---
+
+## §11 References
+
+- **Plan**: `~/.claude/plans/delightful-orbiting-ladybug.md` (v17.1) — §1, §2.4, §3, §4, §5, §6, §7 (approach evaluation), §8 (phase structure), §9 (live testing protocol — now `.claude/rules/live-testing-protocol.md`), §10, §15, §17, §18, §19, §20, §21, §22
+- **ADRs**:
+  - `~/.claude/ecosystem-spec/decisions/ADR-010-telegram-first-signup-direction.md`
+  - `~/.claude/ecosystem-spec/decisions/ADR-011-live-testing-protocol-as-rule.md`
+  - `~/.claude/ecosystem-spec/decisions/ADR-009-agentic-design-patterns.md` (Spec 214 antecedent)
+- **Project rules**:
+  - `.claude/rules/agentic-design-patterns.md` — wizard slot FR-12 must follow these patterns
+  - `.claude/rules/live-testing-protocol.md` — Phase F dogfood discipline (PR-blocker anti-patterns)
+  - `.claude/rules/testing.md` — Agentic-Flow Test Requirements + Pre-PR Grep Gates + DB Migration Checklist
+  - `.claude/rules/pr-workflow.md` — TDD + Pre-push HARD GATE + grep-verify gate + commit-hash verification
+  - `.claude/rules/parallel-agents.md` — subagent dispatch caps (HARD CAP + scope + exit criterion)
+  - `.claude/rules/vercel-cors-canonical.md` — pre-CORS check before any cors_origins edit
+- **Supabase docs**:
+  - https://supabase.com/docs/guides/auth/auth-email-passwordless
+  - https://supabase.com/docs/guides/auth/server-side/nextjs (Next.js 16 App Router cookies adapter)
+  - https://supabase.com/docs/reference/javascript/auth-verifyotp
+  - https://supabase.com/docs/reference/javascript/auth-admin-generatelink
+- **Telegram docs**:
+  - https://core.telegram.org/bots/features#deep-linking (`?start=` payload, 64 chars, charset `[A-Za-z0-9_-]`)
+  - https://core.telegram.org/bots/api#sendmessage (`disable_web_page_preview` field)
+- **Sister specs**:
+  - Spec 214 (post-auth wizard) — references Spec 215 as entry precondition
+  - Spec 208 (landing page) — anon CTA target amended per FR-1
+  - Spec 213 (onboarding backend foundation) — FR-11b 307 auto-provision pattern reused
+- **Auth template content**: `docs-to-process/20260423-auth-templates-v17-1.md` (referenced in plan §19; physical file pending — content embedded in Plan §17.1 + §18.2)
+- **Phase B.5 governance ship**: PR #412 commit `0a3534e` (live-testing-protocol rule + testing.md cross-link)
+- **Live spike evidence (Plan §21)**: subagent `aa80290cd3209c57f`; probe email `simon.yang.ch+v17probe-001@gmail.com`; Supabase response `verification_type='signup'` for new email; supabase-py 2.24.0 native support for `admin.generate_link` confirmed
+- **Six supporting diagrams** (Plan §18.10): produced by review agent `a0827ffa586d754ce`; copy into `docs/diagrams/onboarding-journey-v17.md` during Phase D
+
+---
+
+## §12 Open questions [NEEDS CLARIFICATION]
+
+NONE.
+
+All decisions D1 through D13 + scope items S1 through S4 are resolved per Plan §19, §19.1, and §20:
+- D1 (link_code semantics): synchronous user-tap gate (FR-8 / Option C2)
+- D2 (email templates): code-only signup template (FR-3) + link-only login template (FR-10)
+- D3 (onboarded landing CTA): /dashboard + nav dual entries (FR-11)
+- D4 (legacy flag): `NEXT_PUBLIC_USE_LEGACY_FORM_WIZARD` UNSET → safe deletion (PR-F3)
+- D5/D13 (Spec 215 scope): full auth ownership (this spec)
+- D6 (in-flight reset): destructive reset of 5 dev rows (§9.2)
+- D7 (game-over re-email): skip OTP, mint magic-link directly
+- D8 (typo affordance): post-failure inline button (T-E3)
+- D9 (mid-wizard drop): keep portal resume bridge (FR-11c E5/E6, unchanged)
+- D10 (rate limits): 10 emails/hr, 15 codes/hr, 60s resend, 5min code TTL (NFR-Sec-4)
+- D11 (game-over backstory preservation): preserve user_profiles + backstory_cache; clear user_metrics only
+- D12 (Telegram LoginUrl): REJECTED for v1
+- S1 (Nikita initiates post-handoff): covered by FR-9 + Phase F W1 AC-LiveWalk
+- S2 (early phone-call proposal): FR-12 + FR-13
+- S3 (portal orientation teaching): FR-14
+- S4 (daily engagement emails): MOVED to Spec 216 (separate spec lifecycle)
+
+Phase B is COMPLETE per Plan §19.1. Pre-Phase-C verification 1 (Supabase admin.generate_link spike) PASSED per Plan §21.
+
+---
+
+**End Spec 215 — auth-flow-redesign DRAFT v1**

--- a/specs/215-auth-flow-redesign/tasks.md
+++ b/specs/215-auth-flow-redesign/tasks.md
@@ -1,0 +1,550 @@
+# Tasks: Spec 215 — Auth Flow Redesign (Telegram-First Signup)
+
+**Generated**: 2026-04-24
+**Feature**: 215-auth-flow-redesign
+**Input**: `specs/215-auth-flow-redesign/{spec.md, plan.md}`
+**Branch**: `feat/215-telegram-first-signup` (PR-F1a kickoff); per-PR sub-branches per `plan.md` §4
+**Feature flag**: `NEXT_PUBLIC_TELEGRAM_FIRST_SIGNUP=true`
+
+**Organization**: Tasks are grouped by PR (per plan.md §4) since the spec has a single product story (Telegram-first signup) but ships in 5 sequential PRs for blast-radius control. Each PR is treated as an independently testable phase.
+
+**Test-First (Article III)**: All implementation tasks have ≥2 testable ACs. Write tests FIRST, watch them FAIL, then implement. RED commit + GREEN commit minimum per task.
+
+**Subagent dispatch**: All subagent dispatches MUST include `HARD CAP: <N> tool calls` + scope + exit criterion per `.claude/rules/parallel-agents.md`.
+
+---
+
+## Format: `[ID] [P?] [Phase] Description`
+
+- **[ID]**: T001, T002, ...
+- **[P]**: Parallelizable (different files, no dependency)
+- **[Phase]**: PR-F1a / PR-F1b / PR-F2a / PR-F2b / PR-F3 / W1
+- **Each task**: 2+ ACs, TDD pair, file paths, dependencies, FR/AC mapping
+
+---
+
+## Phase 1: Setup (Branch + Feature Flag)
+
+- [ ] **T001** [PR-F1a] Create branch `feat/215-pr-f1a-data-layer` from master + record baseline test counts
+  - **AC-1**: `git branch --show-current` returns `feat/215-pr-f1a-data-layer`
+  - **AC-2**: `uv run pytest -q --co | tail -1` baseline recorded in PR body
+  - **Files**: branch only
+  - **Estimate**: S (15 min)
+
+- [ ] **T002** [PR-F2b] Add `NEXT_PUBLIC_TELEGRAM_FIRST_SIGNUP` to Vercel env (preview + production, value `false` initially)
+  - **AC-1**: `vercel env ls` shows the var on both envs with `false`
+  - **AC-2**: env var read by middleware + landing components (verified in T024)
+  - **Files**: Vercel env (no repo change)
+  - **Estimate**: S (10 min); deferred to PR-F2b kickoff
+
+---
+
+## Phase 2: Foundational — PR-F1a Data Layer + Admin Endpoint Contract
+
+**Per plan.md §4 PR-F1a. Estimate: ~300 LOC, 6-8 hours.**
+
+**Intelligence queries** (run once at PR-F1a start):
+```bash
+bash .claude/skills/project-intel/scripts/graph-ops.sh briefing nikita/db/models/pending_registration.py
+bash .claude/skills/project-intel/scripts/graph-ops.sh briefing nikita/api/routes/portal_auth.py
+bash .claude/skills/project-intel/scripts/graph-ops.sh search "pending_registration"
+```
+
+### Tests for PR-F1a ⚠️ WRITE FIRST
+
+- [ ] **T003** [P] [PR-F1a] RED: `tests/db/repositories/test_telegram_signup_session_repository.py` — atomic CAS transitions per spec §7.2.1
+  - **AC-1**: AWAITING_EMAIL → CODE_SENT CAS update returns 0 rows when prior state mismatch (concurrent worker race)
+  - **AC-2**: CODE_SENT → MAGIC_LINK_SENT CAS update returns 0 rows when expired (`now() > expires_at`)
+  - **AC-3**: MAGIC_LINK_SENT → COMPLETED is idempotent (re-tap returns 0 rows; no error)
+  - **Mapped FR/AC**: §7.2.1, AC-3.2, AC-5.5
+  - **Verify FAIL**: `uv run pytest tests/db/repositories/test_telegram_signup_session_repository.py -v` shows RED
+  - **Estimate**: M (2hr)
+
+- [ ] **T004** [P] [PR-F1a] RED: `tests/api/routes/test_portal_auth_generate_magiclink.py` — admin endpoint contract per spec §7.6 + Testing H2
+  - **AC-1**: end-user JWT returns 401 (service-role guard)
+  - **AC-2**: valid service-role call returns Pydantic `GenerateMagiclinkResponse` with `verification_type` from Supabase response (no hardcoded literal)
+  - **AC-3**: static-grep fixture asserts no `'magiclink'`/`'signup'` literal in handler source outside `Literal[...]` annotation
+  - **Mapped FR/AC**: FR-5, AC-5.1, AC-5.2, Testing H2, §7.6
+  - **Verify FAIL**: pytest RED
+  - **Estimate**: M (2hr)
+
+- [ ] **T005** [P] [PR-F1a] RED: `tests/monitoring/test_signup_funnel_events.py` — 9 Pydantic event models per Testing H5
+  - **AC-1**: every emitter call uses named Pydantic model (not free-form dict) — assert-via-mock
+  - **AC-2**: `model_dump_json()` round-trip emits no PII fields (no raw `email`, `telegram_id`, `phone`, `name`); only `*_hash` derivatives
+  - **AC-3**: anti-pattern grep gate (`test_no_raw_pii_in_emitter_calls`) returns empty
+  - **Mapped FR/AC**: FR-Telemetry-1, Testing H5
+  - **Verify FAIL**: pytest RED
+  - **Estimate**: M (2hr)
+
+### Implementation for PR-F1a
+
+- [ ] **T006** [PR-F1a] GREEN: Migration `<NNN>_rename_pending_registrations_to_telegram_signup_sessions.sql` per spec §9.1
+  - **AC-1**: RENAME table + RENAME `otp_state` → `signup_state` + RENAME `otp_attempts` → `attempts` (data-layer H2)
+  - **AC-2**: ADD COLUMNs (`magic_link_token`, `magic_link_sent_at`, `verification_type`, `last_attempt_at`)
+  - **AC-3**: `chat_id` column verbatim retained (data-layer H1; FR-11c routing dependency)
+  - **AC-4**: ENABLE RLS + service-role-only policy (per `.claude/rules/testing.md` DB Migration Checklist)
+  - **AC-5**: Migration applied to local Supabase + verified via `mcp__supabase__list_tables`
+  - **Files**: `supabase/migrations/<NNN>_*.sql`
+  - **Dependencies**: T003
+  - **Estimate**: M (2hr)
+
+- [ ] **T007** [P] [PR-F1a] GREEN: Migration `<NNN>_add_preferred_call_window_to_user_profiles.sql` (FR-12)
+  - **AC-1**: `ALTER TABLE user_profiles ADD COLUMN preferred_call_window text NULL`
+  - **AC-2**: Migration is idempotent (`IF NOT EXISTS`); applied + verified
+  - **Files**: `supabase/migrations/<NNN>_*.sql`
+  - **Estimate**: S (30 min)
+
+- [ ] **T008** [PR-F1a] GREEN: Rename + extend ORM model `nikita/db/models/telegram_signup_session.py` (was `pending_registration.py`)
+  - **AC-1**: `signup_state` enum constrained to `{awaiting_email, code_sent, magic_link_sent, completed}`
+  - **AC-2**: `verification_type` typed as `Literal["email","signup","magiclink","recovery"]`
+  - **AC-3**: existing imports of `PendingRegistration` updated repo-wide; `git grep "PendingRegistration"` returns only the new alias or zero
+  - **Files**: rename `pending_registration.py` → `telegram_signup_session.py`; update callers
+  - **Dependencies**: T006
+  - **Estimate**: M (2hr)
+
+- [ ] **T009** [PR-F1a] GREEN: Repository `nikita/db/repositories/telegram_signup_session_repository.py` with CAS helpers
+  - **AC-1**: `transition_to_code_sent(telegram_id, email)` returns `id` or raises `ConcurrentTransitionError`
+  - **AC-2**: `transition_to_magic_link_sent(telegram_id, hashed_token, verification_type)` returns `id` or raises `ExpiredOrConcurrentError`
+  - **AC-3**: `delete_on_completion(telegram_id)` is idempotent (returns count; no exception on 0)
+  - **AC-4**: `increment_attempts(telegram_id)` returns new attempts count atomically
+  - **Files**: `nikita/db/repositories/telegram_signup_session_repository.py`
+  - **Dependencies**: T003, T008
+  - **Estimate**: L (4hr)
+  - **Verify GREEN**: T003 tests pass
+
+- [ ] **T010** [P] [PR-F1a] GREEN: 9 telemetry event Pydantic models in `nikita/monitoring/events.py`
+  - **AC-1**: All 9 models from spec §8.7 Testing H5 table exist as Pydantic v2 classes with required fields
+  - **AC-2**: `email_hash` / `telegram_id_hash` helpers return `sha256(...)[:12]`
+  - **AC-3**: emitter helpers (one per event) accept the Pydantic model and call structured logger
+  - **Files**: `nikita/monitoring/events.py`
+  - **Dependencies**: T005
+  - **Estimate**: M (2hr)
+  - **Verify GREEN**: T005 tests pass
+
+- [ ] **T011** [PR-F1a] GREEN: Admin endpoint `nikita/api/routes/portal_auth.py::generate_magiclink_for_telegram_user` per spec §7.6
+  - **AC-1**: Pydantic `GenerateMagiclinkRequest` + `GenerateMagiclinkResponse` declared
+  - **AC-2**: service-role guard rejects end-user JWT with 401
+  - **AC-3**: handler calls `client.auth.admin.generate_link({type:"magiclink", email, options:{redirect_to}})` and persists `hashed_token` + `verification_type` via T009 repo
+  - **AC-4**: response `verification_type` is from Supabase response verbatim (no normalization)
+  - **AC-5**: handler emits `signup_magic_link_minted` telemetry event (T010)
+  - **Files**: `nikita/api/routes/portal_auth.py`
+  - **Dependencies**: T004, T009, T010
+  - **Estimate**: L (4hr)
+  - **Verify GREEN**: T004 tests pass
+
+### Verification for PR-F1a
+
+- [ ] **T012** [PR-F1a] Run pre-PR grep gates per `.claude/rules/testing.md`: zero-assertion shells, PII format strings, raw cache_key
+  - **AC-1**: All 3 grep commands return empty
+  - **AC-2**: Output recorded in PR body under `## Pre-PR grep gates`
+
+- [ ] **T013** [PR-F1a] Pre-push HARD GATE: `uv run pytest -q` full nikita suite passes
+  - **AC-1**: Full suite green; no skipped tests in PR-F1a-touched modules
+  - **AC-2**: PR body `## Local tests` section records pass count + duration
+
+- [ ] **T014** [PR-F1a] Open PR-F1a + dispatch `/qa-review --pr N` (HARD CAP 5 tool calls; scope: 6 changed files; exit: report CLEAN or N findings)
+  - **AC-1**: PR opened with body referencing spec.md + plan.md §4 PR-F1a + tasks T003-T013
+  - **AC-2**: Fresh-context QA review returns 0 findings across ALL severities
+
+**Checkpoint**: PR-F1a merged. Migration applied to prod via Supabase MCP. Telegram FSM data layer + admin endpoint shipped. Ready for PR-F1b.
+
+---
+
+## Phase 3: PR-F1b — Backend FSM `signup_handler.py` + Telegram webhook routing
+
+**Per plan.md §4 PR-F1b. Estimate: ~400 LOC, 8-12 hours.**
+
+**Trigger phrase check**: this PR touches `nikita/agents/**` indirectly via persona changes in PR-F3, but the FSM itself is `nikita/platforms/**`. Per `.claude/rules/agentic-design-patterns.md`: read it BEFORE planning the FSM (NOT a Pydantic AI agent — single-purpose state machine — so 4 hard rules don't directly apply, but cumulative-state discipline still informs).
+
+### Tests for PR-F1b ⚠️ WRITE FIRST
+
+- [ ] **T015** [P] [PR-F1b] RED: `tests/platforms/telegram/test_signup_handler.py` — FSM transitions per FR-2/3/4
+  - **AC-1**: `/start welcome` for unbound telegram_id triggers welcome message + `signup_state=AWAITING_EMAIL` row
+  - **AC-2**: invalid email keeps state `AWAITING_EMAIL` and emits Nikita-voiced rejection
+  - **AC-3**: valid email transitions to `CODE_SENT` via T009 CAS helper + emits `signup_email_received` telemetry
+  - **AC-4**: invalid OTP increments `attempts`; 3rd invalid in 1h triggers rate-limit + reset to AWAITING_EMAIL
+  - **AC-5**: expired code (now > expires_at) emits Nikita-voiced "Code expired" + row purge
+  - **AC-6**: valid OTP transitions to `MAGIC_LINK_SENT` via FR-5 admin endpoint + Telegram delivery
+  - **Mapped FR/AC**: AC-2.1..AC-2.3, AC-3.1..AC-3.4, AC-4.1..AC-4.4, AC-5.4
+  - **Verify FAIL**: pytest RED
+  - **Estimate**: L (4hr)
+
+- [ ] **T016** [P] [PR-F1b] RED: `tests/platforms/telegram/test_signup_handler_link_preview.py` per Testing H1
+  - **AC-1**: FR-5 path → `bot.send_message` called with `disable_web_page_preview=True`
+  - **AC-2**: NEGATIVE control: FR-2 welcome message does NOT force `disable_web_page_preview=True`
+  - **AC-3**: simulated Telegram crawler `GET <action_link>` followed by user tap still consumes token (single-use semantics not pre-burned)
+  - **Mapped FR/AC**: AC-5.3, Testing H1, NFR-Sec-1
+  - **Verify FAIL**: pytest RED
+  - **Estimate**: M (2hr)
+
+### Implementation for PR-F1b
+
+- [ ] **T017** [PR-F1b] GREEN: `nikita/platforms/telegram/signup_handler.py` consolidated FSM
+  - **AC-1**: `handle_welcome(update, context)` greets Nikita-voiced + transitions UNKNOWN → AWAITING_EMAIL
+  - **AC-2**: `handle_email(update, context)` regex-validates, calls `client.auth.sign_in_with_otp(email, options:{should_create_user:True})`, transitions via T009 CAS
+  - **AC-3**: `handle_code(update, context)` regex-validates `^[0-9]{6}$`, calls `client.auth.verify_otp({email, token, type:"email"})`, on success calls FR-5 admin endpoint (T011)
+  - **AC-4**: rate-limit per D10: 10 emails/hr, 15 codes/hr, 60s resend cooldown, 5min code TTL
+  - **AC-5**: every transition emits corresponding telemetry event (T010)
+  - **AC-6**: post-magic-link bind: `UPDATE public.users SET telegram_id = <tg_id> WHERE id = <auth_uid>` is idempotent
+  - **Files**: `nikita/platforms/telegram/signup_handler.py`
+  - **Dependencies**: T009, T011, T015
+  - **Estimate**: XL → break: T017a (handle_welcome+handle_email, M 3hr), T017b (handle_code + admin call + bind, L 4hr)
+  - **Verify GREEN**: T015 tests pass
+
+- [ ] **T018** [PR-F1b] GREEN: Wire `signup_handler.py` into `nikita/api/routes/telegram.py` webhook
+  - **AC-1**: webhook routes `/start welcome` to `signup_handler.handle_welcome` (replaces legacy registration_handler dispatch)
+  - **AC-2**: webhook routes free-text from `signup_state IN ('awaiting_email','code_sent')` to corresponding handler
+  - **AC-3**: legacy `registration_handler.py` + `otp_handler.py` wiring removed (deletion deferred to PR-F3 to keep PR-F1b additive; this task only swaps the dispatch)
+  - **Files**: `nikita/api/routes/telegram.py`
+  - **Dependencies**: T017
+  - **Estimate**: M (2hr)
+
+- [ ] **T019** [PR-F1b] GREEN: Telegram delivery enforces `disable_web_page_preview=True` for magic-link messages
+  - **AC-1**: helper `send_magic_link_message(chat_id, action_link, button_label)` always passes `disable_web_page_preview=True`
+  - **AC-2**: T016 tests pass
+  - **Files**: helper inside `signup_handler.py` or shared `nikita/platforms/telegram/utils.py`
+  - **Dependencies**: T016, T017
+
+### Verification for PR-F1b
+
+- [ ] **T020** [PR-F1b] Pre-push HARD GATE + grep gates + open PR-F1b + `/qa-review` loop to 0 findings
+  - **AC-1**: Full pytest passes
+  - **AC-2**: Fresh-context QA returns 0 findings ALL severities
+
+**Checkpoint**: PR-F1b merged. Backend FSM live. Magic-link minting and Telegram delivery functional. Ready for PR-F2a.
+
+---
+
+## Phase 4: PR-F2a — Portal `/auth/confirm` route + IS-A interstitial + middleware
+
+**Per plan.md §4 PR-F2a. Estimate: ~250 LOC, 6 hours.**
+
+**Intelligence queries** (run once at PR-F2a start):
+```bash
+bash .claude/skills/project-intel/scripts/graph-ops.sh briefing portal/src/lib/supabase/middleware.ts
+bash .claude/skills/project-intel/scripts/graph-ops.sh search "createServerClient"
+```
+
+### Tests for PR-F2a ⚠️ WRITE FIRST
+
+- [ ] **T021** [P] [PR-F2a] RED: `portal/tests/app/auth/confirm/route.test.ts` per Testing H3 (T-E22/E23/E24/E27)
+  - **AC-1** (T-E22): `verifyOtp` returning expired-token error → response is `Response.redirect("/login?error=link_expired", 302)`
+  - **AC-2** (T-E23): same `token_hash` consumed twice → both succeed; second call returns IS-A interstitial without `?error=*`
+  - **AC-3** (T-E24): fresh device (no cookie jar) → `Set-Cookie` headers present on response
+  - **AC-4** (T-E27): same `token_hash` after `expires_at` → redirect to `/login?error=link_expired` (matches T-E22)
+  - **AC-5**: missing `?token_hash` or `?type` → redirect to `/login?error=missing_params`
+  - **Mapped FR/AC**: FR-6, AC-6.1..AC-6.6, Testing H3
+  - **Verify FAIL**: vitest RED
+  - **Estimate**: M (2hr)
+
+- [ ] **T022** [P] [PR-F2a] RED: `portal/tests/app/auth/confirm/interstitial.test.tsx` per Testing H4 (UA-spoof)
+  - **AC-1**: render with iOS Safari UA → primary "Continue to Nikita" button renders; "Open in Safari" Universal Link does NOT render (already in Safari)
+  - **AC-2**: render with Telegram-IAB UA → primary button renders + "Open in Safari" Universal Link visible
+  - **AC-3**: ARIA contract per FR-6a: `role="main"`, `aria-labelledby`, `aria-describedby` present
+  - **Mapped FR/AC**: FR-6, FR-6a, Testing H4
+  - **Verify FAIL**: vitest RED
+  - **Estimate**: M (2hr)
+
+### Implementation for PR-F2a
+
+- [ ] **T023** [PR-F2a] GREEN: `portal/src/app/auth/confirm/route.ts` server route handler
+  - **AC-1**: reads `?token_hash`, `?type`, `?next` from URL; missing params → 302 to `/login?error=missing_params`
+  - **AC-2**: `createServerClient` (`@supabase/ssr` cookies adapter); calls `supabase.auth.verifyOtp({token_hash, type})` server-side
+  - **AC-3**: error → 302 to `/login?error=<code>`; success → renders interstitial (NOT raw 302)
+  - **AC-4**: `type` from query passed VERBATIM to `verifyOtp` (no hardcoding)
+  - **Files**: `portal/src/app/auth/confirm/route.ts`
+  - **Dependencies**: T021
+  - **Estimate**: M (2hr)
+  - **Verify GREEN**: T021 tests pass
+
+- [ ] **T024** [PR-F2a] GREEN: `portal/src/app/auth/confirm/interstitial.tsx` IS-A always-interstitial Client Component
+  - **AC-1**: ~150 LOC; renders Nikita-voiced "You're cleared. Enter the portal." copy
+  - **AC-2**: primary button "Enter the portal" calls `router.push(next)` with `next` from query
+  - **AC-3**: secondary "Open in Safari" Universal Link rendered conditionally on Telegram-IAB UA detection (regex centralized per GH #420 — helper `isTelegramIAB(ua)` in `portal/src/lib/auth/ua.ts`)
+  - **AC-4**: ARIA per FR-6a (`role="main"`, etc.)
+  - **AC-5**: gated behind `process.env.NEXT_PUBLIC_TELEGRAM_FIRST_SIGNUP === 'true'` (rollback safety)
+  - **Files**: `portal/src/app/auth/confirm/interstitial.tsx`, `portal/src/lib/auth/ua.ts`
+  - **Dependencies**: T022
+  - **Estimate**: L (3hr)
+  - **Verify GREEN**: T022 tests pass
+
+- [ ] **T025** [PR-F2a] GREEN: Update `portal/src/lib/supabase/middleware.ts` exemptions
+  - **AC-1**: ADD `/auth/confirm` to public-allowed routes
+  - **AC-2**: `/onboarding/auth` exemption REMAINS (deletion happens in PR-F2b)
+  - **Files**: `portal/src/lib/supabase/middleware.ts`
+  - **Dependencies**: T023
+
+### Verification for PR-F2a
+
+- [ ] **T026** [PR-F2a] Portal pre-push HARD GATE: `(cd portal && npm run test -- --run && npm run lint && npm run build)`
+  - **AC-1**: Full vitest passes; lint clean; build succeeds
+  - **AC-2**: PR body records output
+
+- [ ] **T027** [PR-F2a] Open PR-F2a + `/qa-review` loop to 0 findings
+  - **AC-1**: PR open with FR-6/6a + Testing H3/H4 references
+  - **AC-2**: Fresh QA 0 findings
+
+**Checkpoint**: PR-F2a merged. Portal `/auth/confirm` route live. Magic-link → portal session round-trip working end-to-end (with PR-F1b backend mint). Ready for PR-F2b.
+
+---
+
+## Phase 5: PR-F2b — Portal UI: `/login` redesign + landing CTA flip + `/onboarding/auth` deletion
+
+**Per plan.md §4 PR-F2b. Estimate: ~350 LOC, 6 hours.**
+
+### Tests for PR-F2b ⚠️ WRITE FIRST
+
+- [ ] **T028** [P] [PR-F2b] RED: `portal/tests/components/landing/cta-href.test.tsx` per FR-1
+  - **AC-1**: anon visitor → all 3 CTAs (`hero-section.tsx`, `cta-section.tsx`, `landing-nav.tsx`) emit `<a href="https://t.me/Nikita_my_bot?start=welcome">`
+  - **AC-2**: auth'd-not-onboarded → CTA routes to `/dashboard` (middleware redirects to `/onboarding`)
+  - **AC-3**: auth'd-onboarded → primary CTA routes to `/dashboard`; nav shows "Continue with Nikita" → Telegram URL
+  - **Mapped FR/AC**: FR-1, FR-11, AC-1.1..AC-1.3, AC-11.1..AC-11.3
+  - **Verify FAIL**: vitest RED
+  - **Estimate**: M (2hr)
+
+- [ ] **T029** [P] [PR-F2b] RED: `portal/tests/app/login/page-client.test.tsx` per FR-10
+  - **AC-1**: page renders Nikita-voiced copy (greppable string from `docs-to-process/20260423-auth-templates-v17-1.md` §1.2)
+  - **AC-2**: `signInWithOtp({email, options:{emailRedirectTo:"<portal>/auth/confirm?next=/dashboard"}})` is called
+  - **AC-3**: NO code-input field rendered (link-only template — D2; AC-10.6 negation guard)
+  - **Mapped FR/AC**: FR-10, FR-10a, AC-10.1..AC-10.6
+  - **Verify FAIL**: vitest RED
+  - **Estimate**: M (2hr)
+
+### Implementation for PR-F2b
+
+- [ ] **T030** [P] [PR-F2b] GREEN: Flip 3 landing CTAs to Telegram URL
+  - **AC-1**: `hero-section.tsx`, `cta-section.tsx`, `landing-nav.tsx` anon `href` → `https://t.me/Nikita_my_bot?start=welcome`
+  - **AC-2**: feature-flagged: when `NEXT_PUBLIC_TELEGRAM_FIRST_SIGNUP !== 'true'`, fallback to `/onboarding/auth` (until flag flips post-W1)
+  - **Files**: 3 landing components
+  - **Dependencies**: T028
+  - **Verify GREEN**: T028 tests pass
+
+- [ ] **T031** [P] [PR-F2b] GREEN: `landing-nav.tsx` adds visible "Sign in" + "Continue with Nikita" entries (FR-11)
+  - **AC-1**: "Sign in" link → `/login`
+  - **AC-2**: "Continue with Nikita" link → Telegram URL (visible to auth'd-onboarded only)
+  - **Files**: `portal/src/components/landing/landing-nav.tsx`
+  - **Dependencies**: T028
+
+- [ ] **T032** [PR-F2b] GREEN: Redesign `portal/src/app/login/page-client.tsx` Nikita-voiced
+  - **AC-1**: copy from `docs-to-process/20260423-auth-templates-v17-1.md` §1.2 verbatim
+  - **AC-2**: `emailRedirectTo` → `/auth/confirm?next=/dashboard`
+  - **AC-3**: NO code-input field (link-only)
+  - **AC-4**: existing `ResendButton` (60s cooldown) preserved
+  - **Files**: `portal/src/app/login/page-client.tsx`
+  - **Dependencies**: T029
+  - **Verify GREEN**: T029 tests pass
+  - **Estimate**: M (3hr)
+
+- [ ] **T033** [PR-F2b] GREEN: `ClearanceGrantedCeremony.tsx` adds S3 portal-orientation copy (FR-14)
+  - **AC-1**: ceremony copy includes "Bookmark this portal — your dashboard, history, and Nikita's daily highlights live here."
+  - **AC-2**: copy is greppable for regression assertion
+  - **Files**: `portal/src/components/onboarding/ClearanceGrantedCeremony.tsx`
+  - **Estimate**: S (30 min)
+
+- [ ] **T034** [PR-F2b] GREEN: DELETE `portal/src/app/onboarding/auth/` route (entire directory)
+  - **AC-1**: `git status` shows directory deleted; no callers remain (`grep -r "onboarding/auth" portal/src/` returns empty except this task ref)
+  - **AC-2**: middleware exemption for `/onboarding/auth` removed (T025 left it in place)
+  - **AC-3**: T-E29 cache purge step recorded in PR body for post-merge execution
+  - **Files**: deletion + `portal/src/lib/supabase/middleware.ts` adjust
+  - **Dependencies**: T030 (landing CTA migrated first)
+  - **Estimate**: S (30 min)
+
+### Verification for PR-F2b
+
+- [ ] **T035** [PR-F2b] Portal pre-push HARD GATE + grep gates
+  - **AC-1**: vitest + lint + build pass
+  - **AC-2**: `grep -r "onboarding/auth" portal/src/` returns empty
+
+- [ ] **T036** [PR-F2b] Open PR-F2b + `/qa-review` loop to 0 findings
+- [ ] **T037** [PR-F2b] Post-merge: Vercel cache purge for `/onboarding/auth` (T-E29) + verify route returns 404
+
+**Checkpoint**: PR-F2b merged. Full Telegram-first signup flow live behind feature flag. Ready for Phase F W1 dogfood.
+
+---
+
+## Phase 6: W1 — Phase F Live Dogfood Walk
+
+**Per spec §8.3 + plan.md §9. Strict adherence to `.claude/rules/live-testing-protocol.md` 12-step canonical protocol.**
+
+- [ ] **T038** [W1] Live dogfood walk W1 with `youwontgetmyname777+walk1@gmail.com`
+  - **AC-1**: 12 steps executed verbatim per `.claude/rules/live-testing-protocol.md`
+  - **AC-2**: 0 CRITICAL findings, 0 unfiled HIGH
+  - **AC-3**: All 9 FR-Telemetry-1 events fired correctly (verified via Cloud Run logs)
+  - **AC-4**: AC-LiveWalk satisfied
+  - **AC-5**: NO DB fabrication (any `INSERT INTO auth.users` / `signInWithPassword` / `E2E_AUTH_BYPASS` is PR-blocker per ADR-011)
+  - **AC-6**: Walk report at `docs-to-process/20260424-dogfood-walk-W1.md`
+  - **AC-7**: DB cleanup applied per FK-safe template
+  - **Estimate**: 2-4 hours
+  - **Dispatch**: as background subagent with `HARD CAP: 25 tool calls` + scope (Telegram MCP + Gmail MCP + agent-browser only) + exit (walk report + GH issues for findings)
+
+- [ ] **T039** [W1] On W1 PASS: flip `NEXT_PUBLIC_TELEGRAM_FIRST_SIGNUP=true` in Vercel prod via REST API
+  - **AC-1**: `vercel env ls` shows `true` on production
+  - **AC-2**: Vercel redeploy triggered + verified live via curl probe of landing CTAs
+  - **AC-3**: 1 deploy cycle (24h minimum) elapses before PR-F3 kickoff (rollback safety)
+
+- [ ] **T040** [W1] On W1 FAIL: file CRITICAL/HIGH GH issues + iterate via fix PR + W2 (cap 3 walks per ADR-011)
+  - **AC-1**: Each finding has GH issue with severity label
+  - **AC-2**: Fix PR per finding follows pr-workflow.md TDD + qa-review loop
+  - **AC-3**: W2 dispatched only after fixes merged
+
+**Checkpoint**: W1 PASS + flag flipped + 24h rollback window elapsed. Ready for PR-F3 legacy deletion.
+
+---
+
+## Phase 7: PR-F3 — Legacy Code Removal + `auth_bridge_tokens` Drop + FR-12/13/14
+
+**Per plan.md §4 PR-F3. Estimate: ~400 LOC deletions, 4 hours. Dependency: W1 PASS + flag flipped + 1 deploy cycle.**
+
+**Trigger phrase check**: `nikita/agents/**` touched (FR-13 persona fragment + FR-12 wizard slot). Per `.claude/rules/agentic-design-patterns.md`: consult rule. The wizard slot addition MUST follow §8.4 mandatory tests (cumulative-state monotonicity, completion-gate triplet, mock-LLM recovery).
+
+### Tests for PR-F3 ⚠️ WRITE FIRST
+
+- [ ] **T041** [P] [PR-F3] RED: `tests/agents/onboarding/test_wizard_slots_preferred_call_window.py` per `.claude/rules/agentic-design-patterns.md` §8.4
+  - **AC-1** (cumulative-state monotonicity): 3-turn fixture with `preferred_call_window` slot; `progress_pct[t+1] >= progress_pct[t]` for every t
+  - **AC-2** (completion-gate triplet): empty WizardSlots → False/0%; partial (no preferred_call_window) → False/<100%; full → True/100%
+  - **AC-3** (mock-LLM recovery): mocked agent returns wrong slot kind for "weekday evenings" → deterministic regex/fallback recovers `preferred_call_window`
+  - **Mapped FR/AC**: FR-12, AC-12.1..AC-12.4, §8.4 mandatory tests
+  - **Verify FAIL**: pytest RED
+  - **Estimate**: L (4hr)
+
+- [ ] **T042** [P] [PR-F3] RED: assertion test `tests/architecture/test_legacy_imports_removed.py`
+  - **AC-1**: `grep -r "registration_handler\|otp_handler" nikita/` returns only test files in `tests/architecture/`
+  - **AC-2**: `grep -r "auth_bridge\|AuthBridge" nikita/ portal/src/` returns only test files
+  - **AC-3**: `grep -r "onboarding-wizard-legacy\|steps/legacy\|components/legacy" portal/src/` returns empty
+  - **Verify FAIL**: pytest RED (until deletions land)
+
+### Implementation for PR-F3
+
+- [ ] **T043** [P] [PR-F3] GREEN: ADD `preferred_call_window` slot to `nikita/agents/onboarding/wizard_slots.py` (FR-12)
+  - **AC-1**: New `Optional[str]` field on `WizardSlots` Pydantic model
+  - **AC-2**: `FinalForm` requires `preferred_call_window` non-empty (cross-field validator allows reasonable values: weekday/weekend × morning/afternoon/evening)
+  - **AC-3**: T041 monotonicity + completion-gate tests pass
+  - **Files**: `nikita/agents/onboarding/wizard_slots.py`
+  - **Dependencies**: T041
+  - **Verify GREEN**: T041 pass
+
+- [ ] **T044** [P] [PR-F3] GREEN: ADD S2 phone-call proposal fragment to `nikita/agents/text/persona.py` (FR-13)
+  - **AC-1**: persona prompt includes guidance to proactively propose phone-call within first 3 turns post-handoff
+  - **AC-2**: greppable string for regression
+  - **Mapped FR/AC**: FR-13, AC-13.1..AC-13.2
+
+- [ ] **T045** [PR-F3] GREEN: DELETE `nikita/platforms/telegram/registration_handler.py` + `otp_handler.py`
+  - **AC-1**: Files removed; `git status` shows deletions
+  - **AC-2**: T042 grep tests pass for these patterns
+
+- [ ] **T046** [PR-F3] GREEN: DELETE `nikita/platforms/telegram/auth.py:61-141` (`register_user` + `verify_otp` deprecated methods)
+  - **AC-1**: Methods removed; remaining file content syntactically valid
+  - **AC-2**: All callers either deleted (T045) or migrated (T017)
+
+- [ ] **T047** [PR-F3] GREEN: DELETE `nikita/db/models/auth_bridge.py` + `nikita/api/routes/auth_bridge.py` + `auth_bridge_repository.py`
+  - **AC-1**: Files removed
+  - **AC-2**: Migration `<NNN>_drop_auth_bridge_tokens.sql` exists and applies cleanly
+  - **AC-3**: `mcp__supabase__execute_sql` confirms `auth_bridge_tokens` row count was 0 before drop (Plan §18.9 verified)
+
+- [ ] **T048** [P] [PR-F3] GREEN: DELETE legacy portal wizard files
+  - **AC-1**: `portal/src/components/onboarding/onboarding-wizard-legacy.tsx` removed
+  - **AC-2**: `portal/src/components/onboarding/steps/legacy/` removed (entire dir)
+  - **AC-3**: `portal/src/components/onboarding/components/legacy/` removed (entire dir)
+  - **AC-4**: D4 verification: `vercel env ls | grep NEXT_PUBLIC_USE_LEGACY_FORM_WIZARD` returns empty (already verified Plan §22)
+
+- [ ] **T049** [P] [PR-F3] GREEN: Collapse dual `generate_portal_bridge_url` (closes GH #233 finally)
+  - **AC-1**: `nikita/onboarding/bridge_tokens.py` is the single source
+  - **AC-2**: `nikita/utils.py` duplicate removed; all callers updated
+  - **AC-3**: GH #233 closed referencing PR-F3
+
+- [ ] **T050** [P] [PR-F3] GREEN: DELETE `_send_bare_portal_auth_link` + `/onboard` slash-command + help-text reference
+  - **AC-1**: `nikita/platforms/telegram/commands.py:408-429` deleted (`_send_bare_portal_auth_link`)
+  - **AC-2**: `commands.py:198` `/onboard` handler deleted
+  - **AC-3**: `commands.py:643` help-text reference removed
+
+### Verification for PR-F3
+
+- [ ] **T051** [PR-F3] Pre-push HARD GATE: full `uv run pytest -q` + portal vitest + lint + build
+  - **AC-1**: All pass; T042 grep tests now GREEN
+  - **AC-2**: PR body records counts
+
+- [ ] **T052** [PR-F3] Open PR-F3 + `/qa-review` loop to 0 findings + merge + post-merge smoke
+
+**Checkpoint**: PR-F3 merged. All legacy auth code removed. Spec 215 implementation COMPLETE. ROADMAP sync.
+
+---
+
+## Phase 8: Polish & Cross-Cutting
+
+- [ ] **T053** [P] Update `docs/deployment.md` with Supabase Email Templates section (signup vs login template configs per spec §7.4)
+  - **AC-1**: Section added with both template HTML linked to `docs-to-process/20260423-auth-templates-v17-1.md`
+  - **AC-2**: Dashboard config screenshots or step-by-step instructions
+
+- [ ] **T054** [P] Copy 6 supporting diagrams from Plan §18.10 into `docs/diagrams/onboarding-journey-v17.md`
+  - **AC-1**: All 6 diagrams present (landing decision tree, FSM, happy-path sequence, 3 failure-mode sequences, ERD, Gantt)
+  - **AC-2**: Markdown ASCII or mermaid where structurally appropriate
+
+- [ ] **T055** Run `/roadmap sync` after PR-F3 merge
+  - **AC-1**: ROADMAP.md reflects Spec 215 COMPLETE status
+
+- [ ] **T056** Close referenced GH issues with PR refs
+  - **AC-1**: GH #393 closed referencing PR-F2a (PKCE eliminated)
+  - **AC-2**: GH #233 closed referencing PR-F3 (bridge URL consolidated)
+
+---
+
+## Dependencies & Execution Order
+
+```
+Phase 1 Setup (T001-T002)
+   ↓
+Phase 2 PR-F1a (T003-T014)  ← tests T003-T005 [P], impl T006-T011 staggered
+   ↓
+Phase 3 PR-F1b (T015-T020)  ← tests T015-T016 [P], impl T017-T019 staggered
+   ↓
+Phase 4 PR-F2a (T021-T027)  ← tests T021-T022 [P], impl T023-T025 staggered
+   ↓
+Phase 5 PR-F2b (T028-T037)  ← tests T028-T029 [P], impl T030-T034 staggered
+   ↓
+Phase 6 W1 (T038-T040)
+   ↓ (W1 PASS + flag flip + 24h)
+Phase 7 PR-F3 (T041-T052)  ← tests T041-T042 [P], impl T043-T050 mostly [P]
+   ↓
+Phase 8 Polish (T053-T056) [P]
+```
+
+### Parallelization summary
+
+- Within each PR's test phase: all RED tests can run in parallel ([P] markers)
+- Within PR-F3: most deletions and additions are independent ([P]) since they touch different files
+- Across PRs: STRICTLY SEQUENTIAL — no parallelization (per plan.md §4 staging)
+
+## Implementation Strategy
+
+**Incremental, feature-flagged**:
+1. PR-F1a → ship → PR-F1b → ship → PR-F2a → ship → PR-F2b → ship (all behind flag)
+2. Phase F W1 dogfood walk validates end-to-end
+3. Flag flip + 24h rollback window
+4. PR-F3 legacy deletion + FR-12/13/14 additions
+
+This gives 4 ship checkpoints before any irreversible deletion lands.
+
+## Test-First Checklist (Article III)
+
+Every implementation task in this plan has:
+- [x] ≥2 acceptance criteria defined
+- [x] Tests specified BEFORE implementation tasks
+- [x] RED → GREEN commit pair required (per `.claude/rules/pr-workflow.md`)
+- [x] AC mapping back to spec.md FRs
+
+## Subagent Dispatch Compliance
+
+Every subagent dispatched in this plan (QA review, dogfood walk, fix subagents) MUST include per `.claude/rules/parallel-agents.md`:
+- HARD CAP: <N> tool calls (5 for QA, 10 for research, 25 for dogfood walk)
+- Explicit scope clause (changed files / specific URLs / specific MCP tools)
+- Defined exit criterion (CLEAN / N findings / partial-results-on-cap)
+
+## Live-Walk Anti-Fabrication Compliance
+
+Phase F W1 (T038) MUST follow `.claude/rules/live-testing-protocol.md` 12-step protocol with NO exceptions. ADR-011 + Walk Y precedent (#410, #411 synthetic findings) governs.
+
+---
+
+**Generated by**: `/tasks` skill (SDD Phase 6)
+**Validated by**: `/audit` skill (SDD Phase 7) — auto-chains next
+**Implementor**: `/implement` skill (SDD Phase 8) — unblocked on `/audit` PASS

--- a/specs/215-auth-flow-redesign/validation-findings.md
+++ b/specs/215-auth-flow-redesign/validation-findings.md
@@ -1,0 +1,81 @@
+# Spec 215 — Validation Findings Manifest
+
+## GATE 2 iter-1 disposition (2026-04-24)
+
+Six parallel `sdd-*-validator` agents ran against `spec.md` v1 (commit pre-iter-2) and returned: **1 CRITICAL + 14 HIGH + 31 MEDIUM + 22 LOW**. This document records disposition per severity tier per the SDD GATE 2 Analyze-Fix Loop (CLAUDE.md SDD Enforcement #7).
+
+---
+
+## CRITICAL (1)
+
+| ID | Validator | Finding | Disposition |
+|---|---|---|---|
+| C1 | data-layer | (Resolved upstream — see PR #414) | **RESOLVED via PR #414 commit `0cef586`.** Closed prior to iter-2 dispatch. |
+
+---
+
+## HIGH (14)
+
+All 14 HIGH findings are **RESOLVED inline in `spec.md`** via the iter-2 commit on this branch (`spec/215-auth-flow-redesign`). See the iter-2 dispatch for the validator re-run; on re-validation PASS, this section flips to "RESOLVED + re-validated PASS."
+
+| ID | Validator | Finding (1-line) | Inline fix in spec.md |
+|---|---|---|---|
+| API-H1 | api | Admin endpoint `generate_magiclink_for_telegram_user` lacks Pydantic request/response models | New §7.6 declares `GenerateMagiclinkRequest` + `GenerateMagiclinkResponse` with service-role auth note |
+| API-H2 | api | Semantic conflict at `/auth/confirm`: T-E23 (idempotent) vs T-E27 (single-use replay block) | T-E27 reframed to TTL-only; T-E23 idempotency wins; FR-6 gains AC-6.7 + AC-6.8 + "Idempotency contract" subsection |
+| DATA-H1 | data-layer | Migration must preserve `chat_id` column (FR-11c E1/E2/E3 routing) | §7.2 table now lists `chat_id BIGINT NOT NULL` as RETAINED with explicit migration step note |
+| DATA-H2 | data-layer | `otp_state`/`otp_attempts` (existing) vs new `signup_state`/`attempts` | Migration ops now `RENAME` the existing columns (one source of truth); §7.2 columns annotated |
+| DATA-H3 | data-layer | D6 destructive reset SQL needs FK-safe cascade order | §9.2 rewritten to follow `.claude/rules/live-testing-protocol.md` template (auth.users last) |
+| DATA-H4 | data-layer | FSM transitions need explicit compare-and-swap predicates | New §7.2.1 "FSM Atomic Transitions" with 4 CAS UPDATE statements + fail-loud semantics |
+| DATA-H5 | data-layer | `magic_link_token` storage contract unclear (raw URL vs hashed_token?) | §7.2 column comment + §7.6 handler contract clarify: hashed_token ONLY, never raw action_link |
+| FE-H1 | frontend | IS-A interstitial visual contract missing (tokens, layout, ARIA) | New FR-6a "Visual Contract: IS-A Interstitial" with Tailwind allowlist, ASCII layout, shadcn refs, ARIA |
+| FE-H2 | frontend | `/login` redesign visual contract missing; risk of code-input field re-introduction | New FR-10a "Visual Contract: /login Redesign" + FR-10 "No code-input field" clause + AC-10.6 |
+| TEST-H1 | testing | No test for `disable_web_page_preview=True` on Telegram dispatch | §8.7 declares `tests/platforms/telegram/test_signup_handler_link_preview.py` with positive + negative-control ACs |
+| TEST-H2 | testing | No test asserting `verification_type` passthrough (no hardcoded literal) | §8.7 declares `tests/api/routes/test_portal_auth_admin.py` with grep-based regression guard |
+| TEST-H3 | testing | Missing T-E22/T-E23/T-E24/T-E27 coverage in portal route | §8.7 declares `portal/tests/app/auth/confirm/route.test.ts` with all 4 scenarios |
+| TEST-H4 | testing | iOS Safari interstitial automation strategy unclear | §8.7 commits to UA-spoof unit test (`interstitial.test.tsx`); manual real-iPhone walk = OPTIONAL secondary |
+| TEST-H5 | testing | No per-event Pydantic models / no PII assertions for FR-Telemetry-1 | §8.7 declares `tests/monitoring/test_signup_funnel_events.py` with 9-event table + grep gate for raw PII kwargs |
+
+**Re-validation criterion**: iter-2 sdd-*-validator dispatch must return `0 HIGH` for this section to flip to "PASS." Per SDD Enforcement #7, max 3 iterations before escalation.
+
+**Iter-2 result (2026-04-24)**: All 6 validators returned **0 CRITICAL + 0 HIGH**. 1 new LOW (architecture file-placement decision) deferred to Phase D `/plan`. Section flipped to **RESOLVED + re-validated PASS**.
+
+---
+
+## MEDIUM (31)
+
+Per CLAUDE.md SDD Enforcement #7(c): MEDIUM findings get a **GH issue** (track for v1.1 / fix in scope where cheap) OR an **explicit accept/defer decision**.
+
+### Filed as GH issues (10) — 2026-04-24
+
+| # | GH | Title |
+|---|---|---|
+| 1 | [#415](https://github.com/yangsi7/nikita/issues/415) | cookie scope/SameSite/Secure/HttpOnly/Domain decision for `/auth/confirm` |
+| 2 | [#416](https://github.com/yangsi7/nikita/issues/416) | CSRF same-origin guard on `/auth/confirm` route |
+| 3 | [#417](https://github.com/yangsi7/nikita/issues/417) | T-E10 atomic SELECT-FOR-UPDATE rebind for email-already-bound |
+| 4 | [#418](https://github.com/yangsi7/nikita/issues/418) | GDPR Art.30 audit trail for telegram_id↔auth.uid binding |
+| 5 | [#419](https://github.com/yangsi7/nikita/issues/419) | ARIA-live audit completeness across auth page-set |
+| 6 | [#420](https://github.com/yangsi7/nikita/issues/420) | centralize Telegram-IAB UA detection regex with regression tests |
+| 7 | [#421](https://github.com/yangsi7/nikita/issues/421) | hydration boundary at `/auth/confirm` (interstitial Client Component) |
+| 8 | [#422](https://github.com/yangsi7/nikita/issues/422) | full RLS policy SQL text in `telegram_signup_sessions` migration |
+| 9 | [#423](https://github.com/yangsi7/nikita/issues/423) | pg_cron prune cadence + jitter for `telegram_signup_sessions` TTL |
+| 10 | [#424](https://github.com/yangsi7/nikita/issues/424) | explicit `CREATE INDEX` on `telegram_signup_sessions(telegram_id, email)` + EXPLAIN |
+
+These are all NON-BLOCKING for Phase D `/plan`. They will be picked up during Phase E `/implement` when the relevant code is written.
+
+### Accepted — non-blocking, log only (21)
+
+The remaining 21 MEDIUM findings are accepted as non-blocking quality nits. They are logged here for traceability and may be picked up opportunistically during Phase E `/implement`. Examples include: doc cross-link polish, prose tightening in FR-3/FR-4 acceptance bullets, additional T-E* edge cases (T-E20, T-E21 placeholders), additional ARIA polish on landing CTAs (FR-1), additional Pydantic Field descriptions, etc. Full text per validator report archived in `validation-reports/iter-1/`.
+
+---
+
+## LOW (22)
+
+ACCEPTED — non-blocking, log only. All 22 LOW findings are wording/style/nit-level. Full text archived in `validation-reports/iter-1/`. No remediation tracked.
+
+---
+
+## User Approval
+
+- [x] User approved proceeding to Phase D `/plan` (2026-04-24, verbal approval in chat)
+
+**Status (2026-04-24)**: GATE 2 iter-2 PASSES (0 CRITICAL + 0 HIGH across all 6 validators). All 14 iter-1 HIGHs resolved inline (commit `9c32619`). 10 MEDIUMs filed as GH issues (#415-#424); 21 MEDIUMs + 22 LOWs accepted as non-blocking. **User approved 2026-04-24** — proceeding to Phase D (`/plan` → `/tasks` → `/audit`).

--- a/tests/platforms/telegram/test_signup_handler.py
+++ b/tests/platforms/telegram/test_signup_handler.py
@@ -247,10 +247,7 @@ class TestHandleCodeInvalid:
         mock_repo.get.return_value = existing
         mock_repo.increment_attempts.return_value = 1
 
-        from supabase.lib.client_options import (  # noqa: F401
-            ClientOptions,
-        )
-        from gotrue.errors import AuthApiError
+        from supabase_auth.errors import AuthApiError
 
         mock_supabase.auth.verify_otp.side_effect = AuthApiError(
             "invalid", 400, "invalid_credentials"
@@ -278,7 +275,7 @@ class TestHandleCodeInvalid:
         mock_repo.get.return_value = existing
         mock_repo.increment_attempts.return_value = 3
 
-        from gotrue.errors import AuthApiError
+        from supabase_auth.errors import AuthApiError
         mock_supabase.auth.verify_otp.side_effect = AuthApiError(
             "invalid", 400, "invalid_credentials"
         )

--- a/tests/platforms/telegram/test_signup_handler.py
+++ b/tests/platforms/telegram/test_signup_handler.py
@@ -294,6 +294,54 @@ class TestHandleCodeInvalid:
         )
 
 
+class TestHandleCodeNonOtpShape:
+    """I-1 regression guard: non-OTP-shaped junk MUST trip the rate-limit
+    path so spam (`hi`, `abc`, ...) cannot bypass the 3-strike purge.
+
+    Per iter-2 QA review I-1: previously `if not OTP_REGEX.match(code)`
+    short-circuited with a gentle reply WITHOUT increment_attempts, leaving
+    a DoS / cost surface. Fix routes through `_handle_invalid_otp` which
+    shares the increment + rate-limit purge path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_non_otp_shape_increments_attempts(
+        self, handler, mock_bot, mock_repo, mock_supabase
+    ):
+        """Non-numeric junk in CODE_SENT MUST call increment_attempts."""
+        mock_repo.increment_attempts.return_value = 1
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="abc"
+        )
+
+        # KEY assertion: increment_attempts was called (was the bypass)
+        mock_repo.increment_attempts.assert_awaited_once_with(telegram_id=123)
+        # verify_otp NEVER called (no shape match)
+        mock_supabase.auth.verify_otp.assert_not_awaited()
+        # User got a reply with tries-left messaging
+        text = mock_bot.send_message.call_args.kwargs["text"]
+        assert text  # non-empty
+
+    @pytest.mark.asyncio
+    async def test_non_otp_shape_three_attempts_triggers_purge(
+        self, handler, mock_bot, mock_repo, mock_supabase
+    ):
+        """3 non-numeric inputs in CODE_SENT MUST purge the row + rate-limit."""
+        mock_repo.increment_attempts.return_value = 3  # 3rd attempt
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="hi"
+        )
+
+        mock_repo.increment_attempts.assert_awaited_once_with(telegram_id=123)
+        # Purge path fired (same as legitimate 3-strike)
+        assert (
+            mock_repo.purge.await_count > 0
+            or mock_repo.delete_on_completion.await_count > 0
+        )
+
+
 class TestHandleCodeExpired:
     @pytest.mark.asyncio
     async def test_ac5_expired_code_purges_row_and_notifies(

--- a/tests/platforms/telegram/test_signup_handler.py
+++ b/tests/platforms/telegram/test_signup_handler.py
@@ -1,0 +1,377 @@
+"""Tests for signup_handler — Spec 215 PR-F1b consolidated FSM.
+
+Maps to T015 acceptance criteria:
+- AC-1: /start welcome for unbound telegram_id triggers welcome + AWAITING_EMAIL row
+- AC-2: invalid email keeps state AWAITING_EMAIL, Nikita rejection
+- AC-3: valid email → CODE_SENT via repo CAS + emits signup_email_received telemetry
+- AC-4: invalid OTP increments attempts; 3rd invalid → rate-limit + reset
+- AC-5: expired code emits "Code expired" + row purge
+- AC-6: valid OTP → MAGIC_LINK_SENT via FR-5 admin endpoint + Telegram delivery
+
+Mapped FR/AC: FR-2, FR-3, FR-4, FR-5; AC-2.1..AC-2.3, AC-3.1..AC-3.4, AC-4.1..AC-4.4, AC-5.4
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from nikita.platforms.telegram.signup_handler import SignupHandler
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_bot() -> AsyncMock:
+    bot = AsyncMock()
+    bot.send_message = AsyncMock()
+    bot.send_message_with_keyboard = AsyncMock()
+    return bot
+
+
+@pytest.fixture
+def mock_repo() -> AsyncMock:
+    repo = AsyncMock()
+    repo.get = AsyncMock(return_value=None)
+    repo.create_awaiting_email = AsyncMock(return_value="row-id-1")
+    repo.transition_to_code_sent = AsyncMock(return_value="row-id-1")
+    repo.transition_to_magic_link_sent = AsyncMock(return_value="row-id-1")
+    repo.delete_on_completion = AsyncMock(return_value=1)
+    repo.increment_attempts = AsyncMock(return_value=1)
+    return repo
+
+
+@pytest.fixture
+def mock_user_repo() -> AsyncMock:
+    repo = AsyncMock()
+    repo.get_by_telegram_id = AsyncMock(return_value=None)
+    repo.update_telegram_id = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def mock_supabase() -> MagicMock:
+    """Mock Supabase async client with auth.* methods."""
+    supabase = MagicMock()
+    supabase.auth.sign_in_with_otp = AsyncMock(return_value=MagicMock(status_code=200))
+
+    verify_response = MagicMock()
+    verify_response.user = MagicMock()
+    verify_response.user.id = "550e8400-e29b-41d4-a716-446655440000"
+    supabase.auth.verify_otp = AsyncMock(return_value=verify_response)
+
+    return supabase
+
+
+@pytest.fixture
+def mock_admin_endpoint() -> AsyncMock:
+    """Mock direct call to portal_auth.generate_magiclink_for_telegram_user."""
+    endpoint = AsyncMock()
+    endpoint.return_value = SimpleNamespace(
+        action_link="https://supabase.example.com/verify?token_hash=xxx&type=magiclink",
+        hashed_token="hashed-xyz",
+        verification_type="magiclink",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    return endpoint
+
+
+@pytest.fixture
+def handler(mock_bot, mock_repo, mock_user_repo, mock_supabase, mock_admin_endpoint):
+    return SignupHandler(
+        bot=mock_bot,
+        repo=mock_repo,
+        user_repo=mock_user_repo,
+        supabase_client=mock_supabase,
+        admin_generate_magiclink=mock_admin_endpoint,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-1 / FR-2 welcome
+# ---------------------------------------------------------------------------
+
+
+class TestHandleWelcome:
+    @pytest.mark.asyncio
+    async def test_ac1_welcome_creates_awaiting_email_row_and_greets(
+        self, handler, mock_bot, mock_repo
+    ):
+        """AC-2.1: `/start welcome` for unbound telegram_id triggers welcome
+        message and creates `signup_state=AWAITING_EMAIL` row in
+        telegram_signup_sessions."""
+        telegram_id = 123456789
+        chat_id = 987654321
+
+        await handler.handle_welcome(telegram_id=telegram_id, chat_id=chat_id)
+
+        mock_repo.create_awaiting_email.assert_awaited_once_with(
+            telegram_id=telegram_id, chat_id=chat_id
+        )
+        mock_bot.send_message.assert_awaited_once()
+        kw = mock_bot.send_message.call_args.kwargs
+        assert kw["chat_id"] == chat_id
+        assert "email" in kw["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_ac1_welcome_emits_signup_started_telemetry(
+        self, handler, mock_bot, mock_repo
+    ):
+        """FR-Telemetry-1: emit signup_started_telegram on FSM entry."""
+        telegram_id = 123456789
+        chat_id = 987654321
+
+        with patch(
+            "nikita.platforms.telegram.signup_handler.emit_signup_started_telegram"
+        ) as mock_emit:
+            await handler.handle_welcome(
+                telegram_id=telegram_id, chat_id=chat_id
+            )
+
+        mock_emit.assert_called_once()
+        event = mock_emit.call_args.args[0]
+        assert event.telegram_id_hash  # hashed, not raw
+
+
+# ---------------------------------------------------------------------------
+# AC-2 / FR-2 invalid email rejection
+# ---------------------------------------------------------------------------
+
+
+class TestHandleEmailInvalid:
+    @pytest.mark.asyncio
+    async def test_ac2_invalid_email_rejects_without_state_change(
+        self, handler, mock_bot, mock_repo, mock_supabase
+    ):
+        """AC-2.2: invalid-email submission emits Nikita-voiced rejection AND
+        keeps signup_state=AWAITING_EMAIL (no row mutation)."""
+        # Fixture: AWAITING_EMAIL row exists
+        existing = MagicMock()
+        existing.signup_state = "awaiting_email"
+        existing.email = ""
+        existing.last_attempt_at = None
+        mock_repo.get.return_value = existing
+
+        await handler.handle_email(
+            telegram_id=123, chat_id=456, text="not-an-email"
+        )
+
+        mock_repo.transition_to_code_sent.assert_not_awaited()
+        mock_supabase.auth.sign_in_with_otp.assert_not_awaited()
+        mock_bot.send_message.assert_awaited_once()
+        text = mock_bot.send_message.call_args.kwargs["text"]
+        assert "email" in text.lower() or "doesn't look" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC-3 / FR-3 valid email path
+# ---------------------------------------------------------------------------
+
+
+class TestHandleEmailValid:
+    @pytest.mark.asyncio
+    async def test_ac3_valid_email_calls_supabase_and_advances_to_code_sent(
+        self, handler, mock_bot, mock_repo, mock_supabase
+    ):
+        """AC-3.1/3.2: valid email → sign_in_with_otp + CAS to CODE_SENT."""
+        existing = MagicMock()
+        existing.signup_state = "awaiting_email"
+        existing.email = ""
+        existing.last_attempt_at = None
+        mock_repo.get.return_value = existing
+
+        await handler.handle_email(
+            telegram_id=123, chat_id=456, text="player@example.com"
+        )
+
+        mock_supabase.auth.sign_in_with_otp.assert_awaited_once()
+        otp_call = mock_supabase.auth.sign_in_with_otp.call_args.args[0]
+        assert otp_call["email"] == "player@example.com"
+        assert otp_call["options"]["should_create_user"] is True
+
+        mock_repo.transition_to_code_sent.assert_awaited_once_with(
+            telegram_id=123, email="player@example.com"
+        )
+
+        mock_bot.send_message.assert_awaited_once()
+        text = mock_bot.send_message.call_args.kwargs["text"]
+        assert "code" in text.lower() or "inbox" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_ac3_emits_signup_email_received_and_code_sent_telemetry(
+        self, handler, mock_repo
+    ):
+        """FR-Telemetry-1: emit signup_email_received + signup_code_sent."""
+        existing = MagicMock()
+        existing.signup_state = "awaiting_email"
+        existing.email = ""
+        existing.last_attempt_at = None
+        mock_repo.get.return_value = existing
+
+        with patch(
+            "nikita.platforms.telegram.signup_handler.emit_signup_email_received"
+        ) as mock_email_emit, patch(
+            "nikita.platforms.telegram.signup_handler.emit_signup_code_sent"
+        ) as mock_code_emit:
+            await handler.handle_email(
+                telegram_id=123, chat_id=456, text="player@example.com"
+            )
+
+        mock_email_emit.assert_called_once()
+        mock_code_emit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC-4 / FR-4 invalid OTP + rate-limit
+# ---------------------------------------------------------------------------
+
+
+class TestHandleCodeInvalid:
+    @pytest.mark.asyncio
+    async def test_ac4_invalid_otp_increments_attempts(
+        self, handler, mock_bot, mock_repo, mock_supabase
+    ):
+        """AC-4.1: invalid OTP increments attempts."""
+        existing = MagicMock()
+        existing.signup_state = "code_sent"
+        existing.email = "player@example.com"
+        existing.attempts = 0
+        existing.expires_at = datetime.now(timezone.utc) + timedelta(minutes=4)
+        mock_repo.get.return_value = existing
+        mock_repo.increment_attempts.return_value = 1
+
+        from supabase.lib.client_options import (  # noqa: F401
+            ClientOptions,
+        )
+        from gotrue.errors import AuthApiError
+
+        mock_supabase.auth.verify_otp.side_effect = AuthApiError(
+            "invalid", 400, "invalid_credentials"
+        )
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="000000"
+        )
+
+        mock_repo.increment_attempts.assert_awaited_once_with(telegram_id=123)
+        mock_repo.transition_to_magic_link_sent.assert_not_awaited()
+        text = mock_bot.send_message.call_args.kwargs["text"]
+        assert "tries" in text.lower() or "left" in text.lower() or "right" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_ac4_third_invalid_otp_triggers_rate_limit_reset(
+        self, handler, mock_bot, mock_repo, mock_supabase
+    ):
+        """AC-4.2: 3 invalid attempts within 1h triggers rate-limit + delete row."""
+        existing = MagicMock()
+        existing.signup_state = "code_sent"
+        existing.email = "player@example.com"
+        existing.attempts = 2
+        existing.expires_at = datetime.now(timezone.utc) + timedelta(minutes=4)
+        mock_repo.get.return_value = existing
+        mock_repo.increment_attempts.return_value = 3
+
+        from gotrue.errors import AuthApiError
+        mock_supabase.auth.verify_otp.side_effect = AuthApiError(
+            "invalid", 400, "invalid_credentials"
+        )
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="000000"
+        )
+
+        # Row deleted (rate-limit reset)
+        # Use delete via repo helper or session — check that we cleaned up
+        assert (
+            mock_repo.delete_on_completion.await_count > 0
+            or hasattr(mock_repo, "delete")
+            and mock_repo.delete.await_count > 0
+            or mock_repo.purge.await_count > 0
+        )
+
+
+class TestHandleCodeExpired:
+    @pytest.mark.asyncio
+    async def test_ac5_expired_code_purges_row_and_notifies(
+        self, handler, mock_bot, mock_repo, mock_supabase
+    ):
+        """AC-4.3 / AC-5.4: expired code → Nikita 'Code expired' + row purge."""
+        existing = MagicMock()
+        existing.signup_state = "code_sent"
+        existing.email = "player@example.com"
+        existing.attempts = 0
+        existing.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        mock_repo.get.return_value = existing
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="123456"
+        )
+
+        # Should NOT call verify_otp at all
+        mock_supabase.auth.verify_otp.assert_not_awaited()
+        text = mock_bot.send_message.call_args.kwargs["text"]
+        assert "expired" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC-6 / FR-5 valid OTP path
+# ---------------------------------------------------------------------------
+
+
+class TestHandleCodeValid:
+    @pytest.mark.asyncio
+    async def test_ac6_valid_otp_calls_admin_endpoint_and_sends_link(
+        self, handler, mock_bot, mock_repo, mock_supabase, mock_admin_endpoint
+    ):
+        """AC-4.4 + AC-5.1..AC-5.4: valid OTP → admin generate_link → Telegram
+        delivery with disable_web_page_preview=True."""
+        existing = MagicMock()
+        existing.signup_state = "code_sent"
+        existing.email = "player@example.com"
+        existing.attempts = 0
+        existing.expires_at = datetime.now(timezone.utc) + timedelta(minutes=4)
+        mock_repo.get.return_value = existing
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="123456"
+        )
+
+        mock_supabase.auth.verify_otp.assert_awaited_once()
+        verify_call = mock_supabase.auth.verify_otp.call_args.args[0]
+        assert verify_call["email"] == "player@example.com"
+        assert verify_call["token"] == "123456"
+        assert verify_call["type"] == "email"
+
+        mock_admin_endpoint.assert_awaited_once()
+
+        # FR-5 / Testing H1: must send via inline button with link-preview off
+        assert (
+            mock_bot.send_message_with_keyboard.await_count > 0
+            or mock_bot.send_message.await_count > 0
+        )
+
+    @pytest.mark.asyncio
+    async def test_ac6_valid_otp_idempotently_binds_telegram_id(
+        self, handler, mock_repo, mock_supabase, mock_user_repo
+    ):
+        """AC-5.5: post-magic-link bind: UPDATE users SET telegram_id is idempotent."""
+        existing = MagicMock()
+        existing.signup_state = "code_sent"
+        existing.email = "player@example.com"
+        existing.attempts = 0
+        existing.expires_at = datetime.now(timezone.utc) + timedelta(minutes=4)
+        mock_repo.get.return_value = existing
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="123456"
+        )
+
+        # Bind attempted (may no-op gracefully if user row doesn't exist yet)
+        mock_user_repo.update_telegram_id.assert_awaited()

--- a/tests/platforms/telegram/test_signup_handler_link_preview.py
+++ b/tests/platforms/telegram/test_signup_handler_link_preview.py
@@ -1,0 +1,169 @@
+"""Spec 215 PR-F1b T016 — Testing H1: Telegram link-preview disabled.
+
+The Telegram link-preview crawler will GET the action_link to render an embed,
+burning the single-use token before the user can tap. Bot MUST set
+`disable_web_page_preview=True` on the `send_message`/keyboard call whenever
+the message body contains the magic-link `action_link`.
+
+Tests:
+- AC-1: FR-5 magic-link send asserts disable_web_page_preview=True
+- AC-2 (NEGATIVE control): FR-2 welcome reply does NOT force
+  disable_web_page_preview (default off)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nikita.platforms.telegram.signup_handler import SignupHandler
+
+
+@pytest.fixture
+def mock_bot() -> AsyncMock:
+    bot = AsyncMock()
+    bot.send_message = AsyncMock()
+    bot.send_message_with_keyboard = AsyncMock()
+    return bot
+
+
+@pytest.fixture
+def mock_repo() -> AsyncMock:
+    repo = AsyncMock()
+    repo.get = AsyncMock(return_value=None)
+    repo.create_awaiting_email = AsyncMock(return_value="row-id-1")
+    repo.transition_to_code_sent = AsyncMock(return_value="row-id-1")
+    repo.transition_to_magic_link_sent = AsyncMock(return_value="row-id-1")
+    repo.delete_on_completion = AsyncMock(return_value=1)
+    repo.increment_attempts = AsyncMock(return_value=1)
+    return repo
+
+
+@pytest.fixture
+def mock_user_repo() -> AsyncMock:
+    repo = AsyncMock()
+    repo.get_by_telegram_id = AsyncMock(return_value=None)
+    repo.update_telegram_id = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def mock_supabase() -> MagicMock:
+    supabase = MagicMock()
+    supabase.auth.sign_in_with_otp = AsyncMock(return_value=MagicMock(status_code=200))
+    verify_response = MagicMock()
+    verify_response.user = MagicMock()
+    verify_response.user.id = "550e8400-e29b-41d4-a716-446655440000"
+    supabase.auth.verify_otp = AsyncMock(return_value=verify_response)
+    return supabase
+
+
+@pytest.fixture
+def mock_admin_endpoint() -> AsyncMock:
+    endpoint = AsyncMock()
+    endpoint.return_value = SimpleNamespace(
+        action_link="https://supabase.example.com/verify?token_hash=xxx&type=magiclink",
+        hashed_token="hashed-xyz",
+        verification_type="magiclink",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    return endpoint
+
+
+@pytest.fixture
+def handler(mock_bot, mock_repo, mock_user_repo, mock_supabase, mock_admin_endpoint):
+    return SignupHandler(
+        bot=mock_bot,
+        repo=mock_repo,
+        user_repo=mock_user_repo,
+        supabase_client=mock_supabase,
+        admin_generate_magiclink=mock_admin_endpoint,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — FR-5 path: disable_web_page_preview=True is mandatory
+# ---------------------------------------------------------------------------
+
+
+class TestMagicLinkLinkPreviewDisabled:
+    @pytest.mark.asyncio
+    async def test_fr5_magic_link_send_disables_web_page_preview(
+        self, handler, mock_bot, mock_repo
+    ):
+        """AC-5.3 + Testing H1 + NFR-Sec-1: every magic-link Telegram message
+        MUST set disable_web_page_preview=True so the link-preview crawler does
+        not burn the single-use token."""
+        existing = MagicMock()
+        existing.signup_state = "code_sent"
+        existing.email = "player@example.com"
+        existing.attempts = 0
+        existing.expires_at = datetime.now(timezone.utc) + timedelta(minutes=4)
+        mock_repo.get.return_value = existing
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="123456"
+        )
+
+        # Either send_message or send_message_with_keyboard was called for the link;
+        # whichever was used MUST have disable_web_page_preview=True
+        link_send_calls = []
+        for call in mock_bot.send_message.await_args_list:
+            link_send_calls.append(("send_message", call))
+        for call in mock_bot.send_message_with_keyboard.await_args_list:
+            link_send_calls.append(("send_message_with_keyboard", call))
+
+        assert link_send_calls, "Bot must send the magic-link message"
+
+        # Find the call that contains the action_link
+        link_call = None
+        for kind, call in link_send_calls:
+            kw = call.kwargs
+            text = kw.get("text", "")
+            keyboard = kw.get("keyboard", [])
+            if "supabase.example.com" in text or any(
+                "supabase.example.com" in (btn.get("url") or "")
+                for row in keyboard
+                for btn in row
+            ):
+                link_call = (kind, call)
+                break
+            # Heuristic: keyboards generally indicate the link CTA
+            if kind == "send_message_with_keyboard":
+                link_call = (kind, call)
+
+        assert link_call is not None, "Magic-link message not found in bot calls"
+        assert link_call[1].kwargs.get("disable_web_page_preview") is True, (
+            f"FR-5 magic-link {link_call[0]} MUST pass "
+            "disable_web_page_preview=True (Testing H1, NFR-Sec-1)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — NEGATIVE control: FR-2 welcome does NOT force disable_web_page_preview
+# ---------------------------------------------------------------------------
+
+
+class TestWelcomeDoesNotForceDisablePreview:
+    @pytest.mark.asyncio
+    async def test_fr2_welcome_does_not_force_disable_web_page_preview(
+        self, handler, mock_bot
+    ):
+        """NEGATIVE control: the FR-2 welcome message does not contain a
+        magic-link, so it should not force disable_web_page_preview=True.
+
+        This guards against an over-eager rule like "always disable previews"
+        that would mask the FR-5 path slipping through without the flag."""
+        await handler.handle_welcome(telegram_id=123, chat_id=456)
+
+        mock_bot.send_message.assert_awaited_once()
+        kw = mock_bot.send_message.call_args.kwargs
+        # NEGATIVE control: True is reserved for magic-link sends. Welcome
+        # SHOULD NOT pass True. (False or absent are both acceptable.)
+        assert kw.get("disable_web_page_preview") is not True, (
+            "FR-2 welcome message must NOT force disable_web_page_preview=True"
+            " (negative control for Testing H1)"
+        )


### PR DESCRIPTION
## Summary
- Spec 215 PR-F1b: consolidated Telegram-first signup FSM
- New `nikita/platforms/telegram/signup_handler.py` (540 LOC) with handle_welcome / handle_email / handle_code
- Replaces legacy registration_handler.py + otp_handler.py dispatch (files untouched — PR-F3 owns deletion)
- Magic-link send via inline button with `disable_web_page_preview=True` (Testing H1, NFR-Sec-1 PR-blocker)
- Direct call to PR-F1a admin endpoint (`generate_magiclink_for_telegram_user`) — service-role bypass via FastAPI DI, no internal HTTP loop
- Idempotent `update_telegram_id` bind + telemetry emission at every FSM transition
- **+ Spec 215 docs** (spec.md, plan.md, tasks.md, audit-report.md, validation-findings.md) — these were authored in Phase D but didn't make it into PR #425's squash (lived on separate spec branch); landing them here so master has the canonical spec/plan/audit alongside the first implementation PR.

Spec: `specs/215-auth-flow-redesign/spec.md` §3.1, §4 FR-2..FR-5, §7.3 FSM, §8.7 Testing H1
Plan: `specs/215-auth-flow-redesign/plan.md` §4 PR-F1b
Tasks: T015-T020 from `specs/215-auth-flow-redesign/tasks.md`

## Local tests
- `uv run pytest -q`: **6705 passed, 2 skipped, 184 deselected, 3 xpassed** in 164s (was 6691; +14 new tests including 2 I-1 regression guards)
- Scoped: `tests/platforms/telegram/test_signup_handler.py tests/platforms/telegram/test_signup_handler_link_preview.py`: **14 passed**

## Pre-PR grep gates
All 3 from `.claude/rules/testing.md`: empty.

## QA review history
- **iter-1**: PARTIAL (cap hit + cwd issues) — 0 BLOCKING / 1 IMPORTANT (suspected scope creep — orchestrator grep-verified false positive) / 1 BLOCKING (suspected coexistence — orchestrator grep-verified order-of-checks-protected, safe)
- **iter-2**: 0 BLOCKING / 1 IMPORTANT (I-1 rate-limit bypass via non-OTP-shape) / 3 NITPICK (N-1 verify_otp comment, N-2 inline import, N-3 unused imports)
- **iter-3**: pending — applied I-1 fix + 2 regression tests + N-1 comment + N-3 unused import cleanup

## Test plan
- [x] FSM tests for AC-2.1..AC-2.3, AC-3.1..AC-3.4, AC-4.1..AC-4.4 (RED → GREEN per task)
- [x] Testing H1 link-preview: positive (FR-5 magic-link asserts disable_web_page_preview=True) + NEGATIVE control (FR-2 welcome does NOT force it)
- [x] Telemetry via Pydantic event models (no free-form dicts)
- [x] Repo CAS helpers used (no re-implementation of FSM at handler level)
- [x] Idempotent update_telegram_id (no-op on re-bind)
- [x] Rate-limit per D10 (3 invalid OTP/1h → reset; 5min code TTL)
- [x] Legacy registration_handler.py + otp_handler.py wiring SWAPPED (files untouched; PR-F3 deletes)
- [x] **I-1 fix**: non-OTP-shape junk routes through `_handle_invalid_otp` to share rate-limit path; 2 new regression tests

## Commits
- `9050aaf` test(215-pr-f1b): RED — signup_handler FSM + link-preview tests (T015 + T016)
- `c639f48` feat(215-pr-f1b): GREEN — signup_handler FSM + bot link-preview + repo helpers (T017 + T019)
- `3b219cf` feat(215-pr-f1b): GREEN — webhook routes free-text + /start welcome to SignupHandler (T018)
- `31534e6` fix(215): QA iter-2 — I-1 rate-limit bypass + N-1/N-3 nitpicks + spec docs

## SDD Phase 8 — PR-F1b of 5
PR-F1a ✅ (#425) → **PR-F1b (THIS)** → PR-F2a (/auth/confirm) → PR-F2b (portal UI) → [Phase F W1 dogfood] → PR-F3 (legacy deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)