### PR TITLE
fix(215,telegram): accept 6-8 digit OTP codes (GH #431, #433)

### DIFF
--- a/nikita/platforms/telegram/signup_handler.py
+++ b/nikita/platforms/telegram/signup_handler.py
@@ -85,8 +85,15 @@ RESEND_COOLDOWN_SECONDS: Final[int] = 60
 # the strict check). Spec §3.1 line 162: `^[^\s@]+@[^\s@]+\.[^\s@]+$`.
 EMAIL_REGEX: Final[re.Pattern[str]] = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
 
-# OTP code regex — strict 6-digit numeric. Spec §3.1 line 68: `^[0-9]{6}$`.
-OTP_REGEX: Final[re.Pattern[str]] = re.compile(r"^[0-9]{6}$")
+# OTP code regex — 6-to-8 digit numeric.
+# Originally `^[0-9]{6}$` per Spec §3.1 line 68, but Supabase Auth (Email
+# Templates → OTP length) defaults to 8 digits in 2026 production. The 6-8
+# range is defensive: it accepts the current 8-digit codes AND any future
+# dashboard rollback to 6 without code change. Length outside 6-8 still
+# falls into the invalid-attempt path (3-strike rate-limit purge — Spec §11
+# D10), so the DoS surface for non-numeric / wrong-length spam stays closed.
+# Refs: GH #431 (walk 2026-04-25 — bot rejected legitimate 8-digit codes).
+OTP_REGEX: Final[re.Pattern[str]] = re.compile(r"^[0-9]{6,8}$")
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +108,7 @@ INVALID_EMAIL_TEXT: Final[str] = (
     "That email doesn't look right. Try again."
 )
 CODE_SENT_TEXT: Final[str] = (
-    "Check your inbox. Send me the 6-digit code."
+    "Check your inbox. Send me the code."
 )
 RESEND_COOLDOWN_TEXT: Final[str] = (
     "Easy — give it a minute, then try again."
@@ -302,7 +309,7 @@ class SignupHandler:
             # bypass the 3-strike purge from Spec §11 D10. Without this,
             # a malicious or buggy client can flood the bot with arbitrary
             # text indefinitely (DoS / cost surface) while only legitimate
-            # 6-digit guesses contribute to the rate-limit counter. Per
+            # well-formed numeric guesses contribute to the rate-limit counter. Per
             # iter-2 QA review I-1.
             await self._handle_invalid_otp(
                 telegram_id=telegram_id, chat_id=chat_id, error_code=None

--- a/tests/platforms/telegram/test_signup_handler.py
+++ b/tests/platforms/telegram/test_signup_handler.py
@@ -420,3 +420,112 @@ class TestHandleCodeValid:
 
         # Bind attempted (may no-op gracefully if user row doesn't exist yet)
         mock_user_repo.update_telegram_id.assert_awaited()
+
+
+class TestHandleCodeOTPLengthFlexibility:
+    """GH #431: Supabase prod sends 8-digit OTP codes; regex must accept 6-8.
+
+    Defensive 6-8 range protects against future Supabase dashboard length
+    drift (configurable per Auth → Email Templates). Anything outside the
+    range still falls into the invalid-attempt path so DoS surface stays
+    closed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_8_digit_otp_is_accepted_and_passed_to_supabase(
+        self, handler, mock_repo, mock_supabase, mock_admin_endpoint
+    ):
+        """8-digit code (Supabase prod default 2026) must reach verify_otp."""
+        existing = MagicMock()
+        existing.signup_state = "code_sent"
+        existing.email = "player@example.com"
+        existing.attempts = 0
+        existing.expires_at = datetime.now(timezone.utc) + timedelta(minutes=4)
+        mock_repo.get.return_value = existing
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="60555977"
+        )
+
+        mock_supabase.auth.verify_otp.assert_awaited_once()
+        verify_call = mock_supabase.auth.verify_otp.call_args.args[0]
+        assert verify_call["token"] == "60555977"
+
+    @pytest.mark.asyncio
+    async def test_7_digit_otp_is_accepted(
+        self, handler, mock_repo, mock_supabase
+    ):
+        """7-digit code is also accepted (defensive midpoint)."""
+        existing = MagicMock()
+        existing.signup_state = "code_sent"
+        existing.email = "player@example.com"
+        existing.attempts = 0
+        existing.expires_at = datetime.now(timezone.utc) + timedelta(minutes=4)
+        mock_repo.get.return_value = existing
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="1234567"
+        )
+
+        mock_supabase.auth.verify_otp.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_5_digit_otp_still_rejected_locally(
+        self, handler, mock_repo, mock_supabase, mock_bot
+    ):
+        """Codes shorter than 6 still go to the invalid-attempt path."""
+        existing = MagicMock()
+        existing.signup_state = "code_sent"
+        existing.email = "player@example.com"
+        existing.attempts = 0
+        existing.expires_at = datetime.now(timezone.utc) + timedelta(minutes=4)
+        mock_repo.get.return_value = existing
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="12345"
+        )
+
+        # No Supabase call — local regex rejection
+        mock_supabase.auth.verify_otp.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_9_digit_otp_still_rejected_locally(
+        self, handler, mock_repo, mock_supabase
+    ):
+        """Codes longer than 8 still go to the invalid-attempt path."""
+        existing = MagicMock()
+        existing.signup_state = "code_sent"
+        existing.email = "player@example.com"
+        existing.attempts = 0
+        existing.expires_at = datetime.now(timezone.utc) + timedelta(minutes=4)
+        mock_repo.get.return_value = existing
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="123456789"
+        )
+
+        mock_supabase.auth.verify_otp.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_still_rejected_locally(
+        self, handler, mock_repo, mock_supabase
+    ):
+        """Letters never reach Supabase regardless of length."""
+        existing = MagicMock()
+        existing.signup_state = "code_sent"
+        existing.email = "player@example.com"
+        existing.attempts = 0
+        existing.expires_at = datetime.now(timezone.utc) + timedelta(minutes=4)
+        mock_repo.get.return_value = existing
+
+        await handler.handle_code(
+            telegram_id=123, chat_id=456, text="abcdefgh"
+        )
+
+        mock_supabase.auth.verify_otp.assert_not_awaited()
+
+    def test_code_sent_text_does_not_promise_specific_digit_count(self):
+        """GH #433: copy must not say "6-digit" since Supabase sends 8."""
+        from nikita.platforms.telegram.signup_handler import CODE_SENT_TEXT
+        assert "6-digit" not in CODE_SENT_TEXT
+        assert "8-digit" not in CODE_SENT_TEXT


### PR DESCRIPTION
## Summary
- Supabase prod sends **8-digit** OTPs as of 2026; bot regex `^[0-9]{6}$` rejected every legitimate code, locking users out of Telegram-first signup (walk 2026-04-25 confirmed via Cloud Run logs)
- `OTP_REGEX`: `^[0-9]{6}$` → `^[0-9]{6,8}$` (defensive range, future-proofs against dashboard length drift; DoS surface intact via 3-strike rate-limit)
- `CODE_SENT_TEXT`: "Send me the 6-digit code." → "Send me the code." (#433)

## Closes
- GH #431 (HIGH) — bot rejects 8-digit Supabase codes
- GH #433 (LOW) — copy mismatches actual digit count

## Tests (TDD RED→GREEN)
6 new in `TestHandleCodeOTPLengthFlexibility`:
- 8-digit OTP reaches Supabase verify_otp with token verbatim
- 7-digit defensive midpoint accepted
- 5-/9-digit, non-numeric still rejected locally (DoS guard)
- CODE_SENT_TEXT must not promise specific digit count

## Local tests
- nikita: `uv run pytest -q` → **6760 passed, 2 skipped, 3 xpassed in 209.88s**
- portal: not touched

## Walk evidence
- Walk report: `docs-to-process/20260425-live-walk-post-pr429.md`
- Cloud Run rev: `nikita-api-00285-dsd`
- Telegram: msg 22305 (`60555977`) → "Not right. 2 tries left." despite valid code

## Deploy plan
After merge: `gcloud run deploy nikita-api --source . --region us-central1 --project gcp-transcribe-test --allow-unauthenticated`. Then re-run W1 walk (Step 3 should pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>