### PR TITLE
fix(215,auth): magic-link PKCE format (closes GH #435)

### DIFF
--- a/nikita/api/routes/portal_auth.py
+++ b/nikita/api/routes/portal_auth.py
@@ -158,12 +158,16 @@ async def _get_repo_for_request(
 @router.post(
     "/generate-magiclink-for-telegram-user",
     response_model=GenerateMagiclinkResponse,
-    summary="Mint a magic-link action_link for a Telegram-verified email",
+    summary="Mint a PKCE token_hash magic-link URL for a Telegram-verified email",
     description=(
         "Service-role only. Calls supabase.auth.admin.generate_link, "
         "persists the hashed_token on the telegram_signup_sessions row, "
-        "and returns the action_link for delivery via Telegram. The "
-        "verification_type field is forwarded verbatim from Supabase."
+        "and returns a direct PKCE URL (/auth/confirm?token_hash=...) for "
+        "delivery via Telegram. The URL targets the portal's /auth/confirm "
+        "server route handler directly (PKCE flow) rather than the Supabase "
+        "hosted action_link (which 302s with tokens in the URL fragment — "
+        "a server-side route handler cannot read URL fragments). "
+        "The verification_type field is forwarded verbatim from Supabase."
     ),
 )
 async def generate_magiclink_for_telegram_user(
@@ -228,8 +232,30 @@ async def generate_magiclink_for_telegram_user(
                 telegram_id_hash(body.telegram_id),
             )
 
+        # GH #435: deliver a direct PKCE URL to the portal's /auth/confirm
+        # server route, NOT props.action_link (the Supabase hosted verify URL).
+        #
+        # props.action_link 302s back to redirect_to with tokens in the URL
+        # *fragment* (#access_token=...).  A server-side Next.js route handler
+        # (portal/src/app/auth/confirm/route.ts) runs in Node, which has no
+        # access to URL fragments — the user would land on
+        # /login?error=missing_params.
+        #
+        # Instead we build the portal /auth/confirm URL directly with the
+        # PKCE token_hash as a query param.  The /auth/confirm route handler
+        # is already written for this shape (it reads searchParams.token_hash).
+        #
+        # redirect_to is still passed to Supabase above as an options hint
+        # (Supabase ignores it for admin-generated links, but it documents
+        # intent and keeps the call consistent with the Supabase docs).
+        pkce_action_link = (
+            f"{settings.portal_url.rstrip('/')}/auth/confirm"
+            f"?token_hash={props.hashed_token}"
+            f"&type={_SUPABASE_LINK_TYPE}"
+            f"&next=/onboarding"
+        )
         return GenerateMagiclinkResponse(
-            action_link=str(props.action_link),
+            action_link=pkce_action_link,
             hashed_token=props.hashed_token,
             verification_type=props.verification_type,
             expires_at=datetime.now(timezone.utc)

--- a/tests/api/routes/test_portal_auth_generate_magiclink.py
+++ b/tests/api/routes/test_portal_auth_generate_magiclink.py
@@ -254,3 +254,98 @@ def test_endpoint_returns_verification_type_verbatim_from_supabase():
         assert kwargs["verification_type"] == "signup"
         assert kwargs["hashed_token"] == "hash-deadbeef"
         assert kwargs["telegram_id"] == 42
+
+
+# ---------------------------------------------------------------------------
+# GH #435: action_link must be PKCE token_hash URL, not Supabase hosted URL.
+# ---------------------------------------------------------------------------
+
+
+def test_action_link_is_pkce_token_hash_url():
+    """GH #435 (CRITICAL): action_link must be portal /auth/confirm PKCE URL.
+
+    Previously the handler returned props.action_link (Supabase hosted URL
+    that 302s back with tokens in the URL fragment). A server-side route
+    handler (/auth/confirm) cannot read URL fragments — the user landed on
+    /login?error=missing_params.
+
+    The fix: action_link must be constructed as:
+        {portal_url}/auth/confirm?token_hash={hashed_token}&type=magiclink&next=/onboarding
+
+    Assert using urllib.parse to verify exact query params are present.
+    """
+    import urllib.parse
+    from nikita.config.settings import get_settings
+
+    settings = get_settings()
+    service_key = "test-service-key-deadbeef"
+    portal_url = settings.portal_url.rstrip("/")
+
+    with patch.object(settings, "supabase_service_key", service_key):
+        app = _build_test_app()
+
+        fake_link_props = MagicMock()
+        # props.action_link is the Supabase-hosted URL (fragment-redirect flow)
+        fake_link_props.action_link = (
+            "https://supabase-project.supabase.co/auth/v1/verify"
+            "?token=abc123&type=magiclink"
+        )
+        fake_link_props.hashed_token = "pkce-hash-deadbeef"
+        fake_link_props.verification_type = "magiclink"
+
+        fake_link_result = MagicMock()
+        fake_link_result.properties = fake_link_props
+
+        fake_supabase = MagicMock()
+        fake_supabase.auth.admin.generate_link = AsyncMock(
+            return_value=fake_link_result
+        )
+
+        fake_repo = AsyncMock()
+        fake_repo.transition_to_magic_link_sent.return_value = "row-id"
+
+        from nikita.api.routes.portal_auth import _get_repo_for_request
+
+        async def _override_repo():
+            return fake_repo
+
+        app.dependency_overrides[_get_repo_for_request] = _override_repo
+
+        with patch(
+            "nikita.api.routes.portal_auth.get_supabase_client",
+            new=AsyncMock(return_value=fake_supabase),
+        ):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/v1/admin/auth/generate-magiclink-for-telegram-user",
+                headers={"Authorization": f"Bearer {service_key}"},
+                json={"telegram_id": 99, "email": "pkce@example.com"},
+            )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        action_link = body["action_link"]
+        parsed = urllib.parse.urlparse(action_link)
+        qs = urllib.parse.parse_qs(parsed.query)
+
+        # Must be the portal's /auth/confirm route, not the Supabase hosted URL
+        assert parsed.scheme in ("http", "https"), f"unexpected scheme in {action_link}"
+        assert parsed.path == "/auth/confirm", (
+            f"action_link path must be /auth/confirm, got {parsed.path!r}. "
+            "GH #435: Supabase hosted URL causes fragment-redirect that server "
+            "route handler cannot read."
+        )
+        assert portal_url in action_link, (
+            f"action_link must point to portal ({portal_url}), got {action_link!r}"
+        )
+        assert qs.get("token_hash") == ["pkce-hash-deadbeef"], (
+            f"action_link must carry token_hash query param for PKCE flow, "
+            f"got qs={qs!r}. GH #435."
+        )
+        assert qs.get("type") == ["magiclink"], (
+            f"action_link must carry type=magiclink query param, got qs={qs!r}"
+        )
+        assert qs.get("next") == ["/onboarding"], (
+            f"action_link must carry next=/onboarding query param, got qs={qs!r}"
+        )


### PR DESCRIPTION
## Summary

- `generate_magiclink_for_telegram_user` previously returned `props.action_link` (Supabase hosted verify URL). That URL 302s back to `redirect_to` with tokens in the URL **fragment** (`#access_token=…`). A server-side Next.js route handler (`/auth/confirm/route.ts`) runs in Node, which has no access to URL fragments — users landed on `/login?error=missing_params`.
- Fix: construct and return a direct PKCE URL (`{portal_url}/auth/confirm?token_hash={hashed_token}&type=magiclink&next=/onboarding`) that the existing `/auth/confirm` server route already handles correctly via `searchParams.token_hash`.

Closes #435.

## Walk evidence

docs-to-process/20260425-live-walk-W2-post-fixes.md

## Local test gate

`uv run pytest -q` — **6761 passed, 2 skipped, 0 failed** (213s)

## Commits

- RED: `7516a9f` — test(215,auth): RED — GH #435 magic-link must use token_hash PKCE format
- GREEN: `525b7dd` — fix(215,auth): GREEN — GH #435 deliver PKCE token_hash URL not Supabase action_link

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>