### PR TITLE
feat(215): PR-F2c.1 foundation — slot taxonomy + Question Registry + dynamic hints

### DIFF
--- a/nikita/agents/onboarding/conversation_prompts.py
+++ b/nikita/agents/onboarding/conversation_prompts.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from nikita.agents.text.persona import NIKITA_PERSONA
+from nikita.agents.onboarding.question_registry import next_question
 from nikita.onboarding.tuning import NIKITA_REPLY_MAX_CHARS
 
 if TYPE_CHECKING:
@@ -129,7 +130,8 @@ def render_dynamic_instructions(ctx: "RunContext[ConverseDeps]") -> str:
 
     Appended to WIZARD_SYSTEM_PROMPT each turn (Pydantic AI appends, does
     not replace the static system_prompt). Returns a short guidance string
-    naming the slots still missing from the cumulative WizardSlots state.
+    naming the slots still missing from the cumulative WizardSlots state,
+    plus a NEXT QUESTION hint from the Question Registry.
 
     When all slots are filled (wizard complete) returns empty string so the
     agent receives no spurious instruction text.
@@ -137,6 +139,8 @@ def render_dynamic_instructions(ctx: "RunContext[ConverseDeps]") -> str:
     Spec 214 FR-11d PR-B — agentic-design-patterns.md §3: "If N narrow tools
     are unavoidable, use dynamic instructions=callable to inject missing-slot
     guidance per turn."
+    Spec 215 T-F2c.7 — wires Question Registry: injects NEXT QUESTION hint
+    and opportunistic optional-slot footer when wizard is incomplete.
     """
     # Lazy import avoids circular dep at module load (agent imports this
     # module; this function accesses ConverseDeps which imports the agent).
@@ -146,7 +150,23 @@ def render_dynamic_instructions(ctx: "RunContext[ConverseDeps]") -> str:
     if not missing:
         return ""
     slots_text = ", ".join(missing)
-    return f"\n\nSTILL MISSING (collect these before completing): {slots_text}"
+    result = f"\n\nSTILL MISSING (collect these before completing): {slots_text}"
+
+    # Spec 215 T-F2c.7: inject NEXT QUESTION hint from registry.
+    if state is not None:
+        nq = next_question(state)
+        if nq is not None:
+            result += f"\nNEXT QUESTION ({nq.slot}): {nq.hint}"
+
+    # Opportunistic footer — only when wizard is still incomplete (missing is non-empty).
+    # LLM may extract optional signals whenever the user volunteers them;
+    # optional slots are never the focus of a turn.
+    result += (
+        "\n\nIf the user volunteers an energy/mood/vibe cue or a personality cue"
+        " during ANY turn, also emit a SlotDelta of kind='vibe' or"
+        " 'personality_archetype' (these are opportunistic — never the focus of a turn)."
+    )
+    return result
 
 
 __all__ = ["NIKITA_PERSONA", "WIZARD_SYSTEM_PROMPT", "render_dynamic_instructions"]

--- a/nikita/agents/onboarding/question_registry.py
+++ b/nikita/agents/onboarding/question_registry.py
@@ -1,0 +1,107 @@
+"""Question Registry for the Spec 215 T-F2c.5 adaptive wizard.
+
+Encodes the 6 required-slot questions as a priority-ordered registry.
+The registry is the single source of truth for which question to ask next,
+replacing implicit question-order rules in the static system prompt.
+
+Option D (binding correction over recommendation §11): optional slots
+(vibe, personality_archetype) are LLM-opportunistic — they are NEVER
+included in ORDERED_QUESTIONS. The LLM extracts them when the user
+volunteers relevant signals; the registry never routes to them.
+
+``next_question(state)`` returns the highest-priority unfilled required
+slot whose condition is met, or None if all required slots are filled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Final
+
+from nikita.agents.onboarding.state import WizardSlots
+
+
+@dataclass(frozen=True)
+class QuestionSpec:
+    """Specification for a single wizard question.
+
+    ``slot``: name of the WizardSlots field to fill.
+    ``priority``: lower number = higher priority (10 is first).
+    ``condition``: callable(WizardSlots) -> bool; returns True when this
+        question is eligible to be asked (prerequisite slots are filled).
+    ``hint``: one-line instruction injected into render_dynamic_instructions
+        telling the LLM HOW to ask this question in Nikita's voice.
+    """
+
+    slot: str
+    priority: int
+    condition: Callable[[WizardSlots], bool]
+    hint: str
+
+
+ORDERED_QUESTIONS: Final[list[QuestionSpec]] = [
+    QuestionSpec(
+        "location",
+        10,
+        lambda s: True,
+        "Ask the user what city they're in. Casual — 'where are you these days?'",
+    ),
+    QuestionSpec(
+        "scene",
+        20,
+        lambda s: s.location is not None,
+        "Ask their scene: techno, art, food, cocktails, nature. Curious, not multiple-choice.",
+    ),
+    QuestionSpec(
+        "darkness",
+        30,
+        lambda s: s.scene is not None,
+        "Ask 1-5 darkness rating. 'How deep are we going?'",
+    ),
+    QuestionSpec(
+        "identity",
+        40,
+        lambda s: s.darkness is not None,
+        "Get name+age+occupation in one warm exchange.",
+    ),
+    QuestionSpec(
+        "backstory",
+        50,
+        lambda s: s.identity is not None,
+        "Three numbered backstory options will be rendered upstream — invite the user to pick one.",
+    ),
+    QuestionSpec(
+        "phone",
+        60,
+        lambda s: s.backstory is not None,
+        "Ask preference: voice or text. Voice requires a number — see VOICE-WITHOUT-PHONE branch.",
+    ),
+]
+"""Ordered question registry — exactly 6 entries, one per required slot.
+
+Priority 10/20/30/40/50/60 with sequential conditions (each question
+requires the previous slot to be filled). Optional slots (vibe,
+personality_archetype) are never included — Option D.
+"""
+
+
+def next_question(state: WizardSlots) -> QuestionSpec | None:
+    """Return the next required question to ask based on current wizard state.
+
+    Filters ORDERED_QUESTIONS to candidates whose condition is met AND whose
+    slot is not yet filled in ``state``. Returns the candidate with the
+    lowest priority number (highest priority), or None if all required slots
+    are filled.
+
+    This is a pure function: same state always returns the same result.
+    Optional slot values (vibe, personality_archetype) in state have no
+    effect on the output — they are not in ORDERED_QUESTIONS.
+    """
+    candidates = [
+        q for q in ORDERED_QUESTIONS
+        if q.condition(state) and getattr(state, q.slot) is None
+    ]
+    return min(candidates, key=lambda q: q.priority) if candidates else None
+
+
+__all__ = ["ORDERED_QUESTIONS", "QuestionSpec", "next_question"]

--- a/nikita/agents/onboarding/state.py
+++ b/nikita/agents/onboarding/state.py
@@ -1,17 +1,21 @@
-"""Cumulative wizard state models for Spec 214 FR-11d PR-A.
+"""Cumulative wizard state models for Spec 214 FR-11d PR-A + Spec 215 T-F2c.2.
 
 Implements the agentic-design-patterns.md Hard Rule §1 (cumulative
 server-side state) and §2 (Pydantic completion gate).
 
 ``WizardSlots`` — mutable accumulator, one optional field per slot:
-  - Slots: location, scene, darkness, identity, backstory, phone
+  - Required slots (6): location, scene, darkness, identity, backstory, phone
+  - Optional slots (2): vibe, personality_archetype (LLM-opportunistic —
+    never in FinalForm required fields, never count toward TOTAL_SLOTS,
+    never appear in missing/progress_pct/slots_dict).
   - ``apply(delta)`` → immutable update via ``model_copy(update=...)``
   - ``progress_pct`` — ``@computed_field`` of cumulative state, NEVER
     of per-turn extraction (anti-pattern: ``_compute_progress(latest_kind)``).
-  - ``missing`` — ``@computed_field`` listing unfilled slot names.
-  - ``slots_dict()`` — plain dict for ``FinalForm.model_validate()``.
+  - ``missing`` — ``@computed_field`` listing unfilled REQUIRED slot names.
+  - ``slots_dict()`` — plain dict of required slots for ``FinalForm.model_validate()``.
+  - ``agent_context_dict()`` — union of all filled slots (required + optional).
 
-``FinalForm`` — Pydantic completion gate.  All 6 required slots as
+``FinalForm`` — Pydantic completion gate.  All 6 REQUIRED slots as
   non-optional fields + ``@model_validator(mode="after")`` for cross-field
   business rules (age ≥ 18).  The validator IS the gate:
   ``try: FinalForm.model_validate(slots.slots_dict()); complete = True``
@@ -20,11 +24,14 @@ server-side state) and §2 (Pydantic completion gate).
 
 ``SlotDelta`` — lightweight input model for ``WizardSlots.apply()``.
   ``kind`` is a Literal discriminator; ``data`` carries slot-specific fields.
+  Optional-slot kinds ("vibe", "personality_archetype") are accepted by
+  SlotDelta and WizardSlots.apply() but are NOT required for completion.
 
 ``TOTAL_SLOTS: Final[int] = 6`` — named constant, regression-guarded.
   Tuning-constants.md: prior values + PR; rationale in module docstring.
-  Current value: 6 (one per extraction schema: location, scene, darkness,
-  identity, backstory, phone). Set in Spec 214 FR-11d, tasks-v2.md §T2.
+  Current value: 6 (one per REQUIRED extraction schema: location, scene,
+  darkness, identity, backstory, phone). Set in Spec 214 FR-11d, tasks-v2.md
+  §T2. Extended in Spec 215 T-F2c.2 to add optional slots.
   Prior: N/A (new constant). Do not change without updating FinalForm
   required fields AND the regression test in test_wizard_state.py.
 """
@@ -67,6 +74,11 @@ _SLOT_KINDS = Literal[
 _ALL_SLOT_NAMES: list[str] = [
     "location", "scene", "darkness", "identity", "backstory", "phone"
 ]
+# Optional slot names: LLM-opportunistic, not required for completion.
+# These are NEVER included in _ALL_SLOT_NAMES, missing, progress_pct,
+# or slots_dict(). They appear only in agent_context_dict() when filled.
+# Spec 215 T-F2c.2 — Option D (binding correction).
+_OPTIONAL_SLOT_NAMES: list[str] = ["vibe", "personality_archetype"]
 
 # ---------------------------------------------------------------------------
 # SlotDelta — input model for WizardSlots.apply()
@@ -92,6 +104,8 @@ class SlotDelta(BaseModel):
         "identity",
         "backstory",
         "phone",
+        "vibe",
+        "personality_archetype",
         "no_extraction",
     ]
     data: dict[str, Any] = Field(default_factory=dict)
@@ -118,12 +132,19 @@ class WizardSlots(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    # Required slots — count toward TOTAL_SLOTS, progress_pct, missing,
+    # slots_dict(), and FinalForm completion gate.
     location: dict[str, Any] | None = None
     scene: dict[str, Any] | None = None
     darkness: dict[str, Any] | None = None
     identity: dict[str, Any] | None = None
     backstory: dict[str, Any] | None = None
     phone: dict[str, Any] | None = None
+
+    # Optional slots — LLM-opportunistic (Spec 215 T-F2c.2, Option D).
+    # Never count toward completion; appear only in agent_context_dict().
+    vibe: dict[str, Any] | None = None
+    personality_archetype: dict[str, Any] | None = None
 
     @computed_field  # type: ignore[misc]
     @property
@@ -155,12 +176,29 @@ class WizardSlots(BaseModel):
         return self.model_copy(update={delta.kind: delta.data})
 
     def slots_dict(self) -> dict[str, Any]:
-        """Return a plain dict of filled slot data for FinalForm.model_validate().
+        """Return a plain dict of filled REQUIRED slot data for FinalForm.model_validate().
 
-        Only includes slots with non-None values.
+        Only includes required slots with non-None values.
+        Optional slots (vibe, personality_archetype) are never included.
         """
         result: dict[str, Any] = {}
         for name in _ALL_SLOT_NAMES:
+            value = getattr(self, name)
+            if value is not None:
+                result[name] = value
+        return result
+
+    def agent_context_dict(self) -> dict[str, Any]:
+        """Return a plain dict of ALL filled slots (required + optional).
+
+        Used to inject full context into the agent's dynamic instructions.
+        Only includes slots with non-None values.
+        Spec 215 T-F2c.2 — Option D: optional slots are LLM-opportunistic,
+        visible to the agent for personalization, but never required for
+        completion.
+        """
+        result: dict[str, Any] = {}
+        for name in _ALL_SLOT_NAMES + _OPTIONAL_SLOT_NAMES:
             value = getattr(self, name)
             if value is not None:
                 result[name] = value
@@ -286,4 +324,5 @@ __all__ = [
     "TOTAL_SLOTS",
     "WizardSlots",
     "WizardState",
+    "_OPTIONAL_SLOT_NAMES",
 ]

--- a/tests/agents/onboarding/test_conversation_prompts_dynamic.py
+++ b/tests/agents/onboarding/test_conversation_prompts_dynamic.py
@@ -1,0 +1,122 @@
+"""Tests for T-F2c.7 — render_dynamic_instructions wires Question Registry.
+
+Covers:
+- Empty state → contains location hint substring + "STILL MISSING"
+- All-required-filled → returns ""
+- Partial state → "NEXT QUESTION (darkness)" + verbatim hint substring
+- Verbatim hint match from ORDERED_QUESTIONS
+- Does not raise when ctx.deps.state is None
+- Opportunistic footer iff missing non-empty
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _import_prompts():
+    from nikita.agents.onboarding.conversation_prompts import (  # noqa: PLC0415
+        render_dynamic_instructions,
+    )
+    return render_dynamic_instructions
+
+
+def _import_slots():
+    from nikita.agents.onboarding.state import SlotDelta, WizardSlots  # noqa: PLC0415
+    return SlotDelta, WizardSlots
+
+
+def _make_ctx(state):
+    """Build a minimal mock RunContext[ConverseDeps] with deps.state set."""
+    ctx = MagicMock()
+    ctx.deps.state = state
+    return ctx
+
+
+def _full_slots():
+    """Return WizardSlots with all 6 required slots filled."""
+    SlotDelta, WizardSlots = _import_slots()
+    slots = WizardSlots()
+    for delta in [
+        SlotDelta(kind="location", data={"city": "Berlin"}),
+        SlotDelta(kind="scene", data={"scene": "techno"}),
+        SlotDelta(kind="darkness", data={"drug_tolerance": 3}),
+        SlotDelta(kind="identity", data={"name": "Sam", "age": 28, "occupation": "artist"}),
+        SlotDelta(kind="backstory", data={"chosen_option_id": "abc", "cache_key": "berlin|techno|3"}),
+        SlotDelta(kind="phone", data={"phone_preference": "text", "phone": None}),
+    ]:
+        slots = slots.apply(delta)
+    return slots
+
+
+class TestRenderDynamicInstructions:
+    def test_empty_state_contains_still_missing(self):
+        """Empty state output contains 'STILL MISSING' with all required slots."""
+        render_dynamic_instructions = _import_prompts()
+        _, WizardSlots = _import_slots()
+        ctx = _make_ctx(WizardSlots())
+        result = render_dynamic_instructions(ctx)
+        assert "STILL MISSING" in result
+
+    def test_empty_state_contains_location_hint(self):
+        """Empty state → NEXT QUESTION hint for location is present."""
+        render_dynamic_instructions = _import_prompts()
+        _, WizardSlots = _import_slots()
+        ctx = _make_ctx(WizardSlots())
+        result = render_dynamic_instructions(ctx)
+        # The hint for location from ORDERED_QUESTIONS
+        assert "where are you" in result.lower() or "NEXT QUESTION (location)" in result
+
+    def test_all_required_filled_returns_empty_string(self):
+        """All-required-filled → render_dynamic_instructions returns ''."""
+        render_dynamic_instructions = _import_prompts()
+        ctx = _make_ctx(_full_slots())
+        result = render_dynamic_instructions(ctx)
+        assert result == ""
+
+    def test_partial_state_location_scene_filled_next_question_darkness(self):
+        """After location+scene filled, output contains 'NEXT QUESTION (darkness)'."""
+        render_dynamic_instructions = _import_prompts()
+        SlotDelta, WizardSlots = _import_slots()
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="location", data={"city": "Berlin"}))
+        slots = slots.apply(SlotDelta(kind="scene", data={"scene": "techno"}))
+        ctx = _make_ctx(slots)
+        result = render_dynamic_instructions(ctx)
+        assert "NEXT QUESTION (darkness)" in result
+
+    def test_partial_state_contains_darkness_hint_substring(self):
+        """After location+scene filled, output contains verbatim hint for darkness."""
+        render_dynamic_instructions = _import_prompts()
+        SlotDelta, WizardSlots = _import_slots()
+        from nikita.agents.onboarding.question_registry import ORDERED_QUESTIONS  # noqa: PLC0415
+        darkness_hint = next(q.hint for q in ORDERED_QUESTIONS if q.slot == "darkness")
+
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="location", data={"city": "Berlin"}))
+        slots = slots.apply(SlotDelta(kind="scene", data={"scene": "techno"}))
+        ctx = _make_ctx(slots)
+        result = render_dynamic_instructions(ctx)
+        assert darkness_hint in result
+
+    def test_does_not_raise_when_state_is_none(self):
+        """render_dynamic_instructions does not raise when ctx.deps.state is None."""
+        render_dynamic_instructions = _import_prompts()
+        ctx = _make_ctx(None)
+        result = render_dynamic_instructions(ctx)  # must not raise
+        assert isinstance(result, str)
+
+    def test_opportunistic_footer_present_when_missing_nonempty(self):
+        """Opportunistic footer appears when required slots are still missing."""
+        render_dynamic_instructions = _import_prompts()
+        _, WizardSlots = _import_slots()
+        ctx = _make_ctx(WizardSlots())  # all missing
+        result = render_dynamic_instructions(ctx)
+        # Footer must contain vibe or personality_archetype guidance
+        assert "vibe" in result or "personality_archetype" in result
+
+    def test_opportunistic_footer_absent_when_all_required_filled(self):
+        """No opportunistic footer when wizard is complete (missing is empty)."""
+        render_dynamic_instructions = _import_prompts()
+        ctx = _make_ctx(_full_slots())
+        result = render_dynamic_instructions(ctx)
+        assert result == ""

--- a/tests/agents/onboarding/test_question_registry.py
+++ b/tests/agents/onboarding/test_question_registry.py
@@ -1,0 +1,247 @@
+"""Tests for T-F2c.5 — Question Registry (nikita.agents.onboarding.question_registry).
+
+Covers:
+- ORDERED_QUESTIONS has exactly 6 entries (required slots only — Option D)
+- Unique slot names, strictly ascending priorities
+- next_question() routing for empty/partial/full state
+- F2 invariant: optional slots filled but identity missing → returns identity
+- QuestionSpec frozen (mutation raises FrozenInstanceError)
+- Pure function: twice-call returns same result
+- Conditions use only required-slot state
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+
+def _import_registry():
+    from nikita.agents.onboarding.question_registry import (  # noqa: PLC0415
+        ORDERED_QUESTIONS,
+        QuestionSpec,
+        next_question,
+    )
+    return ORDERED_QUESTIONS, QuestionSpec, next_question
+
+
+def _import_slots():
+    from nikita.agents.onboarding.state import SlotDelta, WizardSlots  # noqa: PLC0415
+    return SlotDelta, WizardSlots
+
+
+def _full_slots():
+    """Return WizardSlots with all 6 required slots filled."""
+    SlotDelta, WizardSlots = _import_slots()
+    slots = WizardSlots()
+    for delta in [
+        SlotDelta(kind="location", data={"city": "Berlin"}),
+        SlotDelta(kind="scene", data={"scene": "techno"}),
+        SlotDelta(kind="darkness", data={"drug_tolerance": 3}),
+        SlotDelta(kind="identity", data={"name": "Sam", "age": 28, "occupation": "artist"}),
+        SlotDelta(kind="backstory", data={"chosen_option_id": "abc", "cache_key": "berlin|techno|3"}),
+        SlotDelta(kind="phone", data={"phone_preference": "text", "phone": None}),
+    ]:
+        slots = slots.apply(delta)
+    return slots
+
+
+# ---------------------------------------------------------------------------
+# ORDERED_QUESTIONS structure
+# ---------------------------------------------------------------------------
+
+
+class TestOrderedQuestionsStructure:
+    def test_ordered_questions_exactly_six_entries(self):
+        """ORDERED_QUESTIONS must have exactly 6 entries (required slots, Option D)."""
+        ORDERED_QUESTIONS, _, _ = _import_registry()
+        assert len(ORDERED_QUESTIONS) == 6, (
+            f"Expected exactly 6 entries, got {len(ORDERED_QUESTIONS)}. "
+            "Option D: optional slots (vibe, personality_archetype) are never in the registry."
+        )
+
+    def test_ordered_questions_unique_slot_names(self):
+        """No duplicate slot names in ORDERED_QUESTIONS."""
+        ORDERED_QUESTIONS, _, _ = _import_registry()
+        slot_names = [q.slot for q in ORDERED_QUESTIONS]
+        assert len(slot_names) == len(set(slot_names)), (
+            f"Duplicate slot names found: {slot_names}"
+        )
+
+    def test_ordered_questions_strictly_ascending_priorities(self):
+        """Priorities in ORDERED_QUESTIONS must be strictly ascending."""
+        ORDERED_QUESTIONS, _, _ = _import_registry()
+        priorities = [q.priority for q in ORDERED_QUESTIONS]
+        for i in range(1, len(priorities)):
+            assert priorities[i] > priorities[i - 1], (
+                f"Priority not strictly ascending at index {i}: {priorities}"
+            )
+
+    def test_ordered_questions_required_slots_only(self):
+        """ORDERED_QUESTIONS contains only required slot names."""
+        ORDERED_QUESTIONS, _, _ = _import_registry()
+        required = {"location", "scene", "darkness", "identity", "backstory", "phone"}
+        optional = {"vibe", "personality_archetype"}
+        for q in ORDERED_QUESTIONS:
+            assert q.slot in required, (
+                f"Optional slot '{q.slot}' found in ORDERED_QUESTIONS — violates Option D"
+            )
+            assert q.slot not in optional, (
+                f"Optional slot '{q.slot}' in ORDERED_QUESTIONS — must be removed"
+            )
+
+    def test_ordered_questions_priorities_are_10_20_30_40_50_60(self):
+        """Priorities must be exactly 10/20/30/40/50/60 as specified."""
+        ORDERED_QUESTIONS, _, _ = _import_registry()
+        priorities = [q.priority for q in ORDERED_QUESTIONS]
+        assert priorities == [10, 20, 30, 40, 50, 60]
+
+    def test_ordered_questions_slot_order(self):
+        """Slot order must be location → scene → darkness → identity → backstory → phone."""
+        ORDERED_QUESTIONS, _, _ = _import_registry()
+        slots = [q.slot for q in ORDERED_QUESTIONS]
+        assert slots == ["location", "scene", "darkness", "identity", "backstory", "phone"]
+
+
+# ---------------------------------------------------------------------------
+# QuestionSpec shape
+# ---------------------------------------------------------------------------
+
+
+class TestQuestionSpecShape:
+    def test_question_spec_is_frozen(self):
+        """QuestionSpec is a frozen dataclass — mutation raises FrozenInstanceError."""
+        _, QuestionSpec, _ = _import_registry()
+        _, WizardSlots = _import_slots()
+        spec = QuestionSpec(
+            slot="location",
+            priority=10,
+            condition=lambda s: True,
+            hint="Where are you?",
+        )
+        with pytest.raises((dataclasses.FrozenInstanceError, TypeError, AttributeError)):
+            spec.slot = "scene"  # type: ignore[misc]
+
+    def test_question_spec_has_hint_field(self):
+        """QuestionSpec.hint must be a non-empty string."""
+        ORDERED_QUESTIONS, _, _ = _import_registry()
+        for q in ORDERED_QUESTIONS:
+            assert isinstance(q.hint, str) and q.hint, (
+                f"QuestionSpec for '{q.slot}' has empty or missing hint"
+            )
+
+
+# ---------------------------------------------------------------------------
+# next_question routing
+# ---------------------------------------------------------------------------
+
+
+class TestNextQuestion:
+    def test_empty_state_returns_location(self):
+        """next_question(empty_state) returns the location spec (priority 10)."""
+        ORDERED_QUESTIONS, _, next_question = _import_registry()
+        _, WizardSlots = _import_slots()
+        slots = WizardSlots()
+        result = next_question(slots)
+        assert result is not None
+        assert result.slot == "location"
+
+    def test_location_filled_returns_scene(self):
+        """next_question returns scene after location is filled."""
+        _, _, next_question = _import_registry()
+        SlotDelta, WizardSlots = _import_slots()
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="location", data={"city": "Berlin"}))
+        result = next_question(slots)
+        assert result is not None
+        assert result.slot == "scene"
+
+    def test_location_scene_filled_returns_darkness(self):
+        """next_question returns darkness after location + scene filled."""
+        _, _, next_question = _import_registry()
+        SlotDelta, WizardSlots = _import_slots()
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="location", data={"city": "Berlin"}))
+        slots = slots.apply(SlotDelta(kind="scene", data={"scene": "techno"}))
+        result = next_question(slots)
+        assert result is not None
+        assert result.slot == "darkness"
+
+    def test_all_required_filled_returns_none(self):
+        """next_question returns None when all 6 required slots are filled."""
+        _, _, next_question = _import_registry()
+        result = next_question(_full_slots())
+        assert result is None
+
+    def test_f2_invariant_optional_slots_cannot_override_required(self):
+        """F2 invariant: location+scene+darkness filled + vibe/personality_archetype set
+        but identity=None → next_question returns identity (not vibe or personality_archetype).
+
+        Proves Option D: optional slots are never in the registry, so they can
+        never win against a required slot.
+        """
+        _, _, next_question = _import_registry()
+        SlotDelta, WizardSlots = _import_slots()
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="location", data={"city": "Berlin"}))
+        slots = slots.apply(SlotDelta(kind="scene", data={"scene": "techno"}))
+        slots = slots.apply(SlotDelta(kind="darkness", data={"drug_tolerance": 3}))
+        # Set optional slots — should NOT influence registry routing
+        slots = slots.apply(SlotDelta(kind="vibe", data={"aesthetic": "edgy", "confidence": 0.8}))
+        slots = slots.apply(SlotDelta(kind="personality_archetype", data={"archetype": "adventurer", "confidence": 0.7}))
+        # identity is still None
+        assert slots.identity is None
+        result = next_question(slots)
+        assert result is not None
+        assert result.slot == "identity", (
+            f"Expected identity (required), got '{result.slot}'. "
+            "Optional slots must never override required-slot registry."
+        )
+
+    def test_varying_optional_slots_does_not_change_next_question(self):
+        """Optional slot state has zero effect on next_question output."""
+        _, _, next_question = _import_registry()
+        SlotDelta, WizardSlots = _import_slots()
+        slots_base = WizardSlots()
+        slots_base = slots_base.apply(SlotDelta(kind="location", data={"city": "Berlin"}))
+        # Without optionals
+        result_without = next_question(slots_base)
+
+        # With optionals set
+        slots_with_opts = slots_base.apply(
+            SlotDelta(kind="vibe", data={"aesthetic": "edgy", "confidence": 0.9})
+        )
+        result_with = next_question(slots_with_opts)
+
+        assert result_without is not None and result_with is not None
+        assert result_without.slot == result_with.slot
+
+    def test_next_question_pure_same_result_on_repeated_call(self):
+        """next_question is a pure function — calling twice returns same result."""
+        _, _, next_question = _import_registry()
+        _, WizardSlots = _import_slots()
+        slots = WizardSlots()
+        result1 = next_question(slots)
+        result2 = next_question(slots)
+        assert result1 is result2 or (
+            result1 is not None
+            and result2 is not None
+            and result1.slot == result2.slot
+        )
+
+    def test_conditions_gate_sequencing(self):
+        """scene condition: s.location is not None; darkness: s.scene is not None."""
+        _, _, next_question = _import_registry()
+        SlotDelta, WizardSlots = _import_slots()
+        # Only location filled: scene should be next (condition: location is not None)
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="location", data={"city": "Tokyo"}))
+        result = next_question(slots)
+        assert result is not None
+        assert result.slot == "scene"
+
+        # Empty state: scene condition fails (location is None), so only location is candidate
+        slots_empty = WizardSlots()
+        result_empty = next_question(slots_empty)
+        assert result_empty is not None
+        assert result_empty.slot == "location"

--- a/tests/agents/onboarding/test_wizard_state_optional_slots.py
+++ b/tests/agents/onboarding/test_wizard_state_optional_slots.py
@@ -1,0 +1,333 @@
+"""Tests for T-F2c.2 — optional slot extension to WizardSlots.
+
+Covers:
+- vibe and personality_archetype optional fields on WizardSlots
+- SlotDelta.kind Literal includes "vibe" and "personality_archetype"
+- agent_context_dict() returns union of filled required+optional slots
+- slots_dict() still returns required-only
+- missing/progress_pct/is_complete are unaffected by optional slot state
+- Cumulative-state monotonicity over 7 turns (includes optional slots)
+- Completion-gate triplet still holds with optionals set
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+
+def _import_state():
+    from nikita.agents.onboarding.state import (  # noqa: PLC0415
+        FinalForm,
+        SlotDelta,
+        TOTAL_SLOTS,
+        WizardSlots,
+    )
+    return FinalForm, SlotDelta, TOTAL_SLOTS, WizardSlots
+
+
+def _full_required_deltas():
+    """Return SlotDelta list filling all 6 required slots."""
+    from nikita.agents.onboarding.state import SlotDelta  # noqa: PLC0415
+    return [
+        SlotDelta(kind="location", data={"city": "Berlin"}),
+        SlotDelta(kind="scene", data={"scene": "techno"}),
+        SlotDelta(kind="darkness", data={"drug_tolerance": 3}),
+        SlotDelta(
+            kind="identity",
+            data={"name": "Sam", "age": 28, "occupation": "artist"},
+        ),
+        SlotDelta(
+            kind="backstory",
+            data={
+                "chosen_option_id": "aabbccddeeff",
+                "cache_key": "berlin|techno|3",
+            },
+        ),
+        SlotDelta(
+            kind="phone",
+            data={"phone_preference": "text", "phone": None},
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Optional slot defaults
+# ---------------------------------------------------------------------------
+
+
+class TestOptionalSlotDefaults:
+    def test_vibe_defaults_to_none(self):
+        """WizardSlots.vibe is None by default."""
+        _, _, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        assert slots.vibe is None
+
+    def test_personality_archetype_defaults_to_none(self):
+        """WizardSlots.personality_archetype is None by default."""
+        _, _, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        assert slots.personality_archetype is None
+
+
+# ---------------------------------------------------------------------------
+# SlotDelta accepts new kinds
+# ---------------------------------------------------------------------------
+
+
+class TestSlotDeltaNewKinds:
+    def test_slot_delta_accepts_vibe_kind(self):
+        """SlotDelta accepts kind='vibe'."""
+        _, SlotDelta, _, _ = _import_state()
+        delta = SlotDelta(kind="vibe", data={"aesthetic": "edgy", "confidence": 0.8})
+        assert delta.kind == "vibe"
+
+    def test_slot_delta_accepts_personality_archetype_kind(self):
+        """SlotDelta accepts kind='personality_archetype'."""
+        _, SlotDelta, _, _ = _import_state()
+        delta = SlotDelta(kind="personality_archetype", data={"archetype": "adventurer", "confidence": 0.7})
+        assert delta.kind == "personality_archetype"
+
+    def test_slot_delta_unknown_kind_still_rejected(self):
+        """SlotDelta still rejects unknown kinds after optional-kind extension."""
+        _, SlotDelta, _, _ = _import_state()
+        with pytest.raises((ValidationError, ValueError)):
+            SlotDelta(kind="UNKNOWN_SLOT", data={})
+
+    def test_slot_delta_all_valid_kinds_accepted(self):
+        """All canonical kinds (required + optional + no_extraction) are accepted."""
+        _, SlotDelta, _, _ = _import_state()
+        all_kinds = [
+            "location", "scene", "darkness", "identity", "backstory", "phone",
+            "vibe", "personality_archetype",
+            "no_extraction",
+        ]
+        for kind in all_kinds:
+            delta = SlotDelta(kind=kind, data={})
+            assert delta.kind == kind
+
+
+# ---------------------------------------------------------------------------
+# apply() for optional slots
+# ---------------------------------------------------------------------------
+
+
+class TestApplyOptionalSlots:
+    def test_apply_vibe_delta_populates_vibe(self):
+        """apply(SlotDelta(kind='vibe', ...)) populates WizardSlots.vibe."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        delta = SlotDelta(kind="vibe", data={"aesthetic": "edgy", "confidence": 0.8})
+        slots2 = slots.apply(delta)
+        assert slots2.vibe == {"aesthetic": "edgy", "confidence": 0.8}
+
+    def test_apply_personality_archetype_delta_populates_field(self):
+        """apply(SlotDelta(kind='personality_archetype', ...)) populates the field."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        delta = SlotDelta(kind="personality_archetype", data={"archetype": "adventurer", "confidence": 0.7})
+        slots2 = slots.apply(delta)
+        assert slots2.personality_archetype == {"archetype": "adventurer", "confidence": 0.7}
+
+    def test_apply_optional_is_immutable(self):
+        """Applying an optional slot leaves original WizardSlots unchanged."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        delta = SlotDelta(kind="vibe", data={"aesthetic": "chill", "confidence": 0.6})
+        slots2 = slots.apply(delta)
+        assert slots.vibe is None
+        assert slots2.vibe is not None
+
+
+# ---------------------------------------------------------------------------
+# missing / progress_pct unaffected by optional slots
+# ---------------------------------------------------------------------------
+
+
+class TestMissingExcludesOptional:
+    def test_missing_excludes_vibe(self):
+        """missing does not include 'vibe' even when vibe is None."""
+        _, _, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        assert "vibe" not in slots.missing
+
+    def test_missing_excludes_personality_archetype(self):
+        """missing does not include 'personality_archetype' even when None."""
+        _, _, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        assert "personality_archetype" not in slots.missing
+
+    def test_progress_pct_unaffected_by_optional_slots(self):
+        """progress_pct only counts the 6 required slots."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        # Fill vibe only
+        slots2 = slots.apply(SlotDelta(kind="vibe", data={"aesthetic": "edgy", "confidence": 0.9}))
+        # Progress must still be 0 (vibe is optional, not required)
+        assert slots2.progress_pct == 0
+
+    def test_total_slots_constant_unchanged(self):
+        """TOTAL_SLOTS must remain 6 — required-only denominator."""
+        _, _, TOTAL_SLOTS, _ = _import_state()
+        assert TOTAL_SLOTS == 6
+
+
+# ---------------------------------------------------------------------------
+# slots_dict() — required-only
+# ---------------------------------------------------------------------------
+
+
+class TestSlotsDictRequiredOnly:
+    def test_slots_dict_does_not_include_vibe(self):
+        """slots_dict() never includes 'vibe' key even when vibe is set."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="vibe", data={"aesthetic": "cozy", "confidence": 0.5}))
+        d = slots.slots_dict()
+        assert "vibe" not in d
+
+    def test_slots_dict_does_not_include_personality_archetype(self):
+        """slots_dict() never includes 'personality_archetype' key."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="personality_archetype", data={"archetype": "romantic", "confidence": 0.8}))
+        d = slots.slots_dict()
+        assert "personality_archetype" not in d
+
+
+# ---------------------------------------------------------------------------
+# agent_context_dict() — union (required + optional, non-None)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentContextDict:
+    def test_agent_context_dict_includes_required_slot(self):
+        """agent_context_dict() includes filled required slot."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="location", data={"city": "Tokyo"}))
+        ctx = slots.agent_context_dict()
+        assert "location" in ctx
+        assert ctx["location"]["city"] == "Tokyo"
+
+    def test_agent_context_dict_includes_vibe_when_set(self):
+        """agent_context_dict() includes vibe when it has been set."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="vibe", data={"aesthetic": "edgy", "confidence": 0.8}))
+        ctx = slots.agent_context_dict()
+        assert "vibe" in ctx
+        assert ctx["vibe"]["aesthetic"] == "edgy"
+
+    def test_agent_context_dict_includes_personality_archetype_when_set(self):
+        """agent_context_dict() includes personality_archetype when set."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="personality_archetype", data={"archetype": "caretaker", "confidence": 0.75}))
+        ctx = slots.agent_context_dict()
+        assert "personality_archetype" in ctx
+
+    def test_agent_context_dict_excludes_none_values(self):
+        """agent_context_dict() only returns non-None slots."""
+        _, _, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        ctx = slots.agent_context_dict()
+        # Empty slots → empty dict
+        assert ctx == {}
+
+    def test_agent_context_dict_union_both_required_and_optional(self):
+        """agent_context_dict() contains both required and optional when set."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="location", data={"city": "Paris"}))
+        slots = slots.apply(SlotDelta(kind="vibe", data={"aesthetic": "romantic", "confidence": 0.9}))
+        ctx = slots.agent_context_dict()
+        assert "location" in ctx
+        assert "vibe" in ctx
+        assert "scene" not in ctx  # not filled, so not in output
+
+
+# ---------------------------------------------------------------------------
+# Completion gate — optionals do not affect completion
+# ---------------------------------------------------------------------------
+
+
+class TestCompletionGateWithOptionals:
+    def test_is_complete_false_when_only_optionals_set(self):
+        """is_complete is False when only optional slots are set."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        slots = slots.apply(SlotDelta(kind="vibe", data={"aesthetic": "edgy", "confidence": 0.8}))
+        slots = slots.apply(SlotDelta(kind="personality_archetype", data={"archetype": "adventurer", "confidence": 0.7}))
+        assert slots.is_complete is False
+
+    def test_is_complete_true_when_all_required_set_regardless_of_optionals(self):
+        """is_complete is True when all 6 required slots are filled (optionals don't matter)."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        # All required
+        for delta in _full_required_deltas():
+            slots = slots.apply(delta)
+        # Optional NOT set
+        assert slots.personality_archetype is None
+        assert slots.vibe is None
+        assert slots.is_complete is True
+
+    def test_is_complete_true_with_optionals_also_set(self):
+        """is_complete is True when required + optional slots both filled."""
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        for delta in _full_required_deltas():
+            slots = slots.apply(delta)
+        slots = slots.apply(SlotDelta(kind="vibe", data={"aesthetic": "chill", "confidence": 0.6}))
+        slots = slots.apply(SlotDelta(kind="personality_archetype", data={"archetype": "pragmatist", "confidence": 0.8}))
+        assert slots.is_complete is True
+
+    def test_final_form_unchanged_with_optional_slots_set(self):
+        """FinalForm.model_validate ignores optional slot keys in slots_dict."""
+        FinalForm, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        for delta in _full_required_deltas():
+            slots = slots.apply(delta)
+        slots = slots.apply(SlotDelta(kind="vibe", data={"aesthetic": "edgy", "confidence": 0.8}))
+        # slots_dict() must NOT include vibe, so FinalForm validates without error
+        d = slots.slots_dict()
+        form = FinalForm.model_validate(d)
+        assert form is not None
+
+
+# ---------------------------------------------------------------------------
+# Cumulative-state monotonicity over 7 turns (agentic-flow mandatory)
+# ---------------------------------------------------------------------------
+
+
+class TestCumulativeMonotonicitySevenTurns:
+    def test_progress_pct_monotonic_over_seven_turns_including_optional(self):
+        """progress_pct never regresses over 7 turns that include optional-slot turns.
+
+        Turn order: location → vibe (optional) → scene → personality_archetype (optional)
+                    → darkness → identity → backstory
+        Optional-slot turns must not regress progress.
+        """
+        _, SlotDelta, _, WizardSlots = _import_state()
+        slots = WizardSlots()
+        progress_history = [slots.progress_pct]  # 0
+
+        turns = [
+            SlotDelta(kind="location", data={"city": "NYC"}),
+            SlotDelta(kind="vibe", data={"aesthetic": "edgy", "confidence": 0.8}),  # optional
+            SlotDelta(kind="scene", data={"scene": "art"}),
+            SlotDelta(kind="personality_archetype", data={"archetype": "adventurer", "confidence": 0.7}),  # optional
+            SlotDelta(kind="darkness", data={"drug_tolerance": 4}),
+            SlotDelta(kind="identity", data={"name": "Alex", "age": 30, "occupation": "dev"}),
+            SlotDelta(kind="backstory", data={"chosen_option_id": "abc123", "cache_key": "nyc|art|4"}),
+        ]
+
+        for turn in turns:
+            slots = slots.apply(turn)
+            progress_history.append(slots.progress_pct)
+
+        for i in range(1, len(progress_history)):
+            assert progress_history[i] >= progress_history[i - 1], (
+                f"progress regressed at turn {i}: "
+                f"{progress_history[i - 1]} → {progress_history[i]}"
+            )

--- a/tests/onboarding/test_tuning_constants.py
+++ b/tests/onboarding/test_tuning_constants.py
@@ -652,20 +652,24 @@ class TestGetConverseTimeoutMs:
             == tuning.CONVERSE_TIMEOUT_MS_COLD
         )
 
-    def test_returns_cold_at_warmup_boundary(self):
+    def test_returns_cold_at_warmup_boundary(self, monkeypatch):
         """At exactly ``_PROCESS_START + warmup``, the helper returns warm.
 
         The boundary condition matters: the helper uses ``<`` (strict), so
         uptime equal to the warmup window crosses into the warm branch.
         This guards against an accidental flip to ``<=`` which would leave
         the instance on the COLD budget one tick longer than intended.
+
+        Uses monkeypatch to pin _PROCESS_START_MONOTONIC to an exactly-
+        representable float (1000.0) so (start + 30.0) - start == 30.0 in
+        IEEE-754 double precision, removing the float-precision flake that
+        showed up on CI when the import-time monotonic clock landed at an
+        awkward value.
         """
         from nikita.api.routes import portal_onboarding
 
-        at_boundary = (
-            portal_onboarding._PROCESS_START_MONOTONIC
-            + tuning.CONVERSE_COLD_WARMUP_WINDOW_SEC
-        )
+        monkeypatch.setattr(portal_onboarding, "_PROCESS_START_MONOTONIC", 1000.0)
+        at_boundary = 1000.0 + tuning.CONVERSE_COLD_WARMUP_WINDOW_SEC
         assert (
             portal_onboarding.get_converse_timeout_ms(now=at_boundary)
             == tuning.CONVERSE_TIMEOUT_MS_WARM


### PR DESCRIPTION
## Summary

- **T-F2c.2**: Extend `WizardSlots` with `vibe` and `personality_archetype` optional fields; extend `SlotDelta.kind` Literal; add `agent_context_dict()` returning union of all filled slots (required + optional).
- **T-F2c.5**: New `nikita/agents/onboarding/question_registry.py` with `QuestionSpec` frozen dataclass, `ORDERED_QUESTIONS` (exactly 6 entries at priorities 10/20/30/40/50/60), and `next_question(state)` pure function.
- **T-F2c.7**: `render_dynamic_instructions` wires the registry — injects `NEXT QUESTION (slot): hint` after the STILL MISSING line, and appends the opportunistic footer for vibe/personality_archetype when wizard is incomplete.

## Critical correction — Option D

The spec recommendation §11 proposed 8 entries in `ORDERED_QUESTIONS` (6 required + 2 optional). **Option D (binding override)** is implemented instead: optional slots (`vibe`, `personality_archetype`) are LLM-opportunistic, never in `ORDERED_QUESTIONS`. This means:

- `TOTAL_SLOTS = 6` unchanged
- `_ALL_SLOT_NAMES` unchanged (required only)
- `missing`, `progress_pct`, `slots_dict()` unchanged (required only)
- F2 invariant holds by construction: optional slots cannot win over required in the registry because they are not candidates

## Files changed

- `nikita/agents/onboarding/state.py` — add `vibe`/`personality_archetype` optional fields + `_OPTIONAL_SLOT_NAMES` list + `agent_context_dict()` method; extend `SlotDelta.kind` Literal
- `nikita/agents/onboarding/question_registry.py` (NEW) — `QuestionSpec`, `ORDERED_QUESTIONS`, `next_question`
- `nikita/agents/onboarding/conversation_prompts.py` — import `next_question`, extend `render_dynamic_instructions` with hint injection + opportunistic footer
- `tests/agents/onboarding/test_wizard_state_optional_slots.py` (NEW) — 25 tests
- `tests/agents/onboarding/test_question_registry.py` (NEW) — 16 tests
- `tests/agents/onboarding/test_conversation_prompts_dynamic.py` (NEW) — 8 tests

## Local tests

```
6754 passed, 2 skipped, 184 deselected, 3 xpassed, 153 warnings in 214.61s (0:03:34)
```

## Pre-PR grep gates

1. Zero-assertion test shells: all 3 new test files have `assert` counts > 0 (25, 16, 8 respectively). **EMPTY** (no shells found).
2. PII format strings in new prod files: `rg -nE "logger\.(info|warning|error|exception|debug).*%s.*(name|age|occupation|phone)"` — **EMPTY**.
3. Raw `cache_key=` in new prod files — **EMPTY** (no logger calls at all in new prod files).

## Test plan

- [ ] `test_wizard_state_optional_slots.py` — 25 tests: optional slot defaults, SlotDelta new kinds, apply() for optional slots, missing/progress_pct unchanged, slots_dict() required-only, agent_context_dict() union, completion gate with optionals, 7-turn monotonicity
- [ ] `test_question_registry.py` — 16 tests: 6-entry check, unique slots, ascending priorities, F2 invariant (optional slots cannot override required), frozen spec, pure function, condition sequencing
- [ ] `test_conversation_prompts_dynamic.py` — 8 tests: STILL MISSING preserved, location hint injected, empty return on complete state, NEXT QUESTION (darkness) on partial state, verbatim hint match, None-safe, opportunistic footer presence/absence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>