### PR TITLE
fix(hooks): add hookEventName discriminator to SessionStart hookSpecificOutput

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -93,6 +93,7 @@ if [ -n "$CONTEXT_MESSAGE" ]; then
       --arg ctx "$CONTEXT_MESSAGE" \
       '{
         hookSpecificOutput: {
+          hookEventName: "SessionStart",
           additionalContext: $ctx
         },
         suppressOutput: false


### PR DESCRIPTION
## Summary

Resolves the `SessionStart:compact hook error` that fires on every `/compact`:

```
Hook JSON output validation failed — hookSpecificOutput is missing required field "hookEventName"
```

`.claude/hooks/session-start.sh` emitted `hookSpecificOutput` without the `hookEventName` discriminator. Per Claude Code hooks docs (`bash ~/.claude-code-docs/claude-docs-helper.sh hooks`), every event-specific output requires this field matching the mounted event.

## Diff

One key inserted in the `jq -n` block at `session-start.sh:95`:

\`\`\`diff
       hookSpecificOutput: {
+        hookEventName: "SessionStart",
         additionalContext: \$ctx
       },
\`\`\`

## Adjacent scripts audited (no change needed)

| Script | Mount | Status |
|---|---|---|
| validate-workflow.sh | PreToolUse:Write | Already correct (has hookEventName) |
| migration-reminder.sh | PostToolUse:Write\|Edit\|MultiEdit | Already correct (has hookEventName) |
| pre-compact.sh | PreCompact | No hookSpecificOutput (skip) |
| state-file-check.sh | Stop | No hookSpecificOutput (skip) |
| guard-bash.sh | PreToolUse:Bash | No hookSpecificOutput (skip) |

## Local tests

Config-only diff (\`.claude/hooks/\` per pr-workflow.md skip-gate carve-out). Deterministic local probe instead:

\`\`\`bash
\$ echo '{"session_id":"test","cwd":"'"\$PWD"'","hook_event_name":"SessionStart","source":"compact","model":"claude-opus-4-7"}' \\
    | CLAUDE_PROJECT_DIR="\$PWD" bash .claude/hooks/session-start.sh \\
    | jq '.hookSpecificOutput | keys'
[
  "additionalContext",
  "hookEventName"
]
\`\`\`

End-to-end gate: \`/compact\` after merge should no longer surface the SessionStart validation error.

## Test plan

- [x] Read official Claude Code hooks docs to verify required schema
- [x] Audit all 6 project hooks for the same bug pattern (4 not applicable, 2 already correct, 1 broken)
- [x] Apply minimal single-key fix
- [x] Probe confirms \`hookEventName\` + \`additionalContext\` both present
- [ ] Post-merge: trigger \`/compact\` in a real session, confirm no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)